### PR TITLE
Fix: Deduplicate click inputs via InputBuffer (#204)

### DIFF
--- a/src/main/java/btm/sword/listeners/InputListener.java
+++ b/src/main/java/btm/sword/listeners/InputListener.java
@@ -47,17 +47,15 @@ public class InputListener implements Listener {
      */
     @EventHandler
     public void onNormalAttack(PrePlayerAttackEntityEvent event) {
+        event.setCancelled(true);
         SwordPlayer swordPlayer = (SwordPlayer) SwordEntityArbiter.getOrAdd(event.getPlayer());
-        ItemStack item = swordPlayer.getItemStackInHand(true);
 
-        if (swordPlayer.handleItemInteraction(item, InputType.LEFT)) {
-            event.setCancelled(true);
-            return;
-        }
+        if (!swordPlayer.getInputBuffer().accept(InputType.LEFT)) return;
+
+        ItemStack item = swordPlayer.getItemStackInHand(true);
+        if (swordPlayer.handleItemInteraction(item, InputType.LEFT)) return;
 
         swordPlayer.act(InputType.LEFT);
-
-        event.setCancelled(true);
     }
 
     @EventHandler // imagine that...
@@ -96,10 +94,9 @@ public class InputListener implements Listener {
 
         if (swordPlayer.hasPerformedDropAction()) return;
 
-        // TODO: #124 - Log all interactions and figure out if this fires when PrePlayerAttack fires.
-        // TODO: #124 - If so, use the flag set in the above method to cancel this event and return.
-
         if ((action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK)) {
+            if (!swordPlayer.getInputBuffer().accept(InputType.LEFT)) return;
+
             if (swordPlayer.handleItemInteraction(item, InputType.LEFT)) {
                 event.setCancelled(true);
                 return;
@@ -107,12 +104,10 @@ public class InputListener implements Listener {
             swordPlayer.act(InputType.LEFT);
         }
         else if (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK) {
+            if (!swordPlayer.getInputBuffer().accept(InputType.RIGHT)) return;
+
             if (swordPlayer.handleItemInteraction(item, InputType.RIGHT)) {
                 event.setCancelled(true);
-                return;
-            }
-
-            if (swordPlayer.isInteractingWithEntity()) {
                 return;
             }
 
@@ -138,24 +133,20 @@ public class InputListener implements Listener {
      */
     @EventHandler
     public void onPlayerEntityInteract(PlayerInteractEntityEvent event) {
+        event.setCancelled(true);
         SwordPlayer swordPlayer = (SwordPlayer) SwordEntityArbiter.getOrAdd(event.getPlayer());
-        ItemStack item = swordPlayer.getItemStackInHand(true);
 
         swordPlayer.setInteractingWithEntity(true);
-
-        if (swordPlayer.handleItemInteraction(item, InputType.RIGHT)) {
-            event.setCancelled(true);
-            return;
-        }
-        swordPlayer.act(InputType.RIGHT);
-
         Consumer<SwordPlayer> resetInteractingFlag =
                 sp -> sp.setInteractingWithEntity(false);
         SwordScheduler.runConsumerNextTick(resetInteractingFlag, swordPlayer);
 
-        event.setCancelled(true);
+        if (!swordPlayer.getInputBuffer().accept(InputType.RIGHT)) return;
 
-//        event.getRightClicked(); // For later use, not need currently.
+        ItemStack item = swordPlayer.getItemStackInHand(true);
+        if (swordPlayer.handleItemInteraction(item, InputType.RIGHT)) return;
+
+        swordPlayer.act(InputType.RIGHT);
     }
 
     @EventHandler

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -43,6 +43,7 @@ import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.input.ActivationContext;
 import btm.sword.system.input.InputAction;
 import btm.sword.system.input.InputActionExecutor;
+import btm.sword.system.input.InputBuffer;
 import btm.sword.system.input.InputExecutionTree;
 import btm.sword.system.input.InputRegistrar;
 import btm.sword.system.input.InputType;
@@ -87,6 +88,7 @@ public class SwordPlayer extends Combatant {
     private final HashSet<Dummy> yourDummies = new HashSet<>();
 
     private final InputExecutionTree inputExecutionTree;
+    private final InputBuffer inputBuffer;
     private final long baseInputTimeoutMillis = 1400L;
 
     /** Current input context; controls which action paths are visible in the execution tree. */
@@ -168,6 +170,7 @@ public class SwordPlayer extends Combatant {
             .build();
 
         inputExecutionTree = new InputExecutionTree(this);
+        inputBuffer = new InputBuffer();
         InputRegistrar.initializeInputTree(inputExecutionTree.getRoot(), this);
         InputRegistrar.initializeMovementInputs(inputExecutionTree.getRoot());
 
@@ -198,6 +201,7 @@ public class SwordPlayer extends Combatant {
     @Override
     protected void onTick() {
         super.onTick();
+        inputBuffer.tick();
 
         if (player.getHealth() > 0) updateVisualStats();
 

--- a/src/main/java/btm/sword/system/input/InputBuffer.java
+++ b/src/main/java/btm/sword/system/input/InputBuffer.java
@@ -1,0 +1,47 @@
+package btm.sword.system.input;
+
+import java.util.EnumMap;
+
+import org.bukkit.Bukkit;
+
+/**
+ * Per-player input buffer that prevents duplicate inputs from firing within the same server tick.
+ * <p>
+ * Minecraft often fires multiple Bukkit events for a single physical input — for example,
+ * left-clicking an entity fires both {@code PrePlayerAttackEntityEvent} and
+ * {@code PlayerInteractEvent}. Without deduplication, the same input is processed twice,
+ * causing actions like attacks to double-fire.
+ * </p>
+ * <p>
+ * Each {@link InputType} is tracked by the server tick it was last accepted on.
+ * If the same input type is submitted again in the same tick, it is rejected.
+ * </p>
+ */
+public class InputBuffer {
+    private final EnumMap<InputType, Integer> lastAcceptedTick = new EnumMap<>(InputType.class);
+
+    /**
+     * Attempts to accept an input for processing. Returns {@code true} if the input
+     * is fresh (not yet seen this tick) and should be processed, or {@code false}
+     * if it is a duplicate within the current server tick.
+     *
+     * @param input the input type to accept
+     * @return {@code true} if the input should be processed, {@code false} if it is a duplicate
+     */
+    public boolean accept(InputType input) {
+        int currentTick = Bukkit.getCurrentTick();
+        Integer lastTick = lastAcceptedTick.get(input);
+        if (lastTick != null && lastTick == currentTick) {
+            return false;
+        }
+        lastAcceptedTick.put(input, currentTick);
+        return true;
+    }
+
+    /**
+     * Called once per server tick. Reserved for future input forgiveness and retry logic.
+     */
+    public void tick() {
+        // Future: drain retry queue for input forgiveness
+    }
+}

--- a/src/main/java/btm/sword/system/input/InputExecutionTree.java
+++ b/src/main/java/btm/sword/system/input/InputExecutionTree.java
@@ -438,6 +438,9 @@ public class InputExecutionTree {
                 return cachedAction;
             }
             for (ActionContextPair pair : actions) {
+                if (pair == null || pair.action == null || pair.action.get() == null) {
+                    continue;
+                }
                 owner.message(pair.action.get().name);
                 if (pair.context().test(owner)) {
                     owner.message("  ^ passed context test!");


### PR DESCRIPTION
## Summary
- Adds `InputBuffer` — a per-player, per-tick deduplication guard for input events. Tracks the last accepted server tick per `InputType` and rejects duplicates within the same tick.
- Left-clicking an entity fires both `PrePlayerAttackEntityEvent` and `PlayerInteractEvent` in the same server tick, causing `act(LEFT)` to run twice. The buffer collapses these into one.
- Replaces the `isInteractingWithEntity()` check in `onPlayerInteract` for RIGHT-click dedup (the flag is retained for `ThrownItem.onReady()` throw detection).
- Removes resolved TODO #124 comments.
- `InputBuffer.tick()` stub reserved for future input forgiveness/retry logic.

## Test plan
- [ ] Left-click a mob once — single attack fires
- [ ] Left-click again — still exactly one attack per click (was previously double-firing on second click)
- [ ] Right-click an entity — single right-click action, no duplication
- [ ] Right-click interactible blocks (chests, crafting tables) while at root — vanilla interaction works
- [ ] Combo inputs (L → L → L) still chain correctly with no missed or doubled steps
- [ ] Throw priming + right-clicking an entity still triggers auto-throw
- [ ] DROP and SWAP inputs unaffected

Closes #204