### PR TITLE
feat: Block & Parry system (#177, #203)

### DIFF
--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -1109,6 +1109,48 @@ public class Config {
         public static float HIT_PUNCH_SOULFIRE_LOSS = 5f;
         static { register("combat.hit_punch_soulfire_loss", HIT_PUNCH_SOULFIRE_LOSS,
             Float.class, v -> HIT_PUNCH_SOULFIRE_LOSS = v, Config::loadFloat); }
+
+        // Block & parry configuration
+        public static float BLOCK_SOULFIRE_DRAIN_PER_SECOND = 2.5f;
+        static { register("combat.block_soulfire_drain_per_second", BLOCK_SOULFIRE_DRAIN_PER_SECOND,
+            Float.class, v -> BLOCK_SOULFIRE_DRAIN_PER_SECOND = v, Config::loadFloat); }
+
+        public static float BLOCK_SOULFIRE_COST_ON_HIT = 20.0f;
+        static { register("combat.block_soulfire_cost_on_hit", BLOCK_SOULFIRE_COST_ON_HIT,
+            Float.class, v -> BLOCK_SOULFIRE_COST_ON_HIT = v, Config::loadFloat); }
+
+        public static int BLOCK_BREAK_STAGGER_MS = 1000;
+        static { register("combat.block_break_stagger_ms", BLOCK_BREAK_STAGGER_MS,
+            Integer.class, v -> BLOCK_BREAK_STAGGER_MS = v, ConfigurationSection::getInt); }
+
+        public static int PARRY_AVAILABLE_MS = 400;
+        static { register("combat.parry_available_ms", PARRY_AVAILABLE_MS,
+            Integer.class, v -> PARRY_AVAILABLE_MS = v, ConfigurationSection::getInt); }
+
+        public static int PARRY_WINDOW_MS = 200;
+        static { register("combat.parry_window_ms", PARRY_WINDOW_MS,
+            Integer.class, v -> PARRY_WINDOW_MS = v, ConfigurationSection::getInt); }
+
+        public static float PARRY_SOULFIRE_GAIN = 25.0f;
+        static { register("combat.parry_soulfire_gain", PARRY_SOULFIRE_GAIN,
+            Float.class, v -> PARRY_SOULFIRE_GAIN = v, Config::loadFloat); }
+
+        public static int PARRY_STAGGER_MS = 1000;
+        static { register("combat.parry_stagger_ms", PARRY_STAGGER_MS,
+            Integer.class, v -> PARRY_STAGGER_MS = v, ConfigurationSection::getInt); }
+
+        /** Ticks the shield is put on cooldown after a successful parry (prevents re-raising immediately). */
+        public static int PARRY_SHIELD_COOLDOWN_TICKS = 25;
+        static { register("combat.parry_shield_cooldown_ticks", PARRY_SHIELD_COOLDOWN_TICKS,
+            Integer.class, v -> PARRY_SHIELD_COOLDOWN_TICKS = v, ConfigurationSection::getInt); }
+
+        public static int EXHAUSTED_BLOCKING_COOLDOWN_TICKS = 30;
+        static { register("combat.exhausted_blocking_cooldown_ticks", EXHAUSTED_BLOCKING_COOLDOWN_TICKS,
+            Integer.class, v -> EXHAUSTED_BLOCKING_COOLDOWN_TICKS = v, ConfigurationSection::getInt); }
+
+        public static float SHIELD_PASSING_BYPASS_POWER = 0.5f;
+        static { register("combat.shield_passing_bypass_power", SHIELD_PASSING_BYPASS_POWER,
+            Float.class, v -> SHIELD_PASSING_BYPASS_POWER = v, Config::loadFloat); }
     }
     //endregion
 

--- a/src/main/java/btm/sword/listeners/InputListener.java
+++ b/src/main/java/btm/sword/listeners/InputListener.java
@@ -122,6 +122,10 @@ public class InputListener implements Listener {
                 return;
             }
 
+            if (swordPlayer.isUnableToBlock()){
+                swordPlayer.displayDisablingEffect();
+                return;
+            }
             swordPlayer.act(InputType.RIGHT);
         }
     }
@@ -156,6 +160,11 @@ public class InputListener implements Listener {
         SwordScheduler.runConsumerNextTick(resetInteractingFlag, swordPlayer);
 
         if (!swordPlayer.getInputBuffer().accept(InputType.RIGHT)) return;
+
+        if (swordPlayer.isUnableToBlock()){
+            swordPlayer.displayDisablingEffect();
+            return;
+        }
 
         swordPlayer.act(InputType.RIGHT);
     }

