### PR TITLE
Fix: Server hang on lunge + FSM lifecycle cleanup + SimulatedDisplay hierarchy

### DIFF
--- a/src/main/java/btm/sword/system/action/throwing/types/DroppedItem.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/DroppedItem.java
@@ -3,7 +3,6 @@ package btm.sword.system.action.throwing.types;
 import org.bukkit.Bukkit;
 import org.bukkit.FluidCollisionMode;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.World;
 import org.bukkit.block.data.BlockData;
@@ -13,25 +12,17 @@ import org.bukkit.entity.ItemDisplay;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.RayTraceResult;
-import org.bukkit.util.Transformation;
 import org.bukkit.util.Vector;
-import org.joml.Quaternionf;
-import org.joml.Vector3f;
 
 import btm.sword.Sword;
-import btm.sword.system.action.throwing.InteractiveItem;
 import btm.sword.system.action.throwing.InteractiveItemArbiter;
 import btm.sword.system.control.PredicateRunnablePair;
 import btm.sword.system.control.TimeArbiter;
 import btm.sword.utility.Prefab;
 import btm.sword.utility.display.ParticleWrapper;
-import lombok.Getter;
 
-public class DroppedItem implements InteractiveItem {
-    @Getter
-    private final ItemStack itemStack;
+public class DroppedItem extends SimulatedDisplay {
     private final World world;
-    private final ItemDisplay display;
 
     private Location pos;
     private Vector to;
@@ -57,7 +48,7 @@ public class DroppedItem implements InteractiveItem {
         this.itemStack = stack;
 
         this.display = spawnDisplay(start, stack);
-        determineOrientation();
+        determineOrientation(); // inherited from SimulatedDisplay
 
         startPhysics();
     }
@@ -78,45 +69,6 @@ public class DroppedItem implements InteractiveItem {
     public void register() {
         if (display != null) {
             InteractiveItemArbiter.put(this);
-        }
-    }
-
-    public void determineOrientation() {
-        String name = display.getItemStack().getType().toString();
-
-        // *** These numbers are fine for now, config later but this system may change.
-
-        if (name.endsWith("_SWORD")) {
-            display.setTransformation(new Transformation(
-                new Vector3f(),
-                new Quaternionf()
-                    .rotateY((float) Math.PI / 2)
-                    .rotateZ((float) Math.PI / 2),
-                new Vector3f(1, 1, 1),
-                new Quaternionf()
-            ));
-        } else if (name.endsWith("AXE") || name.endsWith("_HOE") || name.endsWith("_SHOVEL")) {
-            display.setTransformation(new Transformation(
-                new Vector3f(),
-                new Quaternionf().rotateY((float) -Math.PI / 2)
-                    .rotateZ((float) Math.PI / 4),
-                new Vector3f(1.5f, 1.5f, 1.5f),
-                new Quaternionf()
-            ));
-        } else if (display.getItemStack().getType() == Material.SHIELD) {
-            display.setTransformation(new Transformation(
-                new Vector3f(0, 0, 0),
-                new Quaternionf().rotateY((float) (Math.PI / 1.01f) * 0),
-                new Vector3f(1, 1, 1),
-                new Quaternionf()
-            ));
-        } else {
-            display.setTransformation(new Transformation(
-                new Vector3f(),
-                new Quaternionf().rotateZ((float) Math.PI / 8),
-                new Vector3f(1, 1, 1),
-                new Quaternionf()
-            ));
         }
     }
 
@@ -239,10 +191,5 @@ public class DroppedItem implements InteractiveItem {
         if (display != null && !display.isDead()) {
             display.remove();
         }
-    }
-
-    @Override
-    public ItemDisplay getDisplay() {
-        return display;
     }
 }

--- a/src/main/java/btm/sword/system/action/throwing/types/SimulatedDisplay.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/SimulatedDisplay.java
@@ -1,0 +1,75 @@
+package btm.sword.system.action.throwing.types;
+
+import org.bukkit.Material;
+import org.bukkit.entity.ItemDisplay;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Transformation;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+
+import btm.sword.system.action.throwing.InteractiveItem;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Abstract base for display-backed simulated items (thrown or dropped).
+ * <p>
+ * Holds the shared {@link ItemDisplay} and {@link ItemStack} fields, and provides
+ * material-based orientation logic used by both {@link ThrownItem} and {@link DroppedItem}.
+ * Physics models are intentionally kept separate in each subclass.
+ */
+@Getter
+@Setter
+public abstract class SimulatedDisplay implements InteractiveItem {
+    protected ItemDisplay display;
+    protected ItemStack itemStack;
+
+    /**
+     * Applies a material-based {@link Transformation} to the display so that swords, axes,
+     * shields, and other tools are oriented correctly in-hand and mid-flight.
+     * <p>
+     * Subclasses may override this method to apply additional offsets.
+     */
+    protected void determineOrientation() {
+        String name = display.getItemStack().getType().toString();
+
+        // *** These numbers are fine for now, config later but this system may change.
+
+        if (name.endsWith("_SWORD")) {
+            display.setTransformation(new Transformation(
+                new Vector3f(),
+                new Quaternionf()
+                    .rotateY((float) Math.PI / 2)
+                    .rotateZ((float) Math.PI / 2),
+                new Vector3f(1, 1, 1),
+                new Quaternionf()
+            ));
+        }
+        else if (name.endsWith("AXE") || name.endsWith("_HOE") || name.endsWith("_SHOVEL")) {
+            display.setTransformation(new Transformation(
+                new Vector3f(),
+                new Quaternionf().rotateY((float) -Math.PI / 2)
+                    .rotateZ((float) Math.PI / 4),
+                new Vector3f(1.5f, 1.5f, 1.5f),
+                new Quaternionf()
+            ));
+        }
+        else if (display.getItemStack().getType() == Material.SHIELD) {
+            display.setTransformation(new Transformation(
+                new Vector3f(0, 0, 0),
+                new Quaternionf().rotateY((float) (Math.PI / 1.01f) * 0),
+                new Vector3f(1, 1, 1),
+                new Quaternionf()
+            ));
+        }
+        else {
+            display.setTransformation(new Transformation(
+                new Vector3f(),
+                new Quaternionf().rotateZ((float) Math.PI / 8),
+                new Vector3f(1, 1, 1),
+                new Quaternionf()
+            ));
+        }
+    }
+
+}

--- a/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
@@ -31,7 +31,6 @@ import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
 import btm.sword.config.Config;
-import btm.sword.system.action.throwing.InteractiveItem;
 import btm.sword.system.action.throwing.InteractiveItemArbiter;
 import btm.sword.system.action.throwing.ItemThrowStyle;
 import btm.sword.system.action.throwing.ThrowAction;
@@ -68,11 +67,9 @@ import net.kyori.adventure.text.format.TextDecoration;
  */
 @Getter
 @Setter
-public class ThrownItem implements InteractiveItem {
+public class ThrownItem extends SimulatedDisplay {
     protected final Combatant thrower;
     private ParticleWrapper blockTrail;
-    protected ItemDisplay display;
-    protected ItemStack itemStack;
     protected Consumer<ItemDisplay> displaySetupInstructions;
 
     protected Impalement thisImpalement;
@@ -245,13 +242,14 @@ public class ThrownItem implements InteractiveItem {
     }
 
     /**
-     * Called when the item is released (actually thrown).
+     * Initializes flight state without starting the timer loop.
      * <p>
-     * Initializes trajectory, physics parameters, and continuous motion updates.
+     * Called by state classes (e.g. LungingState) that drive physics via {@link #stepFlight()} each tick
+     * instead of using the self-contained {@link #onRelease(double)} loop.
      *
-     * @param initialVelocity The starting velocity magnitude of the throw.
+     * @param initialVelocity The starting velocity magnitude.
      */
-    public void onRelease(double initialVelocity) {
+    public void initFlight(double initialVelocity) {
         if (thrower instanceof SwordPlayer sp) {
             sp.setThrewItem(true);
             SwordScheduler.runBukkitTaskLater(() ->
@@ -270,28 +268,57 @@ public class ThrownItem implements InteractiveItem {
 
         xDisplayOffset = yDisplayOffset = zDisplayOffset = 0;
         determineOrientation();
+    }
+
+    /**
+     * Executes one physics tick: applies functions, teleports, rotates, emits particles, evaluates collisions.
+     */
+    protected void tickFlight() {
+        applyFunctions();
+
+        if (!prev.equals(cur) && cur.clone().subtract(prev).toVector().dot(velocity) > 0) {
+            DisplayUtil.setSmoothTeleportDuration(display, 1);
+        }
+
+        teleport();
+        rotate();
+
+        Prefab.Particles.THROW_TRAIl.display(prev); // TODO: #119 - Make type of particles dynamic
+        if (blockTrail != null && timeStep.get() % 3 == 0) // TODO: #119 - Make period dynamic
+            blockTrail.display(prev);
+
+        evaluate();
+        prev = cur.clone();
+
+        timeStep.incrementAndGet();
+    }
+
+    /**
+     * Runs one physics tick and returns {@code true} if the flight is over.
+     * <p>
+     * Used by FSM state classes (e.g. LungingState) to drive physics synchronously from {@code onTick()}.
+     *
+     * @return {@code true} when a termination condition is met (grounded, hit, caught, dead display, or timed out)
+     */
+    public boolean stepFlight() {
+        tickFlight();
+        return grounded || hit || caught || display.isDead()
+            || (timeCutoff > 0 && timeStep.get() * timeScalingFactor > timeCutoff);
+    }
+
+    /**
+     * Called when the item is released (actually thrown).
+     * <p>
+     * Initializes trajectory, physics parameters, and continuous motion updates.
+     *
+     * @param initialVelocity The starting velocity magnitude of the throw.
+     */
+    public void onRelease(double initialVelocity) {
+        initFlight(initialVelocity);
 
         TimeArbiter.runTimeBoundBukkitTaskOnTimer(
             null,
-            () -> {
-                applyFunctions();
-
-                if (!prev.equals(cur) && cur.clone().subtract(prev).toVector().dot(velocity) > 0) {
-                    DisplayUtil.setSmoothTeleportDuration(display, 1);
-                }
-
-                teleport();
-                rotate();
-
-                Prefab.Particles.THROW_TRAIl.display(prev); // TODO: #119 - Make type of particles dynamic
-                if (blockTrail != null && timeStep.get() % 3 == 0) // TODO: #119 - Make period dynamic
-                    blockTrail.display(prev);
-
-                evaluate();
-                prev = cur.clone();
-
-                timeStep.incrementAndGet();
-            },
+            this::tickFlight,
             null,
             0, 50,
             ThrownItem.class, "onRelease",

--- a/src/main/java/btm/sword/system/entity/umbral/README.md
+++ b/src/main/java/btm/sword/system/entity/umbral/README.md
@@ -38,9 +38,9 @@ This package implements the UmbralBlade: the signature weapon of Sword: Combat E
 | `WieldState` | Blade item placed in slot 0; display hidden (viewRange = 0). | None | Teleports display to thrower, restores viewRange, puts link back in slot 0 |
 | `AttackingQuickState` | Private `attack()` helper inlined from former `UmbralBlade.performSimpleAttack`. Consumes soulfire per combo step. | Attack task (scheduled inside `attack()` → `Attack.execute()`) | `setAttackCompleted(false)`, clears glow — does NOT cancel any attack task |
 | `AttackingHeavyState` | Private `attack()` helper inlined from former `UmbralBlade.performWideUmbralSweepAttack`. Dynamic Bezier curve toward targeted entity. | Attack task (scheduled inside `attack()` → `Attack.execute()`) | `setAttackCompleted(false)`, clears glow — does NOT cancel any attack task |
-| `LungingState` | Blade thrown on Bezier trajectory via `onRelease()`. Transitions to `LodgedState` on hit or `RecallingState` on timeout. | Motion loop from `ThrownItem.onRelease()` (a `TimeArbiter` task) | Clears `finishedLunging`, glow, and calls `cleanupBeforeNewThrow()` to stop the motion loop |
-| `GrabImpaleState` | Slerps display to a position above the grabbed entity, then launches a lunge. | `DisplayUtil.displaySlerpToOffset` task (stored in `slerpTask`), then a `SwordScheduler.runBukkitTaskLater` (stored in `attackTask`) that calls `attackEnemy()` which calls `onRelease()` | `setFinishedLunging(false)`, clears glow; cancels both `slerpTask` and `attackTask` |
-| `LodgedState` | Blade fixed at impact location with glow. | None | `cleanupBeforeNewThrow()`, clears glow |
+| `LungingState` | Blade thrown on Bezier trajectory. Physics are driven synchronously from `onTick()` via `stepFlight()` — no timer task. Transitions to `LodgedState` on hit (damage applied in transition action) or `RecallingState` on timeout. | `initFlight()` in `onEnter()` (sets up trajectory; no task started) | Clears `finishedLunging`, glow |
+| `GrabImpaleState` | Slerps display to a position above the grabbed entity, then launches a lunge driven by `onTick()` via `lungeActive` flag + `stepFlight()`. | `DisplayUtil.displaySlerpToOffset` task (stored in `slerpTask`), then a `SwordScheduler.runBukkitTaskLater` (stored in `attackTask`) that calls `attackEnemy()` which calls `initFlight()` | `setFinishedLunging(false)`, clears `lungeActive`, glow; cancels both `slerpTask` and `attackTask` |
+| `LodgedState` | Blade fixed at impact location with glow. Starts entity follow task in `onEnter()` if `hitEntity` is set. | `DisplayUtil.itemDisplayFollow` task (stored in `followTask`) | `followTask.cancel()`, `resetFlightState()`, clears glow |
 | `RecallingState` | Blade slerps back to player chest. Pushes `STANDBY` on arrival. | `DisplayUtil.displaySlerpToOffset` directly (stored in `returnTask`) | `returnTask.cancel()` if not already cancelled |
 | `RecoverState` | Respawns the display entity when it is null or invalid. | `TimeArbiter.runTimeIndependentBukkitTaskOnTimer` (stored in `recoverTask`). **Stores `blade` as an instance field** — the known stateless-rule violation. | `recoverTask.cancel()` |
 | `WaitingState` | Registers blade as interactable, starts idle movement. The `blade -> true` transition fires immediately on the next tick, so in practice this state is never observed for longer than one tick. | `startIdleMovement()` | `endIdleMovement()`, `unregisterAsInteractableItem()` |
@@ -81,7 +81,7 @@ All transitions are defined in `UmbralStateMachine.initTransitions()`, using `Li
 | `WieldState` | `StandbyState` | `TOGGLE` |
 | `AttackingQuickState` | `RecallingState` | `attackCompleted == true` |
 | `AttackingHeavyState` | `RecallingState` | `attackCompleted == true` |
-| `GrabImpaleState` | `LodgedState` | `hitEntity != null` |
+| `GrabImpaleState` | `LodgedState` | `hitEntity != null` — transition action applies knockback damage |
 | `GrabImpaleState` | `RecallingState` | `finishedLunging == true` |
 | `WaitingState` | `StandbyState` | `blade -> true` (always fires) |
 | `RecallingState` | `SheathedState` | `SHEATH` |
@@ -94,7 +94,7 @@ All transitions are defined in `UmbralStateMachine.initTransitions()`, using `Li
 | `LodgedState` | `WieldState` | `WIELD` |
 | `LodgedState` | `StandbyState` | `STANDBY` |
 | `LodgedState` | `AttackingHeavyState` | `ATTACK_HEAVY` |
-| `LungingState` | `LodgedState` | `hitEntity != null` |
+| `LungingState` | `LodgedState` | `hitEntity != null` — transition action applies knockback damage |
 | `LungingState` | `RecallingState` | `finishedLunging == true` |
 
 Dead transitions previously present (`LodgedState -> WaitingState` with `blade -> false` and `WaitingState -> RecallingState` with `isTooFarOrIdleTooLong`) have been removed.
@@ -129,9 +129,11 @@ Player input
 - Base `dispose()`, `onEnd()`, `onGrounded()`, `onHit()`, `onCatch()`
 - `InteractiveItem` contract (via `onGrab()`, `disposeWithNewInteractiveItem()`)
 
-`UmbralBlade` overrides: `groundedCheck()` (uses `prev` as ray origin, not `cur`), `generateFunctions()` (detours to `calcBezierTrajectory()` when `ctrlPointsForLunge` is set), `onGrounded()` (issues `RECALL` instead of embedding), `onEnd()` (sets `finishedLunging = true`), `teleport()` (uses `TimeArbiter.teleportDisplay` instead of the base method), `onCatch()` (no-op), `shouldShowLandingMarker()` (returns false), `handleItemDamageAndCheckIfBroken()` (no-op), `disposeWithNewInteractiveItem()` (issues `RECALL`), `dispose()` (also deactivates state machine).
+`UmbralBlade` overrides: `groundedCheck()` (uses `prev` as ray origin, not `cur`), `generateFunctions()` (detours to `calcBezierTrajectory()` when `ctrlPointsForLunge` is set), `onGrounded()` (issues `RECALL` instead of embedding), `onEnd()` (public; sets `finishedLunging = true`, calls `resetFlightState()`), `onHit()` (no-op — hit effects are applied explicitly in FSM transition actions), `teleport()` (uses `TimeArbiter.teleportDisplay` instead of the base method), `onCatch()` (no-op), `shouldShowLandingMarker()` (returns false), `handleItemDamageAndCheckIfBroken()` (no-op), `disposeWithNewInteractiveItem()` (issues `RECALL`), `dispose()` (also deactivates state machine).
 
-Most of `ThrownItem`'s lifecycle (`onReady()`, `handleOnReleaseActions()`, item damage, landing marker) is either bypassed or no-oped by these overrides. `onRelease()` is the only `ThrownItem` path that `UmbralBlade` actively uses (called from `LungingState.onEnter()` and `GrabImpaleState.attackEnemy()`).
+**Physics lifecycle for lunge:** State classes call `blade.initFlight(velocity)` in `onEnter()` to set up the trajectory without starting a timer task. Each FSM tick, `onTick()` calls `blade.stepFlight()`, which runs one physics tick and returns `true` when a termination condition is met. On termination, the state calls `blade.onEnd()` synchronously — this sets `hitEntity`/`finishedLunging` before transitions are evaluated in the same `tick()` call, eliminating the race condition that previously caused server hangs.
+
+Most of `ThrownItem`'s lifecycle (`onReady()`, `handleOnReleaseActions()`, item damage, landing marker) is either bypassed or no-oped by these overrides. `initFlight()` + `stepFlight()` are the `ThrownItem` paths used by `LungingState` and `GrabImpaleState`; `onRelease()` is used only by normal (non-UmbralBlade) thrown weapons.
 
 ## Known Issues
 

--- a/src/main/java/btm/sword/system/entity/umbral/UmbralBlade.java
+++ b/src/main/java/btm/sword/system/entity/umbral/UmbralBlade.java
@@ -422,7 +422,7 @@ public class UmbralBlade extends ThrownItem {
 
         ControlVectors adjusted = ctrlPointsForLunge.adjustToBasis(currentBasis, 1);
         this.positionFunction = BezierUtil.cubicBezier3D(adjusted);
-        this.velocityFunction = t -> dir.multiply(0.5);
+        this.velocityFunction = t -> dir.clone().multiply(0.5);
     }
 
     public void onGrab(Combatant combatant) {
@@ -478,10 +478,15 @@ public class UmbralBlade extends ThrownItem {
     }
 
     @Override
-    protected void onEnd() {
+    public void onEnd() {
         super.onEnd();
         finishedLunging = true;
-        cleanupBeforeNewThrow();
+        resetFlightState();
+    }
+
+    @Override
+    public void onHit() {
+        // no-op — hit effects are applied explicitly in FSM transition actions and LodgedState.onEnter()
     }
 
     @Override
@@ -503,7 +508,7 @@ public class UmbralBlade extends ThrownItem {
         bladeStateMachine.setDeactivated(true);
     }
 
-    public void cleanupBeforeNewThrow() {
+    public void resetFlightState() {
         hit = false;
         grounded = false;
         caught = false;

--- a/src/main/java/btm/sword/system/entity/umbral/statemachine/UmbralStateMachine.java
+++ b/src/main/java/btm/sword/system/entity/umbral/statemachine/UmbralStateMachine.java
@@ -2,7 +2,9 @@ package btm.sword.system.entity.umbral.statemachine;
 
 import org.bukkit.GameMode;
 import org.bukkit.Location;
+import org.bukkit.util.Vector;
 
+import btm.sword.config.Config;
 import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.entity.umbral.UmbralBlade;
@@ -21,6 +23,8 @@ import btm.sword.system.entity.umbral.statemachine.state.SheathedState;
 import btm.sword.system.entity.umbral.statemachine.state.StandbyState;
 import btm.sword.system.entity.umbral.statemachine.state.WaitingState;
 import btm.sword.system.entity.umbral.statemachine.state.WieldState;
+import btm.sword.utility.Prefab;
+import btm.sword.utility.math.VectorUtil;
 import btm.sword.utility.statemachine.State;
 import btm.sword.utility.statemachine.StateMachine;
 import btm.sword.utility.statemachine.Transition;
@@ -220,7 +224,11 @@ public class UmbralStateMachine extends StateMachine<UmbralBlade> {
             GrabImpaleState.class,
             LodgedState.class,
             b -> b.getHitEntity() != null,
-            b -> {}
+            b -> {
+                Vector kb = VectorUtil.getProjOntoPlane(b.getVelocity(), Config.Direction.UP())
+                    .multiply(Config.Combat.THROWN_DAMAGE_SWORD_AXE_KNOCKBACK_AIRBORNE);
+                b.getHitEntity().hit(b.getThrower(), Prefab.Attacks.thrownWeapon, kb);
+            }
         ));
 
         addTransition(new Transition<>(
@@ -334,7 +342,11 @@ public class UmbralStateMachine extends StateMachine<UmbralBlade> {
             LungingState.class,
             LodgedState.class,
             b -> b.getHitEntity() != null,
-            b -> {}
+            b -> {
+                Vector kb = VectorUtil.getProjOntoPlane(b.getVelocity(), Config.Direction.UP())
+                    .multiply(Config.Combat.THROWN_DAMAGE_SWORD_AXE_KNOCKBACK_AIRBORNE);
+                b.getHitEntity().hit(b.getThrower(), Prefab.Attacks.thrownWeapon, kb);
+            }
         ));
 
         addTransition(new Transition<>(

--- a/src/main/java/btm/sword/system/entity/umbral/statemachine/state/GrabImpaleState.java
+++ b/src/main/java/btm/sword/system/entity/umbral/statemachine/state/GrabImpaleState.java
@@ -18,6 +18,7 @@ import btm.sword.utility.display.DisplayUtil;
 public class GrabImpaleState extends UmbralStateFacade {
     private TimeArbiter.TaskHandle slerpTask;
     private ScheduledFuture<?> attackTask;
+    private boolean lungeActive = false;
 
     @Override
     public String name() {
@@ -38,6 +39,7 @@ public class GrabImpaleState extends UmbralStateFacade {
 
     @Override
     public void onExit(UmbralBlade blade) {
+        lungeActive = false;
         blade.setFinishedLunging(false);
         blade.getDisplay().setGlowing(false);
         if (slerpTask != null && !slerpTask.isCancelled()) slerpTask.cancel();
@@ -46,7 +48,11 @@ public class GrabImpaleState extends UmbralStateFacade {
 
     @Override
     public void onTick(UmbralBlade blade) {
-
+        if (!lungeActive) return;
+        if (blade.stepFlight()) {
+            blade.onEnd();
+            lungeActive = false;
+        }
     }
 
     private void moveToReadyPosition(UmbralBlade blade) {
@@ -76,6 +82,7 @@ public class GrabImpaleState extends UmbralStateFacade {
         blade.setTimeCutoff(Config.UmbralBlade.LUNGE_TIME_CUTOFF);
         blade.setTimeScalingFactor(Config.UmbralBlade.LUNGE_TIME_SCALING_FACTOR);
         blade.setCtrlPointsForLunge(AttackType.LUNGE1.controlVectors());
-        blade.onRelease(Config.UmbralBlade.LUNGE_ON_RELEASE_VELOCITY);
+        blade.initFlight(Config.UmbralBlade.LUNGE_ON_RELEASE_VELOCITY);
+        lungeActive = true;
     }
 }

--- a/src/main/java/btm/sword/system/entity/umbral/statemachine/state/LodgedState.java
+++ b/src/main/java/btm/sword/system/entity/umbral/statemachine/state/LodgedState.java
@@ -1,9 +1,13 @@
 package btm.sword.system.entity.umbral.statemachine.state;
 
+import org.bukkit.entity.LivingEntity;
 
 import btm.sword.config.Config;
+import btm.sword.system.control.TimeArbiter;
+import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.umbral.UmbralBlade;
 import btm.sword.system.entity.umbral.statemachine.UmbralStateFacade;
+import btm.sword.utility.display.DisplayUtil;
 
 /**
  * State where the UmbralBlade is lodged in an entity or block.
@@ -17,15 +21,15 @@ import btm.sword.system.entity.umbral.statemachine.UmbralStateFacade;
  * <ul>
  *   <li>Stop all movement</li>
  *   <li>Set display transformation for lodged position</li>
- *   <li>Attach display to target entity/block</li>
- *   <li>Apply impalement effects (damage over time, if applicable)</li>
+ *   <li>Attach display to target entity/block via entity follow task</li>
  * </ul>
  * </p>
  * <p>
  * <b>Exit Actions:</b>
  * <ul>
- *   <li>Detach from target</li>
- *   <li>Remove impalement effects</li>
+ *   <li>Cancel entity follow task</li>
+ *   <li>Reset flight state</li>
+ *   <li>Clear glow</li>
  * </ul>
  * </p>
  * <p>
@@ -38,6 +42,8 @@ import btm.sword.system.entity.umbral.statemachine.UmbralStateFacade;
  *
  */
 public class LodgedState extends UmbralStateFacade {
+    private TimeArbiter.TaskHandle followTask;
+
     @Override
     public String name() {
         return "LODGED";
@@ -47,12 +53,29 @@ public class LodgedState extends UmbralStateFacade {
     public void onEnter(UmbralBlade blade) {
         blade.getDisplay().setGlowing(true);
         blade.getDisplay().setGlowColorOverride(Config.SwordColor.UMBRAL_GLOW);
+
+        SwordEntity target = blade.getHitEntity();
+        if (target != null) {
+            LivingEntity le = target.self();
+            double heightOffset = Math.max(0, Math.min(blade.getCur().getY() - le.getLocation().getY(), le.getHeight()));
+            boolean followHead = !Config.Combat.IMPALEMENT_HEAD_FOLLOW_EXCEPTIONS.contains(target.type())
+                && heightOffset >= (le.getEyeLocation().getY() - le.getLocation().getY()) * Config.Combat.IMPALEMENT_HEAD_ZONE_RATIO;
+
+            followTask = DisplayUtil.itemDisplayFollow(
+                target, blade.getDisplay(),
+                blade.getVelocity().clone().normalize(),
+                heightOffset, followHead,
+                null, null, null, null
+            );
+        }
     }
 
     @Override
     public void onExit(UmbralBlade blade) {
         blade.getDisplay().setGlowing(false);
-        blade.cleanupBeforeNewThrow();
+        blade.resetFlightState();
+        if (followTask != null && !followTask.isCancelled()) followTask.cancel();
+        followTask = null;
     }
 
     @Override

--- a/src/main/java/btm/sword/system/entity/umbral/statemachine/state/LungingState.java
+++ b/src/main/java/btm/sword/system/entity/umbral/statemachine/state/LungingState.java
@@ -18,7 +18,7 @@ public class LungingState extends UmbralStateFacade {
         blade.setTimeCutoff(Config.UmbralBlade.LUNGE_TIME_CUTOFF);
         blade.setTimeScalingFactor(Config.UmbralBlade.LUNGE_TIME_SCALING_FACTOR);
         blade.setCtrlPointsForLunge(AttackType.LUNGE1.controlVectors());
-        blade.onRelease(Config.UmbralBlade.LUNGE_ON_RELEASE_VELOCITY);
+        blade.initFlight(Config.UmbralBlade.LUNGE_ON_RELEASE_VELOCITY);
 
         blade.getDisplay().setGlowing(true);
         blade.getDisplay().setGlowColorOverride(Config.SwordColor.UMBRAL_GLOW);
@@ -28,11 +28,12 @@ public class LungingState extends UmbralStateFacade {
     public void onExit(UmbralBlade blade) {
         blade.setFinishedLunging(false);
         blade.getDisplay().setGlowing(false);
-        blade.cleanupBeforeNewThrow();
     }
 
     @Override
     public void onTick(UmbralBlade blade) {
-
+        if (blade.stepFlight()) {
+            blade.onEnd();
+        }
     }
 }

--- a/src/main/java/btm/sword/utility/display/DisplayUtil.java
+++ b/src/main/java/btm/sword/utility/display/DisplayUtil.java
@@ -186,7 +186,7 @@ public class DisplayUtil {
      * @param heightOffset vertical height offset from the entity's location
      * @param followHead whether to align the display's direction to the entity's head yaw instead of body yaw
      */
-    public static <T> void itemDisplayFollow(
+    public static <T> TimeArbiter.TaskHandle itemDisplayFollow(
         SwordEntity entity, ItemDisplay itemDisplay, Vector direction,
         double heightOffset, boolean followHead,
         Predicate<T> condition, T toTest,
@@ -199,7 +199,7 @@ public class DisplayUtil {
         entity.self().addPassenger(itemDisplay);
 
         AtomicInteger iteration = new AtomicInteger(0);
-        TimeArbiter.runTimeBoundBukkitTaskOnTimer(
+        return TimeArbiter.runTimeBoundBukkitTaskOnTimer(
             null,
             () -> {
                 Location l = entity.self().getLocation().add(offset);


### PR DESCRIPTION
## Summary

- **Bug fix**: Eliminates the server hang race condition where a lunge hitting an entity caused the `ThrownItem` motion loop to lose all termination conditions and run indefinitely. Physics for `LungingState` and `GrabImpaleState` are now driven synchronously from `onTick()` via `stepFlight()` — `onEnd()` fires before transitions are evaluated in the same FSM tick, so `hitEntity`/`finishedLunging` are always set before the condition check.
- **FSM lifecycle**: Each state now fully owns its lifecycle. `LodgedState` starts and cancels the entity follow task itself. Damage on lunge impact is applied explicitly in the `Lunging→Lodged` and `GrabImpale→Lodged` transition actions. `UmbralBlade.onHit()` is a no-op to prevent generic impalement logic from firing.
- **Hierarchy unification**: `SimulatedDisplay` abstract base class extracts shared `determineOrientation()` logic and `display`/`itemStack` fields from `ThrownItem` and `DroppedItem`.

## Changes

| File | Change |
|------|--------|
| `ThrownItem` | Extract `initFlight()`, `tickFlight()`, `stepFlight()`; `onRelease()` delegates |
| `UmbralBlade` | `onHit()` no-op; fix `velocityFunction` mutation (`dir.clone()`); rename `cleanupBeforeNewThrow()` → `resetFlightState()`; widen `onEnd()` to `public` |
| `LungingState` | `initFlight()` in `onEnter()`; `stepFlight()` in `onTick()` |
| `GrabImpaleState` | `initFlight()` in `attackEnemy()`; `lungeActive` flag; `stepFlight()` in `onTick()` |
| `LodgedState` | Starts/cancels entity follow task (`followTask`) |
| `UmbralStateMachine` | `Lunging→Lodged` and `GrabImpale→Lodged` transitions apply knockback damage |
| `DisplayUtil` | `itemDisplayFollow()` returns `TaskHandle` |
| `SimulatedDisplay` | New abstract base class |
| `DroppedItem` | Extends `SimulatedDisplay`; duplicate `determineOrientation()` removed |

## Test plan

- [ ] Lunge into an enemy → blade lodges, entity takes damage, display follows entity, no server hang
- [ ] Lunge timeout (miss) → blade recalls cleanly
- [ ] GrabImpale → blade lodges after slerp + embedded lunge, damage applied
- [ ] Deactivate blade mid-lunge → no orphaned tasks, display stops
- [ ] Normal non-UmbralBlade throw → unchanged behavior via `onRelease()`