### PR TITLE
Refactor: Dynamic attack duration + cooldown cleanup

### DIFF
--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -592,7 +592,7 @@ public class Config {
                 ConfigurationSection::getInt
         ); }
 
-        public static int ATTACKS_CAST_TIMING_MAX_DURATION = 1200; // 1.4 seconds
+        public static int ATTACKS_CAST_TIMING_MAX_DURATION = 200;
         static { register("combat.attacks_cast_timing_max_duration",
                 ATTACKS_CAST_TIMING_MAX_DURATION, Integer.class,
                 v -> ATTACKS_CAST_TIMING_MAX_DURATION = v,

--- a/src/main/java/btm/sword/system/action/attack/AttackAction.java
+++ b/src/main/java/btm/sword/system/action/attack/AttackAction.java
@@ -73,7 +73,9 @@ public class AttackAction extends SwordAction {
     }
 
     public static void basicSlash(Combatant executor, ItemStack itemUsedInAttack, AttackProfile profile, Boolean orientWithPitch) {
-        new SweepAttack(itemUsedInAttack, profile, orientWithPitch)
+        new SweepAttack(itemUsedInAttack, profile,
+            orientWithPitch, 40,
+            60, 0.1, 0.9)
             .setAttackDuration(attacker -> (int) attacker.calcValueReductive(
                 AspectType.CELERITY,
                 Config.Combat.ATTACKS_CAST_TIMING_MIN_DURATION,

--- a/src/main/java/btm/sword/system/action/attack/AttackAction.java
+++ b/src/main/java/btm/sword/system/action/attack/AttackAction.java
@@ -74,8 +74,7 @@ public class AttackAction extends SwordAction {
 
     public static void basicSlash(Combatant executor, ItemStack itemUsedInAttack, AttackProfile profile, Boolean orientWithPitch) {
         new SweepAttack(itemUsedInAttack, profile,
-            orientWithPitch, 40,
-            60, 0.1, 0.9)
+            orientWithPitch)
             .setAttackDuration(attacker -> (int) attacker.calcValueReductive(
                 AspectType.CELERITY,
                 Config.Combat.ATTACKS_CAST_TIMING_MIN_DURATION,

--- a/src/main/java/btm/sword/system/action/attack/AttackAction.java
+++ b/src/main/java/btm/sword/system/action/attack/AttackAction.java
@@ -10,6 +10,7 @@ import btm.sword.system.attack.SweepAttack;
 import btm.sword.system.attack.style.AttackProfile;
 import btm.sword.system.attack.style.AttackType;
 import btm.sword.system.attack.style.WeaponAttackStyle;
+import btm.sword.system.entity.aspect.AspectType;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.item.ItemUsageManager;
@@ -72,9 +73,12 @@ public class AttackAction extends SwordAction {
     }
 
     public static void basicSlash(Combatant executor, ItemStack itemUsedInAttack, AttackProfile profile, Boolean orientWithPitch) {
-        new SweepAttack(itemUsedInAttack, profile,
-            orientWithPitch, 40,
-            60, 0.1, 0.9)
+        new SweepAttack(itemUsedInAttack, profile, orientWithPitch)
+            .setAttackDuration(attacker -> (int) attacker.calcValueReductive(
+                AspectType.CELERITY,
+                Config.Combat.ATTACKS_CAST_TIMING_MIN_DURATION,
+                Config.Combat.ATTACKS_CAST_TIMING_MAX_DURATION,
+                Config.Combat.ATTACKS_CAST_TIMING_REDUCTION_RATE))
             .setAttackConnectInstructions(
                 new ConsumerToConsumePair<>(
                     itemStack -> ItemUsageManager.damageItemStack(itemStack, 20, executor.self()),

--- a/src/main/java/btm/sword/system/action/attack/DashAttackAction.java
+++ b/src/main/java/btm/sword/system/action/attack/DashAttackAction.java
@@ -19,8 +19,7 @@ public class DashAttackAction extends SwordAction {
 
         boolean forward = direction.equals(DashDirection.FORWARD);
 
-        executor.setTimeOfLastAttack(System.currentTimeMillis());
-        executor.setDurationOfLastAttack(700);
+        executor.applyAttackCooldown();
 
         if (weaponAttackStyle.equals(WeaponAttackStyle.PUNCH)) { // catch any untagged items and perform a punch with it
             PunchAction.throwPunch(executor, true, forward ? 3.5 : 1);

--- a/src/main/java/btm/sword/system/action/attack/PunchAction.java
+++ b/src/main/java/btm/sword/system/action/attack/PunchAction.java
@@ -4,10 +4,8 @@ import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 
-import btm.sword.config.Config;
 import btm.sword.system.action.SwordAction;
 import btm.sword.system.entity.SwordEntityArbiter;
-import btm.sword.system.entity.aspect.AspectType;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.utility.Prefab;
@@ -50,13 +48,7 @@ public class PunchAction extends SwordAction {
     }
 
     public static void throwPunch(Combatant executor, boolean right, double distance) {
-        executor.setTimeOfLastAttack(System.currentTimeMillis());
-        int cooldown = (int) executor.calcValueReductive(AspectType.FINESSE,
-            Config.Combat.ATTACKS_CAST_TIMING_MIN_DURATION,
-            Config.Combat.ATTACKS_CAST_TIMING_MAX_DURATION,
-            Config.Combat.ATTACKS_CAST_TIMING_REDUCTION_RATE);
-        executor.setDurationOfLastAttack(cooldown);
-
+        executor.applyAttackCooldown();
         punch(executor, right, distance);
     }
 }

--- a/src/main/java/btm/sword/system/attack/Attack.java
+++ b/src/main/java/btm/sword/system/attack/Attack.java
@@ -25,7 +25,6 @@ import btm.sword.system.control.PredicateRunnablePair;
 import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.SwordEntityArbiter;
-import btm.sword.system.entity.aspect.AspectType;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.utility.Prefab;
@@ -77,6 +76,8 @@ public class Attack extends SwordAction implements Runnable {
     protected int msPerIteration;
 
     protected final double rangeMultiplier;
+
+    protected Function<Combatant, Integer> attackDurationResolver;
 
     protected Runnable callback;
     protected int msBeforeCallbackSchedule;
@@ -139,6 +140,19 @@ public class Attack extends SwordAction implements Runnable {
         return this;
     }
 
+    /**
+     * Sets a dynamic resolver for the attack animation duration in milliseconds.
+     * Evaluated at execution time with the attacking {@link Combatant}, allowing
+     * the duration to scale with player stats, weapon type, or combo position.
+     *
+     * @param resolver function that computes animation duration from the attacker
+     * @return this attack for chaining
+     */
+    public Attack setAttackDuration(Function<Combatant, Integer> resolver) {
+        this.attackDurationResolver = resolver;
+        return this;
+    }
+
     public boolean nextAttackExists() {
         return nextAttack != null;
     }
@@ -156,19 +170,15 @@ public class Attack extends SwordAction implements Runnable {
         cast();
     }
 
-    // TODO: #139 make usage dynamic
     protected void cast() {
-        // Trigger attack logic immediately; input-level casting will be handled by the InputAction's castDuration
         onRun();
     }
 
     private void onRun() {
-        attacker.setTimeOfLastAttack(System.currentTimeMillis());
-        int cooldown = (int) attacker.calcValueReductive(AspectType.FINESSE,
-            Config.Combat.ATTACKS_CAST_TIMING_MIN_DURATION,
-            Config.Combat.ATTACKS_CAST_TIMING_MAX_DURATION,
-            Config.Combat.ATTACKS_CAST_TIMING_REDUCTION_RATE);
-        attacker.setDurationOfLastAttack(cooldown);
+        attacker.applyAttackCooldown();
+        if (attackDurationResolver != null) {
+            this.attackMilliseconds = attackDurationResolver.apply(attacker);
+        }
         startAttack();
     }
 

--- a/src/main/java/btm/sword/system/entity/impl/Combatant.java
+++ b/src/main/java/btm/sword/system/entity/impl/Combatant.java
@@ -11,6 +11,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.Vector;
 
+import btm.sword.config.Config;
 import btm.sword.system.action.ActionCaster;
 import btm.sword.system.action.movement.MovementAction;
 import btm.sword.system.action.throwing.types.ThrownItem;
@@ -372,6 +373,23 @@ public abstract class Combatant extends SwordEntity {
      */
     public int calcCooldown(AspectType type, double min, double base, double multiplier) {
         return (int) Math.max(min, base - (multiplier * aspects.getAspectVal(type)) );
+    }
+
+    /**
+     * Calculates and applies the standard attack cooldown based on FINESSE.
+     * Sets both {@code timeOfLastAttack} and {@code durationOfLastAttack} so the
+     * input tree's cooldown check ({@code getDurationOfLastAttack}) works correctly.
+     *
+     * @return the computed cooldown duration in milliseconds
+     */
+    public int applyAttackCooldown() {
+        setTimeOfLastAttack(System.currentTimeMillis());
+        int cooldown = (int) calcValueReductive(AspectType.FINESSE,
+            Config.Combat.ATTACKS_CAST_TIMING_MIN_DURATION,
+            Config.Combat.ATTACKS_CAST_TIMING_MAX_DURATION,
+            Config.Combat.ATTACKS_CAST_TIMING_REDUCTION_RATE);
+        setDurationOfLastAttack(cooldown);
+        return cooldown;
     }
 
     public boolean canPerformUmbralLinkAttack() {

--- a/src/main/java/btm/sword/system/input/InputRegistrar.java
+++ b/src/main/java/btm/sword/system/input/InputRegistrar.java
@@ -327,6 +327,12 @@ public class InputRegistrar {
      * @param maxSteps  number of combo steps to register (e.g. 3 for L, LL, LLL)
      */
     private static void registerBasicAttackCombo(InputExecutionTree.InputNode root, int maxSteps) {
+        Function<Combatant, Integer> attackCastDuration = executor -> (int) executor.calcValueReductive(
+            AspectType.CELERITY,
+            Config.Combat.ATTACKS_CAST_TIMING_MIN_DURATION,
+            Config.Combat.ATTACKS_CAST_TIMING_MAX_DURATION,
+            Config.Combat.ATTACKS_CAST_TIMING_REDUCTION_RATE);
+
         for (int step = 1; step <= maxSteps; step++) {
             final int comboStep = step;
             boolean isFirst = step == 1;
@@ -344,6 +350,7 @@ public class InputRegistrar {
                         .action(executor -> UmbralBladeAction.basicAttackWithLink(executor, comboStep))
                         .cooldown(cooldown)
                         .canCast(Combatant::canPerformUmbralLinkAttack)
+                        .castDuration(attackCastDuration)
                         .displayCooldown(true)
                         .displayDisabled(true)
                         .resetIfCannotPerform(!isLast)
@@ -354,6 +361,7 @@ public class InputRegistrar {
                         .action(executor -> AttackAction.basicAttack(executor, comboStep))
                         .cooldown(cooldown)
                         .canCast(Combatant::canPerformAction)
+                        .castDuration(attackCastDuration)
                         .displayCooldown(true)
                         .displayDisabled(true)
                         .resetIfCannotPerform(false)

--- a/src/main/java/btm/sword/system/input/InputRegistrar.java
+++ b/src/main/java/btm/sword/system/input/InputRegistrar.java
@@ -1,7 +1,10 @@
 package btm.sword.system.input;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import btm.sword.config.Config;
 import btm.sword.system.action.UmbralBladeAction;
@@ -36,87 +39,8 @@ public class InputRegistrar {
      * @param root the root node of the execution tree
      */
     public static void initializeMovementInputs(InputExecutionTree.InputNode root) {
-        new InputExecutionTree.InputNodeBuilder(root, List.of(
-            InputType.SWAP,
-            InputType.SWAP
-        )).action(new LinkedList<>(List.of(
-            new InputExecutionTree.ActionContextPair(
-                () -> InputAction.builder()
-                .action(executor -> MovementAction.dash(executor, DashDirection.FORWARD))
-                .cooldown(executor -> executor.calcCooldown(AspectType.CELERITY, 200, 1000, 10))
-                .canCast(Combatant::canAirDash)
-                .castDuration(() -> Config.Movement.DASH_CAST_DURATION)
-                .displayDisabled(true)
-                .resetIfCannotPerform(true)
-                .build(),
-                Combatant::canAirDash)
-            )))
-            .timeoutTicks(7)
-            .cancellable(true)
-            .display(true)
-            .build();
-
-        new InputExecutionTree.InputNodeBuilder(root, List.of(
-            InputType.SWAP,
-            InputType.SWAP,
-            InputType.LEFT
-        )).action(new LinkedList<>(List.of(
-            new InputExecutionTree.ActionContextPair(
-                () -> InputAction.builder()
-                .action(executor -> DashAttackAction.dashAttack(executor, DashDirection.FORWARD))
-                .cooldown(executor -> 0)
-                .canCast(Combatant::canPerformAction)
-                .castDuration(() -> 500)
-                .displayDisabled(true)
-                .resetIfCannotPerform(true)
-                .build(),
-                SwordPlayer::normalActState)
-            )))
-            .timeoutTicks(3)
-            .cancellable(true)
-            .display(true)
-            .build();
-
-        new InputExecutionTree.InputNodeBuilder(root, List.of(
-            InputType.SHIFT,
-            InputType.SHIFT
-        )).action(new LinkedList<>(List.of(
-            new InputExecutionTree.ActionContextPair(
-                () -> InputAction.builder()
-                .action(executor -> MovementAction.dash(executor, DashDirection.BACKWARD))
-                .cooldown(executor -> executor.calcCooldown(AspectType.CELERITY, 200, 1000, 10))
-                .canCast(Combatant::canAirDash)
-                .castDuration(() -> Config.Movement.DASH_CAST_DURATION)
-                .displayDisabled(true)
-                .resetIfCannotPerform(true)
-                .build(),
-                SwordPlayer::normalActState)
-            )))
-            .timeoutTicks(7)
-            .cancellable(true)
-            .display(true)
-            .build();
-
-        new InputExecutionTree.InputNodeBuilder(root, List.of(
-            InputType.SHIFT,
-            InputType.SHIFT,
-            InputType.LEFT
-        )).action(new LinkedList<>(List.of(
-            new InputExecutionTree.ActionContextPair(
-                () -> InputAction.builder()
-                .action(executor -> DashAttackAction.dashAttack(executor, DashDirection.BACKWARD))
-                .cooldown(executor -> 0)
-                .canCast(Combatant::canPerformAction)
-                .castDuration(() -> 500)
-                .displayDisabled(true)
-                .resetIfCannotPerform(true)
-                .build(),
-                SwordPlayer::normalActState)
-            )))
-            .timeoutTicks(3)
-            .cancellable(true)
-            .display(true)
-            .build();
+        registerDash(root, InputType.SWAP, DashDirection.FORWARD, Combatant::canAirDash);
+        registerDash(root, InputType.SHIFT, DashDirection.BACKWARD, SwordPlayer::normalActState);
     }
 
     /**
@@ -148,101 +72,8 @@ public class InputRegistrar {
             .display(true)
             .build();
 
-        // basic umbral attacks — registered BEFORE basic attacks so they're first in the action list
-        new InputExecutionTree.InputNodeBuilder(root, List.of(
-            InputType.LEFT
-        )).action(new LinkedList<>(List.of(
-            new InputExecutionTree.ActionContextPair(
-                () -> InputAction.builder()
-                .action(executor -> UmbralBladeAction.basicAttackWithLink(executor, 1))
-                .cooldown(Combatant::getDurationOfLastAttack)
-                .canCast(Combatant::canPerformUmbralLinkAttack)
-                .displayCooldown(true)
-                .displayDisabled(true)
-                .resetIfCannotPerform(true)
-                .build(),
-                SwordPlayer::soulLinkState),
-            new InputExecutionTree.ActionContextPair(
-                () -> InputAction.builder()
-                .action(executor -> AttackAction.basicAttack(executor, 1))
-                .cooldown(Combatant::getDurationOfLastAttack)
-                .canCast(Combatant::canPerformAction)
-                .castDuration(() -> 0)
-                .displayCooldown(true)
-                .displayDisabled(true)
-                .resetIfCannotPerform(false)
-                .build(),
-                SwordPlayer::normalActState)
-            )))
-            .timeoutTicks(60)
-            .sameItemRequired(true)
-            .cancellable(true)
-            .display(true)
-            .build();
-
-        new InputExecutionTree.InputNodeBuilder(root, List.of(
-            InputType.LEFT,
-            InputType.LEFT
-        )).action(new LinkedList<>(List.of(
-            new InputExecutionTree.ActionContextPair(
-                () -> InputAction.builder()
-                .action(executor -> UmbralBladeAction.basicAttackWithLink(executor, 2))
-                .cooldown(executor -> 0)
-                .canCast(Combatant::canPerformUmbralLinkAttack)
-                .displayCooldown(true)
-                .displayDisabled(true)
-                .resetIfCannotPerform(true)
-                .build(),
-                SwordPlayer::soulLinkState),
-            new InputExecutionTree.ActionContextPair(
-                () -> InputAction.builder()
-                .action(executor -> AttackAction.basicAttack(executor, 2))
-                .cooldown(executor -> 0)
-                .canCast(Combatant::canPerformAction)
-                .castDuration(() -> 0)
-                .displayCooldown(true)
-                .displayDisabled(true)
-                .resetIfCannotPerform(false)
-                .build(),
-                SwordPlayer::normalActState)
-            )))
-            .timeoutTicks(60)
-            .sameItemRequired(true)
-            .cancellable(true)
-            .display(true)
-            .build();
-
-        new InputExecutionTree.InputNodeBuilder(root, List.of(
-            InputType.LEFT,
-            InputType.LEFT,
-            InputType.LEFT
-        )).action(new LinkedList<>(List.of(
-            new InputExecutionTree.ActionContextPair(
-                () -> InputAction.builder().action(executor -> UmbralBladeAction.basicAttackWithLink(executor, 3))
-                    .cooldown(executor -> 0)
-                    .canCast(Combatant::canPerformUmbralLinkAttack)
-                    .displayCooldown(true)
-                    .displayDisabled(true)
-                    .resetIfCannotPerform(false)
-                    .build(),
-                SwordPlayer::soulLinkState),
-            new InputExecutionTree.ActionContextPair(
-                () -> InputAction.builder()
-                    .action(executor -> AttackAction.basicAttack(executor, 3))
-                    .cooldown(executor -> 0)
-                    .canCast(Combatant::canPerformAction)
-                    .castDuration(() -> 0)
-                    .displayCooldown(true)
-                    .displayDisabled(true)
-                    .resetIfCannotPerform(false)
-                    .build(),
-                    SwordPlayer::normalActState)
-            )))
-            .timeoutTicks(60)
-            .sameItemRequired(true)
-            .cancellable(true)
-            .display(true)
-            .build();
+        // basic attack combo chain (L, LL, LLL) — umbral variants registered first for priority
+        registerBasicAttackCombo(root, 3);
 
 
         // lunge (umbral link DROP + RIGHT) — registered FIRST, takes priority over throw when holding soul link
@@ -481,14 +312,128 @@ public class InputRegistrar {
             .build();
 
         // Active Skill slots (ACTIVE_1 and ACTIVE_2)
+        registerActiveSkillSlot(root, owner, SkillSlot.ACTIVE_1, 1);
+        registerActiveSkillSlot(root, owner, SkillSlot.ACTIVE_2, 2);
+    }
+
+    // ── Helper methods ──────────────────────────────────────────────────────
+
+    /**
+     * Registers the basic attack combo chain (L, LL, LLL...) with both umbral-link and
+     * normal-state variants. The first combo step uses {@code getDurationOfLastAttack} as
+     * its cooldown; subsequent steps have zero cooldown so the chain flows naturally.
+     *
+     * @param root      the tree root node
+     * @param maxSteps  number of combo steps to register (e.g. 3 for L, LL, LLL)
+     */
+    private static void registerBasicAttackCombo(InputExecutionTree.InputNode root, int maxSteps) {
+        for (int step = 1; step <= maxSteps; step++) {
+            final int comboStep = step;
+            boolean isFirst = step == 1;
+            boolean isLast = step == maxSteps;
+
+            Function<Combatant, Integer> cooldown = isFirst
+                ? Combatant::getDurationOfLastAttack
+                : executor -> 0;
+
+            new InputExecutionTree.InputNodeBuilder(root,
+                Collections.nCopies(step, InputType.LEFT)
+            ).action(new LinkedList<>(List.of(
+                new InputExecutionTree.ActionContextPair(
+                    () -> InputAction.builder()
+                        .action(executor -> UmbralBladeAction.basicAttackWithLink(executor, comboStep))
+                        .cooldown(cooldown)
+                        .canCast(Combatant::canPerformUmbralLinkAttack)
+                        .displayCooldown(true)
+                        .displayDisabled(true)
+                        .resetIfCannotPerform(!isLast)
+                        .build(),
+                    SwordPlayer::soulLinkState),
+                new InputExecutionTree.ActionContextPair(
+                    () -> InputAction.builder()
+                        .action(executor -> AttackAction.basicAttack(executor, comboStep))
+                        .cooldown(cooldown)
+                        .canCast(Combatant::canPerformAction)
+                        .displayCooldown(true)
+                        .displayDisabled(true)
+                        .resetIfCannotPerform(false)
+                        .build(),
+                    SwordPlayer::normalActState)
+            )))
+                .timeoutTicks(60)
+                .sameItemRequired(true)
+                .cancellable(true)
+                .display(true)
+                .build();
+        }
+    }
+
+    /**
+     * Registers a dash and its follow-up dash-attack for the given input key and direction.
+     * Dash: {@code key, key}. Dash-attack: {@code key, key, LEFT}.
+     *
+     * @param root      the tree root node
+     * @param key       the double-tap input (SWAP for forward, SHIFT for backward)
+     * @param direction the dash direction
+     * @param context   context predicate for the dash action
+     */
+    private static void registerDash(InputExecutionTree.InputNode root,
+                                     InputType key, DashDirection direction,
+                                     Predicate<SwordPlayer> context) {
+        new InputExecutionTree.InputNodeBuilder(root, List.of(key, key))
+            .action(new LinkedList<>(List.of(
+                new InputExecutionTree.ActionContextPair(
+                    () -> InputAction.builder()
+                        .action(executor -> MovementAction.dash(executor, direction))
+                        .cooldown(executor -> executor.calcCooldown(AspectType.CELERITY, 200, 1000, 10))
+                        .canCast(Combatant::canAirDash)
+                        .castDuration(() -> Config.Movement.DASH_CAST_DURATION)
+                        .displayDisabled(true)
+                        .resetIfCannotPerform(true)
+                        .build(),
+                    context)
+            )))
+            .timeoutTicks(7)
+            .cancellable(true)
+            .display(true)
+            .build();
+
+        new InputExecutionTree.InputNodeBuilder(root, List.of(key, key, InputType.LEFT))
+            .action(new LinkedList<>(List.of(
+                new InputExecutionTree.ActionContextPair(
+                    () -> InputAction.builder()
+                        .action(executor -> DashAttackAction.dashAttack(executor, direction))
+                        .cooldown(executor -> 0)
+                        .canCast(Combatant::canPerformAction)
+                        .castDuration(() -> 500)
+                        .displayDisabled(true)
+                        .resetIfCannotPerform(true)
+                        .build(),
+                    SwordPlayer::normalActState)
+            )))
+            .timeoutTicks(3)
+            .cancellable(true)
+            .display(true)
+            .build();
+    }
+
+    /**
+     * Registers tap and hold variants for an active skill slot.
+     *
+     * @param root      the tree root node
+     * @param owner     the player who owns the tree
+     * @param slot      the skill slot to bind
+     * @param slotIndex the hotbar slot index (1 or 2) for context predicate
+     */
+    private static void registerActiveSkillSlot(InputExecutionTree.InputNode root,
+                                                SwordPlayer owner,
+                                                SkillSlot slot, int slotIndex) {
         // Tap variant
-        new InputExecutionTree.InputNodeBuilder(root, List.of(
-            InputType.SWAP,
-            InputType.RIGHT
-        )).action(new LinkedList<>(List.of(
-            new InputExecutionTree.ActionContextPair(
-                () -> SkillSlotActionFactory.create(owner, SkillSlot.ACTIVE_1, false),
-                sp -> sp.activeItemState(1))
+        new InputExecutionTree.InputNodeBuilder(root, List.of(InputType.SWAP, InputType.RIGHT))
+            .action(new LinkedList<>(List.of(
+                new InputExecutionTree.ActionContextPair(
+                    () -> SkillSlotActionFactory.create(owner, slot, false),
+                    sp -> sp.activeItemState(slotIndex))
             )))
             .dynamic(true)
             .sameItemRequired(true)
@@ -498,44 +443,11 @@ public class InputRegistrar {
 
         // Hold variant
         new InputExecutionTree.InputNodeBuilder(root, List.of(
-            InputType.SWAP,
-            InputType.RIGHT,
-            InputType.RIGHT_HOLD
+            InputType.SWAP, InputType.RIGHT, InputType.RIGHT_HOLD
         )).action(new LinkedList<>(List.of(
                 new InputExecutionTree.ActionContextPair(
-                    () -> SkillSlotActionFactory.create(owner, SkillSlot.ACTIVE_1, true),
-                    sp -> sp.activeItemState(1))
-            )))
-            .dynamic(true)
-            .sameItemRequired(true)
-            .cancellable(true)
-            .display(true)
-            .build();
-
-        // ACTIVE_2 tap variant
-        new InputExecutionTree.InputNodeBuilder(root, List.of(
-            InputType.SWAP,
-            InputType.RIGHT
-        )).action(new LinkedList<>(List.of(
-            new InputExecutionTree.ActionContextPair(
-                () -> SkillSlotActionFactory.create(owner, SkillSlot.ACTIVE_2, false),
-                sp -> sp.activeItemState(2))
-            )))
-            .dynamic(true)
-            .sameItemRequired(true)
-            .cancellable(true)
-            .display(true)
-            .build();
-
-        // ACTIVE_2 hold variant
-        new InputExecutionTree.InputNodeBuilder(root, List.of(
-            InputType.SWAP,
-            InputType.RIGHT,
-            InputType.RIGHT_HOLD
-        )).action(new LinkedList<>(List.of(
-            new InputExecutionTree.ActionContextPair(
-                () -> SkillSlotActionFactory.create(owner, SkillSlot.ACTIVE_2, true),
-                sp -> sp.activeItemState(2))
+                    () -> SkillSlotActionFactory.create(owner, slot, true),
+                    sp -> sp.activeItemState(slotIndex))
             )))
             .dynamic(true)
             .sameItemRequired(true)


### PR DESCRIPTION
## Summary
- **Dynamic attack duration** (#139): `Attack.setAttackDuration(Function<Combatant, Integer>)` allows animation timing to scale with player stats (CELERITY), weapon type, or combo position at execution time. `basicSlash` now uses this instead of hardcoded values.
- **Consolidated cooldown** (#180): `Combatant.applyAttackCooldown()` replaces 3 duplicated cooldown calculations across `Attack.onRun()`, `PunchAction.throwPunch()`, and `DashAttackAction.dashAttack()`.
- **InputRegistrar helpers** (#180): `registerBasicAttackCombo()`, `registerDash()`, and `registerActiveSkillSlot()` eliminate ~65 lines of repetitive registration boilerplate and provide a clear pattern for adding new skills.

## Test plan
- [x] Basic attack combo (L, LL, LLL) works with correct cooldown on first hit and no cooldown between chain hits
- [x] Attack animation speed scales with CELERITY stat
- [x] Punches and dash attacks still apply cooldown correctly
- [x] Dash (FF, SS) and dash-attack (FF+L, SS+L) still function
- [x] Active skill slots (SWAP+R tap/hold) resolve correctly for slots 1 and 2
- [x] Umbral link attacks still take priority over normal attacks when holding soul link

Closes #139, closes #180