--- a/src/main/java/btm/sword/listeners/PlayerListener.java
+++ b/src/main/java/btm/sword/listeners/PlayerListener.java
@@ -303,7 +303,7 @@ public class PlayerListener implements Listener {
      */
     @EventHandler
     public void playerShieldBreakEvent(PlayerShieldDisableEvent event) {
-        event.setCancelled(true);
+//        event.setCancelled(true);
     }
 
     @EventHandler

--- a/src/main/java/btm/sword/system/action/BlockAction.java
+++ b/src/main/java/btm/sword/system/action/BlockAction.java
@@ -1,0 +1,196 @@
+package btm.sword.system.action;
+
+import org.bukkit.util.Vector;
+
+import btm.sword.config.Config;
+import btm.sword.system.attack.Blockability;
+import btm.sword.system.attack.HitValuePacket;
+import btm.sword.system.entity.base.SwordEntity;
+import btm.sword.system.entity.impl.Combatant;
+import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.utility.sound.SoundType;
+import btm.sword.utility.sound.SoundUtil;
+
+/**
+ * Handles block and parry resolution for defending {@link SwordPlayer} combatants.
+ * <p>
+ * Called from {@link SwordEntity#hit} when the defender is blocking. Determines whether
+ * the incoming hit is negated (block), perfectly countered (parry), or reduced
+ * (shield-passing), then applies the appropriate stat changes and feedback.
+ * </p>
+ *
+ * <h2>Block flow</h2>
+ * <ol>
+ *   <li>RIGHT pressed → {@link #startBlock} sets blocking and starts soulfire drain</li>
+ *   <li>SWAP pressed within the trie timeout ({@link Config.Combat#PARRY_AVAILABLE_MS}) → {@link #parryAttempt}
+ *       ends the block, opens hit-detection window, and puts the shield on cooldown</li>
+ *   <li>Incoming hit during parry window → {@link #resolveBlock} applies parry or block result</li>
+ * </ol>
+ */
+public final class BlockAction {
+
+    private BlockAction() {}
+
+    /** Result of a block resolution attempt. */
+    public enum BlockResult {
+        /** Hit was fully negated — defender blocked in time, attack was BLOCKABLE. */
+        BLOCKED,
+        /** Hit was parried — defender was in the parry window, attack was BLOCKABLE. */
+        PARRIED,
+        /** Hit bypassed the shield — attack is SHIELD_PASSING; caller applies scaled damage. */
+        SHIELD_PASSED,
+        /** Block did not apply (non-frontal hit, or no applicable blockability). */
+        NOT_BLOCKED
+    }
+
+    /**
+     * Resolves an incoming hit against a blocking defender.
+     * <p>
+     * Checks frontal alignment first. BLOCKABLE hits are either parried (if parry window is
+     * active) or blocked. SHIELD_PASSING hits always return {@link BlockResult#SHIELD_PASSED}
+     * so the caller can apply scaled damage.
+     * </p>
+     *
+     * @param source   the attacking combatant
+     * @param defender the blocking player
+     * @param packet   the incoming hit packet
+     * @return the block resolution result
+     */
+    public static BlockResult resolveBlock(Combatant source, SwordPlayer defender, HitValuePacket packet) {
+        if (!isFrontalHit(source, defender)) {
+            return BlockResult.NOT_BLOCKED;
+        }
+
+        if (packet.blockability() == Blockability.BLOCKABLE) {
+            if (defender.isInParryWindow()) {
+                applyParrySuccess(defender, source);
+                return BlockResult.PARRIED;
+            } else {
+                applyBlockSuccess(defender);
+                return BlockResult.BLOCKED;
+            }
+        } else if (packet.blockability() == Blockability.SHIELD_PASSING) {
+            return BlockResult.SHIELD_PASSED;
+        }
+
+        return BlockResult.NOT_BLOCKED;
+    }
+
+    /**
+     * Begins a block for the given player. Sets blocking state, marks the parry-available
+     * end timestamp, and starts the soulfire drain ticker.
+     * <p>
+     * Called by the {@code RIGHT} trie node action in {@code InputRegistrar} when the
+     * player has a shield in their offhand and is in a normal action state.
+     * </p>
+     *
+     * @param player the player beginning to block
+     */
+    public static void startBlock(SwordPlayer player) {
+        player.setBlocking(true);
+        player.startBlockDrain();
+    }
+
+    /**
+     * Executes a parry attempt: opens the hit-detection window, ends the sustained block,
+     * and puts the shield on cooldown so the player cannot re-raise it immediately.
+     * <p>
+     * Called by the {@code RIGHT → SWAP} trie path while the parry window (trie timeout)
+     * is still open. Soulfire drain self-cancels because blocking is set to false.
+     * </p>
+     *
+     * @param player the blocking player who triggered the parry
+     */
+    public static void parryAttempt(SwordPlayer player) {
+        player.setParryWindowEnd(System.currentTimeMillis() + Config.Combat.PARRY_WINDOW_MS);
+        player.setBlocking(false);
+        player.disableShield(Config.Combat.PARRY_SHIELD_COOLDOWN_TICKS);
+        SoundUtil.playSound(player.self(), SoundType.ITEM_SHIELD_BLOCK, 1.0f, 1.5f);
+    }
+
+    /**
+     * Returns a {@link Vector} with shard, toughness, and soulfire values scaled by
+     * the packet's {@link HitValuePacket#bypassPower()}, for use when applying shield-passing damage.
+     * <p>
+     * Convenience used by {@link SwordEntity#hit} to avoid duplicating math.
+     * </p>
+     *
+     * @param packet the original hit packet
+     * @return a new HitValuePacket with damage values multiplied by bypassPower
+     */
+    public static HitValuePacket applyBypassScale(HitValuePacket packet) {
+        return new HitValuePacket(
+            () -> 0f,
+            packet::invulnerableTicks,
+            () -> Math.max(1, (int) (packet.shardDamage() * packet.bypassPower())),
+            () -> packet.toughnessDamage() * packet.bypassPower(),
+            () -> packet.soulfireLoss() * packet.bypassPower(),
+            Blockability.SHIELD_PASSING,
+            packet::bypassPower
+        );
+    }
+
+    /**
+     * Applies feedback for a successful block (non-parry): drains soulfire and plays
+     * the block sound.
+     *
+     * @param defender the player who blocked
+     */
+    private static void applyBlockSuccess(SwordPlayer defender) {
+        defender.getAspects().soulfire().remove(Config.Combat.BLOCK_SOULFIRE_COST_ON_HIT);
+        SoundUtil.playSound(defender.self(), SoundType.ITEM_SHIELD_BLOCK,
+            1.0f, 0.9f);
+
+        if (defender.getAspects().soulfire().cur() <= 0) {
+            onBlockBroken(defender);
+        }
+    }
+
+    /**
+     * Applies feedback for a successful parry: grants soulfire to the defender and
+     * locks the attacker with a cast-duration stagger.
+     *
+     * @param defender the player who parried
+     * @param attacker the combatant whose hit was parried
+     */
+    private static void applyParrySuccess(SwordPlayer defender, Combatant attacker) {
+        defender.getAspects().soulfire().add(Config.Combat.PARRY_SOULFIRE_GAIN);
+        SoundUtil.playSound(defender.self(), SoundType.ITEM_SHIELD_BLOCK,
+            1.5f, 2.0f);
+        ActionCaster.cast(attacker, Config.Combat.PARRY_STAGGER_MS, () -> {});
+    }
+
+    /**
+     * Returns true if the incoming attack originates from within the defender's frontal arc
+     * (within 45° to either side of the direction they are facing).
+     *
+     * @param source   the attacker
+     * @param defender the blocking player
+     * @return true if the hit is frontal
+     */
+    private static boolean isFrontalHit(Combatant source, SwordPlayer defender) {
+        Vector toAttacker = source.getLocation().toVector()
+            .subtract(defender.getLocation().toVector())
+            .setY(0);
+        if (toAttacker.lengthSquared() < 1e-6) return true;
+        toAttacker.normalize();
+        Vector facing = defender.getFlatDir();
+        // dot > cos(135°) means attacker is within the frontal 270° arc (45° behind cutoff)
+        return facing.dot(toAttacker) > Math.cos(Math.toRadians(135));
+    }
+
+    /**
+     * Forcibly breaks the block when the defender's soulfire hits zero while blocking.
+     * Clears block state and applies a stagger (cast-duration lock) to the defender.
+     *
+     * @param player the player whose block was broken
+     */
+    public static void onBlockBroken(SwordPlayer player) {
+        player.disableShield(Config.Combat.EXHAUSTED_BLOCKING_COOLDOWN_TICKS);
+        player.setBlocking(false);
+        player.cancelBlockDrainTask();
+        SoundUtil.playSound(player.self(), SoundType.ITEM_SHIELD_BREAK,
+            1.0f, 0.8f);
+        ActionCaster.cast(player, Config.Combat.BLOCK_BREAK_STAGGER_MS, () -> {});
+    }
+}

--- a/src/main/java/btm/sword/system/action/constraint/CommonConstraints.java
+++ b/src/main/java/btm/sword/system/action/constraint/CommonConstraints.java
@@ -3,6 +3,7 @@ package btm.sword.system.action.constraint;
 import org.bukkit.Material;
 
 import btm.sword.system.entity.impl.Combatant;
+import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.entity.umbral.statemachine.state.LodgedState;
 import btm.sword.system.entity.umbral.statemachine.state.RecallingState;
 import btm.sword.system.entity.umbral.statemachine.state.SheathedState;
@@ -84,4 +85,11 @@ public final class CommonConstraints {
         c -> c.getAbilityCastTask() == null && !c.isGrabbing() && !c.isGrabbed()
             && c.getUmbralBlade() != null
             && c.getUmbralBlade().inState(LodgedState.class);
+
+    /**
+     * Passes when the combatant is not currently blocking (holding shield up).
+     * For non-player combatants (which cannot block), this always passes.
+     */
+    public static final ActionConstraint NOT_BLOCKING =
+        c -> !(c instanceof SwordPlayer sp) || !sp.isBlocking();
 }

--- a/src/main/java/btm/sword/system/action/movement/Dash.java
+++ b/src/main/java/btm/sword/system/action/movement/Dash.java
@@ -149,7 +149,7 @@ public class Dash {
 
         double length = itemDisplay.getLocation().subtract(ex.getEyeLocation()).length();
 
-        if (flatDash && !umbral) {
+        if (flatDash && !umbral && direction > 0) {
             performFlatDashToItemFromGround(length);
         }
         else {

--- a/src/main/java/btm/sword/system/attack/Blockability.java
+++ b/src/main/java/btm/sword/system/attack/Blockability.java
@@ -1,0 +1,19 @@
+package btm.sword.system.attack;
+
+/**
+ * Classifies how an attack interacts with a blocking defender.
+ * <p>
+ * Assigned on every {@link HitValuePacket} to control block and parry resolution
+ * in {@link btm.sword.system.entity.base.SwordEntity#hit}.
+ * </p>
+ */
+public enum Blockability {
+    /** Attack is fully negated by a block or parry. */
+    BLOCKABLE,
+
+    /**
+     * Attack partially bypasses the shield. Damage is scaled by
+     * {@link HitValuePacket#bypassPower()} regardless of parry window.
+     */
+    SHIELD_PASSING
+}

--- a/src/main/java/btm/sword/system/attack/HitValuePacket.java
+++ b/src/main/java/btm/sword/system/attack/HitValuePacket.java
@@ -2,43 +2,111 @@ package btm.sword.system.attack;
 
 import java.util.function.Supplier;
 
+/**
+ * Encapsulates all damage-related values for a single hit, using suppliers so that
+ * hot-reloaded config values are always read fresh at hit time.
+ * <p>
+ * {@link #blockability} controls how this hit interacts with a blocking defender.
+ * For {@link Blockability#SHIELD_PASSING} hits, {@link #bypassPower()} (0–1) is
+ * applied as a damage multiplier — 1.0 means full damage passes through, 0.5 means
+ * half.
+ * </p>
+ */
 public class HitValuePacket {
     private final Supplier<Float> reapedSoulfire;
     private final Supplier<Integer> invulnerableTicks;
     private final Supplier<Integer> shardDamage;
     private final Supplier<Float> toughnessDamage;
     private final Supplier<Float> soulfireLoss;
+    private final Blockability blockability;
+    private final Supplier<Float> bypassPower;
 
+    /**
+     * Full constructor with explicit blockability classification.
+     *
+     * @param reapedSoulfire    soulfire transferred from defender to attacker on hit
+     * @param invulnerableTicks invulnerability frames granted after the hit
+     * @param shardDamage       raw shard (HP) damage
+     * @param toughnessDamage   raw toughness damage
+     * @param soulfireLoss      soulfire drained from the defender
+     * @param blockability      how the hit interacts with a blocking defender
+     * @param bypassPower       fraction of damage that passes through for SHIELD_PASSING (0–1);
+     *                          evaluated fresh on each hit so config hot-reload takes effect
+     */
+    public HitValuePacket(
+        Supplier<Float> reapedSoulfire,
+        Supplier<Integer> invulnerableTicks,
+        Supplier<Integer> shardDamage,
+        Supplier<Float> toughnessDamage,
+        Supplier<Float> soulfireLoss,
+        Blockability blockability,
+        Supplier<Float> bypassPower) {
+        this.reapedSoulfire = reapedSoulfire;
+        this.invulnerableTicks = invulnerableTicks;
+        this.shardDamage = shardDamage;
+        this.toughnessDamage = toughnessDamage;
+        this.soulfireLoss = soulfireLoss;
+        this.blockability = blockability;
+        this.bypassPower = bypassPower;
+    }
+
+    /**
+     * Convenience constructor that defaults to {@link Blockability#BLOCKABLE} with no bypass power.
+     *
+     * @param reapedSoulfire   soulfire transferred from defender to attacker on hit
+     * @param invulnerableTicks invulnerability frames granted after the hit
+     * @param shardDamage      raw shard (HP) damage
+     * @param toughnessDamage  raw toughness damage
+     * @param soulfireLoss     soulfire drained from the defender
+     */
     public HitValuePacket(
         Supplier<Float> reapedSoulfire,
         Supplier<Integer> invulnerableTicks,
         Supplier<Integer> shardDamage,
         Supplier<Float> toughnessDamage,
         Supplier<Float> soulfireLoss) {
-        this.reapedSoulfire = reapedSoulfire;
-        this.invulnerableTicks = invulnerableTicks;
-        this.shardDamage = shardDamage;
-        this.toughnessDamage = toughnessDamage;
-        this.soulfireLoss = soulfireLoss;
+        this(reapedSoulfire, invulnerableTicks, shardDamage, toughnessDamage, soulfireLoss,
+            Blockability.BLOCKABLE, () -> 0f);
     }
 
+    /** @return soulfire transferred from defender to attacker on hit */
     public float reapedSoulfire() {
         return reapedSoulfire.get();
     }
 
+    /** @return invulnerability frames granted after the hit */
     public int invulnerableTicks() {
         return invulnerableTicks.get();
     }
 
+    /** @return raw shard (HP) damage */
     public int shardDamage() {
         return shardDamage.get();
     }
 
+    /** @return raw toughness damage */
     public float toughnessDamage() {
         return toughnessDamage.get();
     }
 
+    /** @return soulfire drained from the defender */
     public float soulfireLoss() {
         return soulfireLoss.get();
+    }
+
+    /** @return how this hit interacts with a blocking defender */
+    public Blockability blockability() {
+        return blockability;
+    }
+
+    /**
+     * Fraction of damage that passes through a shield for {@link Blockability#SHIELD_PASSING} hits.
+     * Range 0–1: 1.0 = full damage, 0.0 = no damage.
+     * Evaluated fresh each call so config hot-reload takes effect.
+     *
+     * @return bypass power fraction
+     */
+    public float bypassPower() {
+        return bypassPower.get();
     }
 }

--- a/src/main/java/btm/sword/system/entity/base/SwordEntity.java
+++ b/src/main/java/btm/sword/system/entity/base/SwordEntity.java
@@ -32,6 +32,7 @@ import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 
 import btm.sword.Sword;
 import btm.sword.config.Config;
+import btm.sword.system.action.BlockAction;
 import btm.sword.system.action.throwing.impale.Impalement;
 import btm.sword.system.action.throwing.types.DroppedItem;
 import btm.sword.system.attack.HitValuePacket;
@@ -43,6 +44,7 @@ import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.aspect.AspectType;
 import btm.sword.system.entity.impl.Combatant;
+import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.utility.Debug;
 import btm.sword.utility.Prefab;
 import btm.sword.utility.SwordTimeUnit;
@@ -533,7 +535,36 @@ public abstract class SwordEntity {
         }
     }
 
+    /**
+     * Returns true if a parry hit-detection window is currently active on this entity.
+     * Overridden in {@link SwordPlayer} to check the real parry window timestamp.
+     *
+     * @return true if an incoming BLOCKABLE hit will be parried
+     */
+    public boolean isInParryWindow() {
+        return false;
+    }
+
     public void hit(Combatant source, HitValuePacket v, Vector knockbackVelocity, Affliction... afflictions) {
+        if (this instanceof SwordPlayer defender && defender.isBlocking()) {
+            BlockAction.BlockResult result = BlockAction.resolveBlock(source, defender, v);
+            switch (result) {
+                case BLOCKED, PARRIED -> { return; }
+                case SHIELD_PASSED -> {
+                    HitValuePacket scaled = BlockAction.applyBypassScale(v);
+                    hit(source,
+                        scaled.reapedSoulfire(),
+                        scaled.invulnerableTicks(),
+                        scaled.shardDamage(),
+                        scaled.toughnessDamage(),
+                        scaled.soulfireLoss(),
+                        knockbackVelocity,
+                        afflictions);
+                    return;
+                }
+                default -> { /* NOT_BLOCKED: fall through to normal hit */ }
+            }
+        }
         hit(source,
             v.reapedSoulfire(),
             v.invulnerableTicks(),

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -34,6 +34,7 @@ import org.joml.Vector3f;
 import com.destroystokyo.paper.profile.PlayerProfile;
 
 import btm.sword.config.Config;
+import btm.sword.system.action.BlockAction;
 import btm.sword.system.action.throwing.ThrowAction;
 import btm.sword.system.control.PredicateRunnablePair;
 import btm.sword.system.control.SwordScheduler;
@@ -58,6 +59,7 @@ import btm.sword.system.item.SwordItemType;
 import btm.sword.system.item.special.NonMovableItem;
 import btm.sword.system.item.special.SlotAnchoredItem;
 import btm.sword.system.playerdata.PlayerData;
+import btm.sword.utility.Prefab;
 import btm.sword.utility.SwordTimeUnit;
 import btm.sword.utility.display.DisplayUtil;
 import lombok.Getter;
@@ -114,6 +116,12 @@ public class SwordPlayer extends Combatant {
     private boolean threwItem;
     @Setter
     private boolean blocking;
+
+    /** System.currentTimeMillis() deadline for the active parry hit-detection window. */
+    @Setter
+    private long parryWindowEnd = 0L;
+
+    private TimeArbiter.TaskHandle blockDrainTask;
 
     private TimeArbiter.TaskHandle rightClickHoldTask;
     private boolean holdingRight;
@@ -266,6 +274,57 @@ public class SwordPlayer extends Combatant {
         endStatusDisplay();
         endIndicatorDisplay();
         destroyed = true;
+    }
+
+    /**
+     * Returns true if the parry hit-detection window is active (an incoming
+     * BLOCKABLE hit within this window will be parried).
+     *
+     * @return true if the parry window is active
+     */
+    @Override
+    public boolean isInParryWindow() {
+        return System.currentTimeMillis() < parryWindowEnd;
+    }
+
+    /**
+     * Cancels the active soulfire block drain task, if any.
+     */
+    public void cancelBlockDrainTask() {
+        if (blockDrainTask != null && !blockDrainTask.isCancelled()) {
+            blockDrainTask.cancel();
+            blockDrainTask = null;
+        }
+    }
+
+    /**
+     * Starts the repeating soulfire drain ticker while blocking.
+     * Drains {@link Config.Combat#BLOCK_SOULFIRE_DRAIN_PER_SECOND} per second.
+     * Breaks the block automatically if soulfire hits zero. Called from
+     * {@link btm.sword.system.action.BlockAction#startBlock}.
+     */
+    public void startBlockDrain() {
+        cancelBlockDrainTask();
+        // Tick every 200ms (5 times/sec); each tick drains 1/5 of the per-second cost.
+        int periodMs = 200;
+        blockDrainTask = TimeArbiter.runTimeIndependentBukkitTaskOnTimer(
+            null,
+            () -> {
+                if (!isBlocking()) return;
+                Prefab.Particles.UMBRAL_FLAME.display(getChestLocation().add(dir()));
+                float drainPerTick = Config.Combat.BLOCK_SOULFIRE_DRAIN_PER_SECOND / (1000f / periodMs);
+                aspects.soulfire().remove(drainPerTick);
+                if (aspects.soulfire().cur() <= 0) {
+                    BlockAction.onBlockBroken(this);
+                }
+            },
+            periodMs, periodMs,
+            SwordPlayer.class, "startBlockDrain",
+            new PredicateRunnablePair(
+                () -> !isBlocking(),
+                this::cancelBlockDrainTask
+            )
+        );
     }
 
     /**
@@ -486,6 +545,15 @@ public class SwordPlayer extends Combatant {
      */
     public boolean hasPerformedDropAction() {
         return performedDropAction;
+    }
+
+    public void disableShield(int ticks) {
+        self.clearActiveItem();
+        player.setCooldown(getItemStackInHand(false), ticks);
+    }
+
+    public boolean isUnableToBlock() {
+        return player.getCooldown(getItemStackInHand(false)) > 0;
     }
 
     @Override
@@ -802,9 +870,6 @@ public class SwordPlayer extends Combatant {
         mainItemStackAtTimeOfHold = getItemStackInHand(true);
         offItemStackAtTimeOfHold = getItemStackInHand(false);
 
-        if (offItemStackAtTimeOfHold.getType().equals(Material.SHIELD)) {
-            setBlocking(true);
-        }
         indexOfRightHold = getCurrentInvIndex();
 
         if (!holdingUmbralItemInMainHand()) {
@@ -819,7 +884,9 @@ public class SwordPlayer extends Combatant {
 
         rightClickHoldTask = TimeArbiter.runTimeIndependentBukkitTaskOnTimer(
             () -> {
-                inputExecutionTree.restartTimeoutTimer();
+                // While blocking, let the trie timeout expire naturally — that closes the parry window.
+                // For all other right-hold scenarios (throw ready, etc.) keep the timer alive.
+                if (!isBlocking()) inputExecutionTree.restartTimeoutTimer();
                 // player must ALWAYS be holding a shield in offhand, then... I can work with this though
                 if (!player.isHandRaised() && !player.isBlocking()) {
                     endHoldingRight();
@@ -850,6 +917,7 @@ public class SwordPlayer extends Combatant {
         rightHoldTimeStart = 0L;
         timeRightHeld = 0L;
         setBlocking(false);
+        cancelBlockDrainTask();
     }
 
     /**
@@ -859,6 +927,7 @@ public class SwordPlayer extends Combatant {
         holdingRight = false;
         timeRightHeld = System.currentTimeMillis() - rightHoldTimeStart;
         setBlocking(false);
+        cancelBlockDrainTask();
         setItemStackInHand(offItemStackAtTimeOfHold, false);
         if (!mainItemStackAtTimeOfHold.isEmpty() && !threwItem && !holdingUmbralItemInMainHand())
             setItemAtIndex(mainItemStackAtTimeOfHold, indexOfRightHold);

--- a/src/main/java/btm/sword/system/entity/umbral/statemachine/UmbralStateMachine.java
+++ b/src/main/java/btm/sword/system/entity/umbral/statemachine/UmbralStateMachine.java
@@ -227,7 +227,7 @@ public class UmbralStateMachine extends StateMachine<UmbralBlade> {
             b -> {
                 Vector kb = VectorUtil.getProjOntoPlane(b.getVelocity(), Config.Direction.UP())
                     .multiply(Config.Combat.THROWN_DAMAGE_SWORD_AXE_KNOCKBACK_AIRBORNE);
-                b.getHitEntity().hit(b.getThrower(), Prefab.Attacks.thrownWeapon, kb);
+                b.getHitEntity().hit(b.getThrower(), Prefab.Attacks.umbralImpale, kb);
             }
         ));
 
@@ -345,7 +345,7 @@ public class UmbralStateMachine extends StateMachine<UmbralBlade> {
             b -> {
                 Vector kb = VectorUtil.getProjOntoPlane(b.getVelocity(), Config.Direction.UP())
                     .multiply(Config.Combat.THROWN_DAMAGE_SWORD_AXE_KNOCKBACK_AIRBORNE);
-                b.getHitEntity().hit(b.getThrower(), Prefab.Attacks.thrownWeapon, kb);
+                b.getHitEntity().hit(b.getThrower(), Prefab.Attacks.umbralImpale, kb);
             }
         ));
 

--- a/src/main/java/btm/sword/system/input/InputRegistrar.java
+++ b/src/main/java/btm/sword/system/input/InputRegistrar.java
@@ -6,7 +6,10 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.bukkit.Material;
+
 import btm.sword.config.Config;
+import btm.sword.system.action.BlockAction;
 import btm.sword.system.action.UmbralBladeAction;
 import btm.sword.system.action.attack.AttackAction;
 import btm.sword.system.action.attack.DashAttackAction;
@@ -20,6 +23,7 @@ import btm.sword.system.action.utility.UtilityAction;
 import btm.sword.system.entity.aspect.AspectType;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.utility.SwordTimeUnit;
 
 /**
  * Registers all input sequences into an {@link InputExecutionTree}.
@@ -28,6 +32,11 @@ import btm.sword.system.entity.impl.SwordPlayer;
  * {@link InputExecutionTree.ActionContextPair} rather than on {@link InputType}.
  * Shared nodes (e.g. DROP + RIGHT for lunge and throw) are populated in priority order —
  * the first registered action whose context passes is executed.
+ * </p>
+ * <p>
+ * Visibility predicates of sequential nodes are checked BEFORE the action
+ * of the current node is executed.
+ * Keep this in mind when developing sequential action systems.
  * </p>
  */
 public class InputRegistrar {
@@ -68,6 +77,51 @@ public class InputRegistrar {
                 SwordPlayer::normalActState)
             )))
             .timeoutTicks(20)
+            .cancellable(true)
+            .display(true)
+            .build();
+
+        // Block: RIGHT begins blocking (if shield in offhand). The node timeout is the parry window —
+        // while it is alive, SWAP can follow to trigger a parry. The hold task does NOT restart the
+        // timer while blocking, so the window closes naturally after PARRY_AVAILABLE_MS ticks.
+        // Registered before any other RIGHT-prefixed paths so the node exists with the correct timeout.
+        new InputExecutionTree.InputNodeBuilder(root, List.of(
+            InputType.RIGHT
+        )).action(new LinkedList<>(List.of(
+            new InputExecutionTree.ActionContextPair(
+                () -> InputAction.builder()
+                    .name("Block")
+                    .action(c -> BlockAction.startBlock((SwordPlayer) c))
+                    .cooldown(executor -> 0)
+                    .canCast(c -> true)
+                    .displayDisabled(false)
+                    .resetIfCannotPerform(false)
+                    .build(),
+                sp -> sp.normalActState() && sp.getItemStackInHand(false).getType() == Material.SHIELD)
+        )))
+            .timeoutTicks(SwordTimeUnit.millisToTicks(Config.Combat.PARRY_AVAILABLE_MS))
+            .cancellable(true)
+            .display(true)
+            .build();
+
+        // Parry: RIGHT → SWAP while the trie is still at the RIGHT node (within timeout).
+        // Context predicate confirms the Bukkit player is actively blocking. If the window
+        // has expired (trie reset) SWAP hits root instead → dash or skill.
+        new InputExecutionTree.InputNodeBuilder(root, List.of(
+            InputType.RIGHT,
+            InputType.SWAP
+        )).action(new LinkedList<>(List.of(
+            new InputExecutionTree.ActionContextPair(
+                () -> InputAction.builder()
+                .name("Parry")
+                .action(c -> BlockAction.parryAttempt((SwordPlayer) c))
+                .cooldown(executor -> 0)
+                .canCast(c -> true)
+                .displayDisabled(false)
+                .resetIfCannotPerform(false)
+                .build(),
+                sp -> true)
+            )))
             .cancellable(true)
             .display(true)
             .build();

--- a/src/main/java/btm/sword/system/input/README.md
+++ b/src/main/java/btm/sword/system/input/README.md
@@ -126,6 +126,10 @@ root (InputNode, action = null)
 
 `SwordPlayer.act()` calls `step()` and then, on a non-null result, calls `InputActionExecutor.execute()` on the resolved action.
 
+### Important Development Note
+Visibility predicates of sequential nodes are checked BEFORE the action of the current node is executed. Keep this in mind when developing sequential action systems.
+
+
 ### Timeout
 
 Each `InputNode` has a `timeoutTicks` field (default 20 ticks = 1 second). When a node with children is reached, a one-shot timer fires `reset()` after `timeoutTicks * 50 ms`. Starting a new input restarts the timer. The timeout enforces that players must complete a combo within the allotted window or the sequence resets.

--- a/src/main/java/btm/sword/utility/Prefab.java
+++ b/src/main/java/btm/sword/utility/Prefab.java
@@ -15,6 +15,7 @@ import org.bukkit.util.Vector;
 
 import btm.sword.config.Config;
 import btm.sword.system.attack.Attack;
+import btm.sword.system.attack.Blockability;
 import btm.sword.system.attack.HitValuePacket;
 import btm.sword.utility.display.ParticleWrapper;
 import btm.sword.utility.sound.SoundType;
@@ -64,8 +65,9 @@ public class Prefab {
         public static final ParticleWrapper UMBRAL_FLAME = new ParticleWrapper(Particle.DUST_COLOR_TRANSITION, 3, 0.05, 0.05, 0.05, 1,
             new Particle.DustTransition(Color.fromRGB(53, 166, 240), Color.fromRGB(52, 72, 81), 0.5f));
 
-        public static final ParticleWrapper THROW_TRAIl = new ParticleWrapper(Particle.DUST, 1, 0.2, 0.2, 0.2,
-                new Particle.DustOptions(Color.WHITE, 2.5f));
+        public static final ParticleWrapper THROW_TRAIl = new ParticleWrapper(Particle.CRIT, 2, 0.1, 0.1, 0.1, 0);
+//        public static final ParticleWrapper THROW_TRAIl = new ParticleWrapper(Particle.DUST, 1, 0.2, 0.2, 0.2,
+//                new Particle.DustOptions(Color.WHITE, 2.5f));
 
         public static final ParticleWrapper ITEM_THROW_BREAK = new ParticleWrapper(Particle.ENCHANTED_HIT, 150, 0.4, 0.4, 0.4);
 
@@ -145,6 +147,21 @@ public class Prefab {
             () -> Config.Combat.HIT_PUNCH_SHARD_DAMAGE,
             () -> Config.Combat.HIT_PUNCH_TOUGHNESS_DAMAGE,
             () -> Config.Combat.HIT_PUNCH_SOULFIRE_LOSS
+        );
+
+        /**
+         * Hit packet for UmbralBlade lunge and grab-impale hits.
+         * SHIELD_PASSING: reduces damage by {@link Config.Combat#SHIELD_PASSING_BYPASS_POWER}
+         * even against a blocking defender — these attacks pierce the guard.
+         */
+        public static final HitValuePacket umbralImpale = new HitValuePacket(
+            () -> 0f,
+            () -> Config.Combat.THROWN_DAMAGE_SWORD_AXE_INVULNERABILITY_TICKS,
+            () -> Config.Combat.THROWN_DAMAGE_SWORD_AXE_BASE_SHARDS,
+            () -> Config.Combat.THROWN_DAMAGE_SWORD_AXE_TOUGHNESS_DAMAGE,
+            () -> Config.Combat.THROWN_DAMAGE_SWORD_AXE_SOULFIRE_REDUCTION,
+            Blockability.SHIELD_PASSING,
+            () -> Config.Combat.SHIELD_PASSING_BYPASS_POWER
         );
     }
 

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -1,123 +1,123 @@
 color:
-  
+
   text_resource_color: '#DEDEDE'
-  
+
   text_aspect_color: '#009FFF'
-  
+
   title_input_string: '#970000'
-  
+
   text_item_name: '#006E97'
   text_cool: '#F0A10C'
   text_item_controls: '#AD6DFF'
   text_item_header: '#E1E1E1'
   text_item_base: '#787878'
   text_cool_dark: '#333C4B'
-  
+
   umbral_glow: '#FFFFFF'
   ferocious_sweep: '#FF0000'
 
 
 angle:
-  
+
   umbral_blade_idle_period: 0.3926991 # π/8
 
 
 physics:
-  
+
   thrown_items_gravity_damper: 46.0
   thrown_items_trajectory_rotation: 0.03696
-  
+
   thrown_items_display_offset_x: -0.5
   thrown_items_display_offset_y: 0.1
   thrown_items_display_offset_z: 0.5
-  
+
   thrown_items_origin_offset_forward: 0.5
   thrown_items_origin_offset_up: 0.1
   thrown_items_origin_offset_back: -0.25
-  
+
   thrown_items_rotation_speed_sword: 0.0
   thrown_items_rotation_speed_axe: -0.3926991 # -π/8
   thrown_items_rotation_speed_hoe: -0.3926991
   thrown_items_rotation_speed_pickaxe: -0.3926991
   thrown_items_rotation_speed_shovel: -0.3926991
   thrown_items_rotation_speed_shield: -0.3926991
-  
+
   thrown_items_rotation_speed_default_speed: 0.09817477 # π/32
-  
+
   attack_velocity_grounded_damping_horizontal: 0.3
   attack_velocity_grounded_damping_vertical: 0.4
-  
+
   attack_velocity_knockback_vertical_base: 0.25
   attack_velocity_knockback_horizontal_modifier: 0.1
   attack_velocity_knockback_normal_multiplier: 0.7
 
 
 combat:
-  
+
   shards_lost_percent_toughness_reset: 0.3
   toughness_recharge_percent: 0.75
-  
+
   attacks_base_damage: 20.0
-  
+
   attacks_down_air_threshold: -0.4
-  
+
   attacks_cast_timing_min_duration: 25
   attacks_cast_timing_max_duration: 200
   attacks_cast_timing_reduction_rate: 0.2
   attacks_cooldown_mult: 2.0
-  
-  
+
+
   attacks_duration_multiplier: 500
-  
+
   attacks_range_multipliers_basic_1: 1.4
   attacks_range_multipliers_basic_2: 1.4
   attacks_range_multipliers_basic_3: 1.4
   attacks_range_multipliers_neutral_air: 1.3
   attacks_range_multipliers_down_air: 1.2
-  
+
   sweep_attack_x_scale: 0.25
   sweep_attack_y_scale: 1
   sweep_attack_z_scale: 0.25
-  
+
   hitboxes_basic_reach: 1.5
   hitboxes_basic_width: 1.5
   hitboxes_basic_height: 1.5
-  
+
   hitboxes_down_air_reach: 1.6
   hitboxes_down_air_width: 1.4
   hitboxes_down_air_height: 2.5
-  
+
   hitboxes_secant_radius: 1.0
-  
+
   thrown_damage_sword_damage_multiplier: 1.0
   thrown_damage_item_velocity_multiplier: 1.5
   thrown_damage_base_thrown_damage: 12.0
-  
+
   thrown_damage_sword_axe_invulnerability_ticks: 0
   thrown_damage_sword_axe_base_shards: 2
   thrown_damage_sword_axe_toughness_damage: 75.0
   thrown_damage_sword_axe_soulfire_reduction: 50.0
   thrown_damage_sword_axe_knockback_grounded: 0.7
   thrown_damage_sword_axe_knockback_airborne: 1.0
-  
+
   thrown_damage_other_invulnerability_ticks: 0
   thrown_damage_other_base_shards: 2
   thrown_damage_other_toughness_damage: 75.0
   thrown_damage_other_soulfire_reduction: 50.0
   thrown_damage_other_knockback_multiplier: 0.7
   thrown_damage_other_explosion_power: 1.0
-  
+
   impalement_damage_per_tick: 2.0
   impalement_ticks_between_damage: 10
   impalement_max_impalements: 3
   impalement_head_zone_ratio: 0.8
-  
+
   impalement_head_follow_exceptions:
   - SPIDER
-  
+
   impalement_pin_max_iterations: 200
   impalement_pin_check_interval: 100
-  
+
   attack_class_exempt_from_combat:
   - ARMOR_STAND
   - ITEM_FRAME
@@ -127,94 +127,106 @@ combat:
   - BLOCK_DISPLAY
   - TEXT_DISPLAY
   - INTERACTION
-  
+
   attack_class_timing_attack_duration: 750
   attack_class_timing_attack_iterations: 50
   attack_class_timing_attack_start_value: 0.0
   attack_class_timing_attack_end_value: 1.0
-  
+
   attack_class_modifiers_range_multiplier: 1.0
-  
+
   attack_class_hit_invuln_ticks: 5
   attack_class_hit_shards: 1
   attack_class_hit_toughness: 15
   attack_class_hit_soulfire: 6
 
+  block_soulfire_drain_per_second: 5.0
+  block_soulfire_cost_on_hit: 20.0
+  block_break_stagger_ms: 1000
+
+  parry_available_ms: 400
+  parry_window_ms: 200
+  parry_soulfire_gain: 25.0
+  parry_stagger_ms: 1000
+  parry_shield_cooldown_ticks: 100
+
+  shield_passing_bypass_power: 0.5
+
 
 timing:
-  
+
   thrown_items_catch_grace_period: 3
-  
+
   thrown_items_disposal_timeout: 30000
   thrown_items_disposal_check_interval: 500
-  
+
   thrown_items_pin_delay: 2
   thrown_items_throw_completion_delay: 6
-  
+
   intervals_entity_tick: 1
   intervals_status_display_update: 5
   intervals_combat_cleanup: 20
-  
+
   attacks_combo_window_base: 3
 
 
 display:
-  
+
   default_teleport_duration: 2
-  
+
   status_display_enabled: true
   status_display_height_offset: 2.0
   status_display_update_interval: 5
   status_display_block_brightness: 15
   status_display_sky_brightness: 15
-  
+
   item_display_follow_update_interval: 100
   item_display_follow_particle_interval: 4
   item_display_follow_billboard_mode: FIXED
-  
+
   particles_enabled: true
   particles_density: 10
 
 
 detection:
-  
+
   ground_check_max_distance: 0.3
-  
+
   raytrace_max_distance: 50.0
   raytrace_step_size: 0.1
   raytrace_ignore_passable_blocks: true
-  
+
   throw_pin_ray_distance: 1.0
   throw_ground_check_multiplier: 0.1
   throw_hit_check_dist_multiplier: 0.6
   throw_hit_check_ray_size: 1.0
-  
+
   entity_detection_search_radius: 10.0
   entity_detection_include_spectators: false
 
 
 audio:
-  
+
   sounds_enabled: true
-  
+
   sounds_global_volume: 1.0
   sounds_global_pitch: 1.0
-  
+
   throw_sound: ENTITY_ENDER_DRAGON_FLAP
   throw_volume: 0.35
   throw_pitch: 0.4
-  
+
   attack_sound: ITEM_TRIDENT_THROW
   attack_volume: 0.6
   attack_pitch: 0.7
-  
+
   entity_hit_connect_volume: 0.9
   entity_hit_connect_pitch: 1.0
-  
+
   punch_attempt: ENTITY_PLAYER_ATTACK_SWEEP
   punch_attempt_vol: 1.5
   punch_attempt_pitch: 0.5
-  
+
   punch_connect: BLOCK_ENDER_CHEST_OPEN
   punch_connect_vol: 1.5
   punch_connect_pitch: 1.0
@@ -222,38 +234,38 @@ audio:
 
 
 entity:
-  
+
   player_base_health: 100.0
   player_base_toughness: 10.0
   player_base_soulfire: 100.0
-  
+
   hostile_health_multiplier: 1.0
   hostile_damage_multiplier: 1.0
-  
+
   combat_profile_max_air_dodges: 1
   combat_profile_shards_current: 5
   combat_profile_shards_regen_period: 5000
   combat_profile_shards_regen_amount: 1
-  
+
   combat_profile_toughness_current: 20.0
   combat_profile_toughness_regen_period: 1000
   combat_profile_toughness_regen_amount: 0.25
-  
+
   combat_profile_soulfire_current: 100.0
   combat_profile_soulfire_regen_period: 200
-  combat_profile_soulfire_regen_amount: 0.009999999776482582
-  
+  combat_profile_soulfire_regen_amount: 0.002
+
   combat_profile_form_current: 10.0
   combat_profile_form_regen_period: 60
   combat_profile_form_regen_amount: 1.0
-  
+
   hit_tough_break_recharge_amount_percent: 2.0
   hit_tough_break_recharge_period_percent: 0.2
   hit_tough_break_recharge_cutoff_percent: 0.6
 
 
 movement:
-  
+
   dash_max_distance: 12.0
   dash_flat_item_dash_scaler: 0.35
   speed_duration: 5
@@ -274,9 +286,9 @@ movement:
   dash_particle_task_period: 2
   dash_particle_timer_increment: 2
   dash_particle_timer_threshold: 4
-  
+
   dash_grab_check_delay: 200
-  
+
   dash_velocity_task_delay: 0
   dash_velocity_task_period: 1
   dash_particle_count: 100
@@ -287,7 +299,7 @@ movement:
   dash_flap_sound_pitch: 1.0
   dash_sweep_sound_volume: 0.3
   dash_sweep_sound_pitch: 0.6
-  
+
   toss_base_force: 1.5
   toss_might_multiplier_base: 2.5
   toss_might_multiplier_increment: 0.1
@@ -302,12 +314,12 @@ movement:
   toss_knockback_multiplier: 0.3
   toss_explosion_power: 2.0
   toss_hit_invulnerability_ticks: 3
-  
+
   toss_hit_shard_damage: 1
   toss_hit_toughness_damage: 10.0
-  
+
   toss_hit_soulfire_reduction: 5.0
-  
+
   grab_pull_strength: 0.8
   grab_max_range: 3.0
   grab_hold_duration: 40
@@ -315,51 +327,51 @@ movement:
 
 
 world:
-  
+
   block_interaction_allow_block_breaking: false
   block_interaction_respect_world_guard: true
-  
+
   explosions_set_fire: false
   explosions_break_blocks: false
 
 
 debug:
-  
+
   logging_verbose_combat: false
   logging_verbose_movement: false
-  
+
   logging_verbose_config: false
-  
+
   visualization_show_hitboxes: false
   visualization_show_raytraces: false
 
 
 grab:
-  
+
   case_duration: 12
   base_duration: 60
   base_range: 3.0
   base_thickness: 0.6
-  
+
   duration_scaling: 0.2
   range_scaling: 0.1
   thickness_scaling: 0.1
-  
+
   hold_distance: 2.0
   hold_buffer: 0.4
   pull_speed: 0.6
-  
+
   vertical_force_threshold: 1.2
   close_y_velocity_scale: 0.25
-  
+
   jump_boost_amplifier: 1
   jump_boost_duration: 2
-  
+
   executor_horizontal_dampening: 0.2
 
 
 hostile:
-  
+
   aggro_range: 16.0
   approach_distance: 6.0
   surround_min_allies: 2
@@ -369,7 +381,7 @@ hostile:
 
 
 umbral:
-  
+
   time_cutoff: 1.2
   time_scaling_factor: 9
   on_release: 3


### PR DESCRIPTION
## Summary
- Adds `Blockability` enum (`BLOCKABLE` / `SHIELD_PASSING`) on every `HitValuePacket`, classifying how attacks interact with a blocking defender
- Implements sustained block (RIGHT press with shield in offhand) with soulfire drain, and parry (RIGHT → SWAP within the trie timeout window) via the `InputExecutionTree`
- Parry disables the player's shield for a configurable cooldown (`parry_shield_cooldown_ticks`) and opens a short hit-detection window; block and parry both resolve in `SwordEntity.hit()` via the new `BlockAction` class

## Test plan
- [x] Hold RIGHT with shield in offhand → soulfire drains at ~5/sec
- [x] Hold RIGHT with no shield → no blocking, no drain (trie context fails, normal throw/hold behavior)
- [x] Press RIGHT then SWAP quickly → parry window opens; shield goes on cooldown; player cannot re-raise shield immediately
- [x] Press SWAP after parry window expires (trie reset) → dash fires normally
- [x] Take a frontal hit while blocking → hit negated, 20 soulfire drained from defender
- [x] Take a side hit while blocking → hit passes through normally
- [x] Take a hit during active parry window → attacker staggered, defender gains soulfire
- [x] UmbralBlade lunge/grab-impale hits a blocking player → partial damage (SHIELD_PASSING)
- [x] Soulfire hits 0 while blocking → block forcibly broken, player stunned, shield disabled
- [x] `/sword reload` → block drain rate and parry values update live