### PR TITLE
[Refactor] Grab and Movement retrieve item logic

### DIFF
--- a/src/main/java/btm/sword/system/action/throwing/InteractiveItemArbiter.java
+++ b/src/main/java/btm/sword/system/action/throwing/InteractiveItemArbiter.java
@@ -94,19 +94,18 @@ public class InteractiveItemArbiter {
 //            }
         }
 
-//        ItemStack item = display.getItemStack();
+        // UmbralBlade manages its own item state (weapon/link/blade fields) and never populates
+        // the inherited SimulatedDisplay.itemStack field — check before the null guard below.
+        if (interactiveItem instanceof UmbralBlade umbralBlade) {
+            umbralBlade.setRetrieved(true);
+            umbralBlade.onGrab(executor);
+            return;
+        }
 
         ItemStack item = interactiveItem.getItemStack();
         if (item == null) return;
         if (!item.isEmpty()) {
-            if (interactiveItem instanceof UmbralBlade umbralBlade) {
-                umbralBlade.onGrab(executor);
-                return;
-            }
-            else {
-                interactiveItem.dispose();
-            }
-
+            interactiveItem.dispose();
             executor.giveItem(item);
             Location displayLoc = display.getLocation();
             if (item.getType().isBlock()) {

--- a/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
@@ -522,11 +522,11 @@ public class ThrownItem extends SimulatedDisplay {
     public void onHit() {
         if (hitEntity == null) return;
 
-        // TODO: #127 - Better checks for weapon, can tag with impactType = 'impale'
         String name = display.getItemStack().getType().toString();
 
         handleItemDamageAndCheckIfBroken();
 
+        // TODO: #127 - Better checks for weapon, can tag with impactType = 'impale'
         if (name.endsWith("_SWORD") || name.endsWith("AXE")) {
             startImpalementTask(hitEntity);
         }
@@ -543,19 +543,11 @@ public class ThrownItem extends SimulatedDisplay {
 
         int currentDamage = ItemUsageManager.currentItemDamage(itemStack);
 
-        Debug.debug(ThrownItem.class, 514, "Current Damage: " + currentDamage);
-
         int maxThrownItemUses = 3;
         int onThrowHitDamageToItem = ItemUsageManager.maxItemDamage(itemStack) / maxThrownItemUses;
 
-        Debug.debug(ThrownItem.class, 514, "OnThrowHitDamage: " + onThrowHitDamageToItem);
-        Debug.debug(ThrownItem.class, 514, "Check Value: " + onThrowHitDamageToItem * (1 - maxThrownItemUses));
-
-
         if (currentDamage >= onThrowHitDamageToItem * (maxThrownItemUses - 1)) {
             Prefab.Particles.ITEM_THROW_BREAK.display(display.getLocation());
-
-            Debug.debug(ThrownItem.class, 519, "Item is getting destroyed");
 
             itemStack.damage(77777777, thrower.self());
             display.remove();
@@ -579,7 +571,7 @@ public class ThrownItem extends SimulatedDisplay {
         }
     }
 
-    private void startImpalementTask(SwordEntity target) {
+    public void startImpalementTask(SwordEntity target) {
         Vector kb = EntityUtil.isOnGround(target.self()) ?
             velocity.clone().multiply(Config.Combat.THROWN_DAMAGE_SWORD_AXE_KNOCKBACK_GROUNDED) :
             VectorUtil.getProjOntoPlane(velocity, Config.Direction.UP()).multiply(Config.Combat.THROWN_DAMAGE_SWORD_AXE_KNOCKBACK_AIRBORNE);

--- a/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
@@ -45,7 +45,6 @@ import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.input.ActivationContext;
 import btm.sword.system.item.ItemUsageManager;
 import btm.sword.system.item.KeyRegistry;
-import btm.sword.utility.Debug;
 import btm.sword.utility.Prefab;
 import btm.sword.utility.display.DisplayUtil;
 import btm.sword.utility.display.ParticleWrapper;

--- a/src/main/java/btm/sword/system/entity/impl/Combatant.java
+++ b/src/main/java/btm/sword/system/entity/impl/Combatant.java
@@ -2,6 +2,8 @@ package btm.sword.system.entity.impl;
 
 import java.util.concurrent.TimeUnit;
 
+import btm.sword.system.entity.umbral.statemachine.state.WieldState;
+
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
@@ -276,6 +278,14 @@ public abstract class Combatant extends SwordEntity {
      */
     public boolean canPerformAction() {
         return abilityCastTask == null && !isGrabbing && !isGrabbed();
+    }
+
+    public boolean canPerformWieldAction() {
+        return canPerformAction() && (
+                umbralBlade.inState(StandbyState.class) ||
+                umbralBlade.inState(SheathedState.class) ||
+                umbralBlade.inState(WieldState.class)
+            );
     }
 
     public boolean canPerformUmbralAction() {

--- a/src/main/java/btm/sword/system/entity/impl/Combatant.java
+++ b/src/main/java/btm/sword/system/entity/impl/Combatant.java
@@ -2,8 +2,6 @@ package btm.sword.system.entity.impl;
 
 import java.util.concurrent.TimeUnit;
 
-import btm.sword.system.entity.umbral.statemachine.state.WieldState;
-
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
@@ -27,6 +25,7 @@ import btm.sword.system.entity.umbral.statemachine.state.LodgedState;
 import btm.sword.system.entity.umbral.statemachine.state.RecallingState;
 import btm.sword.system.entity.umbral.statemachine.state.SheathedState;
 import btm.sword.system.entity.umbral.statemachine.state.StandbyState;
+import btm.sword.system.entity.umbral.statemachine.state.WieldState;
 import btm.sword.system.input.ActivationContext;
 import btm.sword.system.item.KeyRegistry;
 import btm.sword.utility.Prefab;

--- a/src/main/java/btm/sword/system/entity/umbral/UmbralBlade.java
+++ b/src/main/java/btm/sword/system/entity/umbral/UmbralBlade.java
@@ -481,7 +481,7 @@ public class UmbralBlade extends ThrownItem {
 
     @Override
     protected void rotate() {
-
+        // no-op
     }
 
     @Override

--- a/src/main/java/btm/sword/system/entity/umbral/statemachine/state/LodgedState.java
+++ b/src/main/java/btm/sword/system/entity/umbral/statemachine/state/LodgedState.java
@@ -1,13 +1,10 @@
 package btm.sword.system.entity.umbral.statemachine.state;
 
-import org.bukkit.entity.LivingEntity;
 
 import btm.sword.config.Config;
-import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.umbral.UmbralBlade;
 import btm.sword.system.entity.umbral.statemachine.UmbralStateFacade;
-import btm.sword.utility.display.DisplayUtil;
 
 /**
  * State where the UmbralBlade is lodged in an entity or block.

--- a/src/main/java/btm/sword/system/entity/umbral/statemachine/state/LodgedState.java
+++ b/src/main/java/btm/sword/system/entity/umbral/statemachine/state/LodgedState.java
@@ -42,7 +42,6 @@ import btm.sword.utility.display.DisplayUtil;
  *
  */
 public class LodgedState extends UmbralStateFacade {
-    private TimeArbiter.TaskHandle followTask;
 
     @Override
     public String name() {
@@ -55,27 +54,27 @@ public class LodgedState extends UmbralStateFacade {
         blade.getDisplay().setGlowColorOverride(Config.SwordColor.UMBRAL_GLOW);
 
         SwordEntity target = blade.getHitEntity();
-        if (target != null) {
-            LivingEntity le = target.self();
-            double heightOffset = Math.max(0, Math.min(blade.getCur().getY() - le.getLocation().getY(), le.getHeight()));
-            boolean followHead = !Config.Combat.IMPALEMENT_HEAD_FOLLOW_EXCEPTIONS.contains(target.type())
-                && heightOffset >= (le.getEyeLocation().getY() - le.getLocation().getY()) * Config.Combat.IMPALEMENT_HEAD_ZONE_RATIO;
 
-            followTask = DisplayUtil.itemDisplayFollow(
-                target, blade.getDisplay(),
-                blade.getVelocity().clone().normalize(),
-                heightOffset, followHead,
-                null, null, null, null
-            );
-        }
+        blade.startImpalementTask(target);
+//        if (target != null) {
+//            LivingEntity le = target.self();
+//            double heightOffset = Math.max(0, Math.min(blade.getCur().getY() - le.getLocation().getY(), le.getHeight()));
+//            boolean followHead = !Config.Combat.IMPALEMENT_HEAD_FOLLOW_EXCEPTIONS.contains(target.type())
+//                && heightOffset >= (le.getEyeLocation().getY() - le.getLocation().getY()) * Config.Combat.IMPALEMENT_HEAD_ZONE_RATIO;
+//
+//            followTask = DisplayUtil.itemDisplayFollow(
+//                target, blade.getDisplay(),
+//                blade.getVelocity().clone().normalize(),
+//                heightOffset, followHead,
+//                null, null, null, null
+//            );
+//        }
     }
 
     @Override
     public void onExit(UmbralBlade blade) {
         blade.getDisplay().setGlowing(false);
         blade.resetFlightState();
-        if (followTask != null && !followTask.isCancelled()) followTask.cancel();
-        followTask = null;
     }
 
     @Override

--- a/src/main/java/btm/sword/system/input/InputRegistrar.java
+++ b/src/main/java/btm/sword/system/input/InputRegistrar.java
@@ -229,7 +229,7 @@ public class InputRegistrar {
                 () -> InputAction.builder()
                 .action(UmbralBladeAction::wield)
                 .cooldown(executor -> 400)
-                .canCast(Combatant::canPerformAction)
+                .canCast(Combatant::canPerformWieldAction)
                 .displayCooldown(true)
                 .displayDisabled(true)
                 .resetIfCannotPerform(true)


### PR DESCRIPTION
## Summary
- Refactored item retrieval logic across grab and movement actions to improve clarity and consistency
- Fixed state transition issues in UmbralBlade state machine
- Improved umbral blade impalement logic

## Changes
- Consolidate item retrieval logic in `InteractiveItemArbiter`
- Clean up `ThrownItem` and `Combatant` method ownership
- Fix `LodgedState` transition issues
- Update input registrar references

Closes #147