### PR TITLE
Add: Mob ability system with VisualProjectile refactor and throw fixes (#196, #197, #202)

### DIFF
--- a/src/main/java/btm/sword/Sword.java
+++ b/src/main/java/btm/sword/Sword.java
@@ -12,7 +12,10 @@ import btm.sword.config.ConfigManager;
 import btm.sword.listeners.EntityListener;
 import btm.sword.listeners.InputListener;
 import btm.sword.listeners.PlayerListener;
+import btm.sword.listeners.SystemListener;
+import btm.sword.listeners.WorldListener;
 import btm.sword.system.action.throwing.InteractiveItemArbiter;
+import btm.sword.system.action.throwing.ProjectileManager;
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.inventory.InventoryMenuManager;
 import btm.sword.system.playerdata.PlayerDataManager;
@@ -42,6 +45,8 @@ public final class Sword extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new InputListener(), this);
         getServer().getPluginManager().registerEvents(new PlayerListener(), this);
         getServer().getPluginManager().registerEvents(new EntityListener(), this);
+        getServer().getPluginManager().registerEvents(new WorldListener(), this);
+        getServer().getPluginManager().registerEvents(new SystemListener(), this);
 
         // Register commands using Paper's Brigadier lifecycle system
         LifecycleEventManager<@NotNull Plugin> manager = this.getLifecycleManager();
@@ -51,6 +56,9 @@ public final class Sword extends JavaPlugin {
 
         // Catch and register all entities whose data is already cached by the server
         SwordEntityArbiter.registerAllExistingEntities();
+
+        // Start the standalone projectile tick loop (does not affect FSM-driven projectiles)
+        ProjectileManager.startTicking();
 
         InventoryMenuManager.registerAll();
 

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -1499,7 +1499,54 @@ public class Config {
             Config::loadFloat
         ); }
 
-        // Throw sound configuration
+        public static SoundType BLOCK_BROKEN_SOUND = SoundType.ITEM_SHIELD_BREAK;
+        static { register(
+            "audio.block_broken_sound",
+            BLOCK_BROKEN_SOUND, SoundType.class,
+            v -> BLOCK_BROKEN_SOUND = v,
+            Config::loadSoundType
+        ); }
+
+        public static float BLOCK_BROKEN_VOLUME = 1.0f; // 0.0-1.0
+        static { register(
+            "audio.block_broken_volume",
+            BLOCK_BROKEN_VOLUME, Float.class,
+            v -> BLOCK_BROKEN_VOLUME = v,
+            Config::loadFloat
+        ); }
+
+        public static float BLOCK_BROKEN_PITCH = 1.0f;
+        static { register(
+            "audio.block_broken_pitch",
+            BLOCK_BROKEN_PITCH, Float.class,
+            v -> BLOCK_BROKEN_PITCH = v,
+            Config::loadFloat
+        ); }
+
+        public static SoundType PARRY_ATTEMPT_SOUND = SoundType.RANDOM_BANE_SLASH;
+        static { register(
+            "audio.parry_attempt_sound",
+            PARRY_ATTEMPT_SOUND, SoundType.class,
+            v -> PARRY_ATTEMPT_SOUND = v,
+            Config::loadSoundType
+        ); }
+
+        public static float PARRY_ATTEMPT_VOLUME = 1.0f; // 0.0-1.0
+        static { register(
+            "audio.parry_sound_volume",
+            PARRY_ATTEMPT_VOLUME, Float.class,
+            v -> PARRY_ATTEMPT_VOLUME = v,
+            Config::loadFloat
+        ); }
+
+        public static float PARRY_ATTEMPT_PITCH = 1.0f;
+        static { register(
+            "audio.parry_attempt_pitch",
+            PARRY_ATTEMPT_PITCH, Float.class,
+            v -> PARRY_ATTEMPT_PITCH = v,
+            Config::loadFloat
+        ); }
+
         public static SoundType PRE_ATTACK_SOUND = SoundType.ENTITY_EVOKER_FANGS_ATTACK;
         static { register(
             "audio.pre_attack_sound",

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -2616,6 +2616,33 @@ public class Config {
             v -> ATTACK_READY_TICKS = v,
             (s, p, d) -> s.getInt(p, d)
         ); }
+
+        /** Cooldown in ticks after the mob uses its melee slash ability (1 s at 20 TPS). */
+        public static int MOB_SLASH_COOLDOWN_TICKS = 20;
+        static { register(
+            "hostile.mob_slash_cooldown_ticks",
+            20, Integer.class,
+            v -> MOB_SLASH_COOLDOWN_TICKS = v,
+            (s, p, d) -> s.getInt(p, d)
+        ); }
+
+        /** Cooldown in ticks after the mob uses its throw ability (3 s at 20 TPS). */
+        public static int MOB_THROW_COOLDOWN_TICKS = 60;
+        static { register(
+            "hostile.mob_throw_cooldown_ticks",
+            60, Integer.class,
+            v -> MOB_THROW_COOLDOWN_TICKS = v,
+            (s, p, d) -> s.getInt(p, d)
+        ); }
+
+        /** Parabolic arc height multiplier for the mob throw ability. */
+        public static double MOB_THROW_ARC_HEIGHT = 0.4;
+        static { register(
+            "hostile.mob_throw_arc_height",
+            0.4, Double.class,
+            v -> MOB_THROW_ARC_HEIGHT = v,
+            (s, p, d) -> s.getDouble(p, d)
+        ); }
     }
     //endregion
 

--- a/src/main/java/btm/sword/listeners/WorldListener.java
+++ b/src/main/java/btm/sword/listeners/WorldListener.java
@@ -1,0 +1,13 @@
+package btm.sword.listeners;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
+
+public class WorldListener implements Listener {
+    @EventHandler
+    public void onBlockPlace(BlockPlaceEvent event) {
+
+        event.setCancelled(true);
+    }
+}

--- a/src/main/java/btm/sword/system/action/BlockAction.java
+++ b/src/main/java/btm/sword/system/action/BlockAction.java
@@ -8,6 +8,7 @@ import btm.sword.system.attack.HitValuePacket;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.utility.Prefab;
 import btm.sword.utility.sound.SoundType;
 import btm.sword.utility.sound.SoundUtil;
 
@@ -105,7 +106,8 @@ public final class BlockAction {
         player.setParryWindowEnd(System.currentTimeMillis() + Config.Combat.PARRY_WINDOW_MS);
         player.setBlocking(false);
         player.disableShield(Config.Combat.PARRY_SHIELD_COOLDOWN_TICKS);
-        SoundUtil.playSound(player.self(), SoundType.ITEM_SHIELD_BLOCK, 1.0f, 1.5f);
+
+        Prefab.Sounds.PARRY_ATTEMPT.playForAllInRadius(player.getLocation(), 15);
     }
 
     /**
@@ -189,8 +191,9 @@ public final class BlockAction {
         player.disableShield(Config.Combat.EXHAUSTED_BLOCKING_COOLDOWN_TICKS);
         player.setBlocking(false);
         player.cancelBlockDrainTask();
-        SoundUtil.playSound(player.self(), SoundType.ITEM_SHIELD_BREAK,
-            1.0f, 0.8f);
+
+        Prefab.Sounds.BLOCK_BROKEN.playForAllInRadius(player.getLocation(), 15);
+
         ActionCaster.cast(player, Config.Combat.BLOCK_BREAK_STAGGER_MS, () -> {});
     }
 }

--- a/src/main/java/btm/sword/system/action/throwing/InteractiveItemArbiter.java
+++ b/src/main/java/btm/sword/system/action/throwing/InteractiveItemArbiter.java
@@ -88,10 +88,6 @@ public class InteractiveItemArbiter {
         if (interactiveItem == null) return;
         if (interactiveItem instanceof ThrownItem thrownItem) {
             thrownItem.setRetrieved(true);
-//            if (thrownItem.getHitEntity() instanceof SwordEntity swordEntity && swordEntity.self().isValid()) {
-//                Impalement impalement = thrownItem.getThisImpalement();
-//                swordEntity.removeImpalement(impalement);
-//            }
         }
 
         // UmbralBlade manages its own item state (weapon/link/blade fields) and never populates

--- a/src/main/java/btm/sword/system/action/throwing/ProjectileManager.java
+++ b/src/main/java/btm/sword/system/action/throwing/ProjectileManager.java
@@ -1,0 +1,45 @@
+package btm.sword.system.action.throwing;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.Bukkit;
+
+import btm.sword.Sword;
+import btm.sword.system.action.throwing.types.Projectile;
+
+/**
+ * Manages all active {@link Projectile} instances and drives their physics loop
+ * from a single repeating Bukkit task.
+ * <p>
+ * {@link btm.sword.system.entity.umbral.UmbralBlade UmbralBlade} and other FSM-driven
+ * projectiles are <em>not</em> registered here — they are ticked by their own state machine.
+ * Only standalone projectiles spawned via {@link Projectile#launch} are registered.
+ * </p>
+ */
+public class ProjectileManager {
+
+    private static final List<Projectile> active = new ArrayList<>();
+
+    /**
+     * Registers a {@link Projectile} so that it will be ticked each physics step.
+     *
+     * @param projectile the projectile to track
+     */
+    public static void register(Projectile projectile) {
+        active.add(projectile);
+    }
+
+    /**
+     * Starts the global physics loop. Call once from {@code Sword.onEnable()}.
+     * The loop runs every server tick and removes projectiles whose
+     * {@link Projectile#tick()} returns {@code false}.
+     */
+    public static void startTicking() {
+        Bukkit.getScheduler().runTaskTimer(
+            Sword.getInstance(),
+            () -> active.removeIf(p -> !p.tick()),
+            0L, 1L
+        );
+    }
+}

--- a/src/main/java/btm/sword/system/action/throwing/ThrowAction.java
+++ b/src/main/java/btm/sword/system/action/throwing/ThrowAction.java
@@ -3,7 +3,9 @@ package btm.sword.system.action.throwing;
 import java.util.function.Consumer;
 
 import org.bukkit.entity.ItemDisplay;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.Nullable;
 
 import btm.sword.Sword;
 import btm.sword.system.action.SwordAction;
@@ -35,6 +37,15 @@ import btm.sword.system.input.ActivationContext;
  */
 public class ThrowAction extends SwordAction {
     /**
+     * Initializes the throw sequence for the given executor using the item currently in the main hand.
+     *
+     * @param executor the combatant beginning a throw action
+     */
+    public static void throwReady(Combatant executor) {
+        throwReady(executor, null);
+    }
+
+    /**
      * Initializes the throw sequence for the given executor.
      * <p>
      * This method marks the executor as attempting a throw, spawns an
@@ -43,43 +54,34 @@ public class ThrowAction extends SwordAction {
      * <p>
      * If the executor is a {@link SwordPlayer}, the thrown item's display will mirror
      * the item currently in hand (based on the item snapshot taken at hold time).
+     * If {@code itemOverride} is non-null, that item is used for the display and logical
+     * item stack regardless of what the executor holds — used by mob AI to throw a specific item.
      *
-     * @param executor The combatant beginning a throw action.
+     * @param executor     the combatant beginning a throw action
+     * @param itemOverride the explicit item to throw, or {@code null} to derive from the executor's hand
      */
-    public static void throwReady(Combatant executor) {
-        // Guard against throwing the Umbral Items
-        // TODO: #122 - Add logic here for lunging/directing/hurling the umbral blade, actually,
-        //  just have a separate input path with a different key...
-        //  it's not working there right now though, should be fixed
-
-        if (executor instanceof SwordPlayer swordPlayer && swordPlayer.isUmbralItem(swordPlayer.getMainItemStackAtTimeOfHold())) {
-//            UmbralBladeAction.lunge(executor);
-//            UmbralItemThrowAction.umbralLungeP1reparation(executor);
-//            swordPlayer.resetTree();
-//            swordPlayer.displayMistake(); // display something cool
-            return;
-        }
-
+    public static void throwReady(Combatant executor, @Nullable ItemStack itemOverride) {
         executor.setAttemptingThrow(true);
         executor.setThrowCancelled(false);
         executor.setThrowSuccessful(false);
         if (executor instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.THROWING);
 
         Consumer<ItemDisplay> setupInstructions;
-        ThrownItem thrownItem;
-        if (executor instanceof SwordPlayer sp && !sp.getItemStackInHand(true).isEmpty()) {
+        ItemStack logicalItem;
+
+        if (itemOverride != null) {
+            setupInstructions = display -> display.setItemStack(itemOverride);
+            logicalItem = itemOverride;
+        } else if (executor instanceof SwordPlayer sp && !sp.getItemStackInHand(true).isEmpty()) {
             setupInstructions = display -> display.setItemStack(sp.getMainItemStackAtTimeOfHold());
-        }
-        else {
+            logicalItem = sp.getMainItemStackAtTimeOfHold();
+        } else {
             setupInstructions = display -> display.setItemStack(executor.getItemStackInHand(true));
+            logicalItem = executor.getItemStackInHand(true);
         }
 
-        thrownItem = new ThrownItem(executor, setupInstructions, 1);
-
-        thrownItem.setItemStack(executor instanceof SwordPlayer sp && !sp.getItemStackInHand(true).isEmpty() ?
-            sp.getMainItemStackAtTimeOfHold() :
-            executor.getItemStackInHand(true));
-
+        ThrownItem thrownItem = new ThrownItem(executor, setupInstructions, 1);
+        thrownItem.setItemStack(logicalItem);
         executor.setThrownItem(thrownItem);
 
         // This Bukkit Runnable is fine for now

--- a/src/main/java/btm/sword/system/action/throwing/types/Projectile.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/Projectile.java
@@ -1,0 +1,188 @@
+package btm.sword.system.action.throwing.types;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.bukkit.FluidCollisionMode;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.util.RayTraceResult;
+import org.bukkit.util.Vector;
+
+import btm.sword.config.Config;
+import btm.sword.system.action.throwing.ProjectileManager;
+import btm.sword.system.entity.SwordEntityArbiter;
+import btm.sword.system.entity.base.SwordEntity;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * A pure-physics projectile with no display entity and no thrower reference.
+ * <p>
+ * Use this class for invisible or effect-only projectiles that only need collision detection
+ * and callbacks. For a visually-simulated item display projectile see {@link VisualProjectile}.
+ * </p>
+ * <p>
+ * Register instances with {@link ProjectileManager} to have them ticked automatically.
+ * </p>
+ */
+@Getter
+@Setter
+public class Projectile {
+    protected World world;
+    protected Vector position;
+    protected Vector previousPosition;
+    protected Vector velocity;
+    protected Vector origin;
+
+    protected Function<Double, Vector> positionFunction;
+    protected Function<Double, Vector> velocityFunction;
+
+    /** Raw tick counter — only incremented on the main thread by {@link #tick()}. */
+    protected int tick;
+    protected double timeScalingFactor = -1;
+    protected double timeCutoff = -1;
+
+    protected boolean grounded;
+    protected boolean hit;
+    protected boolean expired;
+
+    /** UUIDs of entities already struck — prevents multi-hit on fast projectiles. */
+    protected final Set<UUID> hitEntities = new HashSet<>();
+
+    /** Called with the struck {@link SwordEntity} when a living entity is hit. */
+    public Consumer<SwordEntity> onHitCallback;
+    /** Called when the projectile lands on a block. */
+    public Runnable onGroundCallback;
+    /** Called when the time cutoff is exceeded. */
+    public Runnable onExpireCallback;
+
+    /**
+     * Constructs a projectile at the given world origin, moving in the given direction at the given speed.
+     *
+     * @param world     the world in which the projectile exists
+     * @param origin    starting position
+     * @param direction normalized launch direction
+     * @param speed     initial speed in blocks per tick (approximate)
+     */
+    public Projectile(World world, Vector origin, Vector direction, double speed) {
+        this.world = world;
+        this.origin = origin.clone();
+        this.position = origin.clone();
+        this.previousPosition = origin.clone();
+
+        Vector dir = direction.clone().normalize();
+        this.velocity = dir.clone().multiply(speed);
+
+        double gravDamper = Config.Physics.THROWN_ITEMS_GRAVITY_DAMPER;
+        double horiz = Math.sqrt(dir.getX() * dir.getX() + dir.getZ() * dir.getZ());
+        double phi = Math.atan2(dir.getY(), horiz);
+        double forwardCoef = speed * Math.cos(phi);
+        double upwardCoef = speed * Math.sin(phi);
+        Vector flat = dir.clone().setY(0).normalize();
+        Vector fwdVel = flat.clone().multiply(forwardCoef);
+        Vector upVel = Config.Direction.UP().multiply(upwardCoef);
+
+        positionFunction = t -> flat.clone().multiply(forwardCoef * t)
+            .add(Config.Direction.UP().multiply(
+                (upwardCoef * t) - (speed * (1.0 / gravDamper) * t * t)));
+
+        velocityFunction = t -> fwdVel.clone()
+            .add(upVel.clone()
+                .add(Config.Direction.UP().multiply(-speed * (2.0 / gravDamper) * t)));
+    }
+
+    /**
+     * Convenience factory that constructs and registers the projectile in one step.
+     *
+     * @param world     the world
+     * @param origin    starting position
+     * @param direction launch direction (normalized)
+     * @param speed     initial speed
+     * @return the newly registered {@link Projectile}
+     */
+    public static Projectile launch(World world, Vector origin, Vector direction, double speed) {
+        Projectile p = new Projectile(world, origin, direction, speed);
+        ProjectileManager.register(p);
+        return p;
+    }
+
+    /**
+     * Advances one physics step.
+     *
+     * @return {@code true} to continue ticking; {@code false} when the projectile should be removed
+     */
+    public boolean tick() {
+        double time = timeScalingFactor < 0 ? tick : tick * timeScalingFactor;
+        previousPosition = position.clone();
+        position = origin.clone().add(positionFunction.apply(time));
+        velocity = velocityFunction.apply(time);
+
+        evaluate();
+        tick++;
+
+        if (timeCutoff > 0 && time > timeCutoff) {
+            expired = true;
+            if (onExpireCallback != null) onExpireCallback.run();
+        }
+
+        return !grounded && !hit && !expired;
+    }
+
+    /**
+     * Runs collision checks for this tick.
+     */
+    protected void evaluate() {
+        if (hit || grounded) return;
+        hitCheck();
+        groundedCheck();
+    }
+
+    /**
+     * Checks for entity collision along the previous→current sweep.
+     */
+    protected void hitCheck() {
+        double dist = position.clone().subtract(previousPosition).length();
+        if (dist < 1e-6) return;
+
+        Location prevLoc = previousPosition.toLocation(world);
+        RayTraceResult result = world.rayTraceEntities(
+            prevLoc,
+            velocity,
+            dist * Config.Detection.THROW_HIT_CHECK_DIST_MULTIPLIER,
+            Config.Detection.THROW_HIT_CHECK_DIST_MULTIPLIER,
+            entity -> entity instanceof LivingEntity l && !l.isDead()
+                && !hitEntities.contains(entity.getUniqueId())
+        );
+
+        if (result == null || !(result.getHitEntity() instanceof LivingEntity le)) return;
+
+        hit = true;
+        hitEntities.add(le.getUniqueId());
+        SwordEntity target = SwordEntityArbiter.getOrAdd(le);
+        if (onHitCallback != null) onHitCallback.accept(target);
+    }
+
+    /**
+     * Checks whether the projectile has hit a solid block.
+     */
+    protected void groundedCheck() {
+        double dist = position.clone().subtract(previousPosition).length();
+        if (dist < 1e-6) return;
+
+        Location prevLoc = previousPosition.toLocation(world);
+        RayTraceResult result = world.rayTraceBlocks(
+            prevLoc, velocity,
+            dist * Config.Detection.THROW_GROUND_CHECK_MULTIPLIER,
+            FluidCollisionMode.NEVER, true);
+
+        if (result == null || result.getHitBlock() == null || result.getHitBlock().getType().isAir()) return;
+
+        grounded = true;
+        if (onGroundCallback != null) onGroundCallback.run();
+    }
+}

--- a/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
@@ -1,17 +1,13 @@
 package btm.sword.system.action.throwing.types;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.bukkit.Color;
 import org.bukkit.FluidCollisionMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.Particle;
-import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Display;
 import org.bukkit.entity.Entity;
@@ -20,34 +16,27 @@ import org.bukkit.entity.ItemDisplay;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.TextDisplay;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Transformation;
 import org.bukkit.util.Vector;
-import org.jetbrains.annotations.NotNull;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
 import btm.sword.config.Config;
-import btm.sword.system.action.throwing.InteractiveItemArbiter;
-import btm.sword.system.action.throwing.ItemThrowStyle;
 import btm.sword.system.action.throwing.ThrowAction;
 import btm.sword.system.action.throwing.impale.Impalement;
 import btm.sword.system.control.PredicateRunnablePair;
 import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.control.TimeArbiter;
-import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.input.ActivationContext;
 import btm.sword.system.item.ItemUsageManager;
-import btm.sword.system.item.KeyRegistry;
 import btm.sword.utility.Prefab;
 import btm.sword.utility.display.DisplayUtil;
-import btm.sword.utility.display.ParticleWrapper;
 import btm.sword.utility.entity.EntityUtil;
 import btm.sword.utility.math.Basis;
 import btm.sword.utility.math.VectorUtil;
@@ -58,66 +47,35 @@ import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 
 /**
- * Represents a thrown item entity that is actively simulated in the world.
+ * A thrown item tied to a specific {@link Combatant} thrower.
  * <p>
- * Handles all aspects of the throw lifecycle — initialization, motion physics,
- * collision detection, and interaction outcomes such as hitting entities,
- * embedding in blocks, or being caught.
+ * Extends {@link VisualProjectile} with thrower-aware physics origin, hand management,
+ * impalement, and a landing prediction marker. The thrower's look direction drives trajectory
+ * unless {@link #setLaunchDirection(Vector)} is called to override it (used by mob AI).
+ * </p>
  */
 @Getter
 @Setter
-public class ThrownItem extends SimulatedDisplay {
+public class ThrownItem extends VisualProjectile {
     protected final Combatant thrower;
-    private ParticleWrapper blockTrail;
-    protected Consumer<ItemDisplay> displaySetupInstructions;
 
     protected Impalement thisImpalement;
 
-    protected float xDisplayOffset;
-    protected float yDisplayOffset;
-    protected float zDisplayOffset;
+    /** Predicate tested by the impalement follow-task to decide when embedding ends. */
+    protected Predicate<VisualProjectile> exitImpalementStatePredicate;
 
-    protected Location origin;
-    protected Location cur;
-    protected Location prev;
-    protected Vector to; // cur - prev
-    protected Vector velocity;
-
-    protected double timeScalingFactor = -1;
-    protected double timeCutoff = -1;
-    protected AtomicInteger timeStep = new AtomicInteger(0);
-
-    protected Basis currentBasis;
-
-    protected double initialVelocity;
-
-    protected Function<Double, Vector> positionFunction;
-    protected Function<Double, Vector> velocityFunction;
-
-    protected boolean grounded;
-    protected Block stuckBlock;
-    protected ParticleWrapper blockDustPillarParticle;
-
-    protected boolean retrieved;
-
-    protected boolean hit;
-    protected SwordEntity hitEntity;
-
-    protected boolean caught;
-
-    protected boolean inFlight;
-
-    protected Predicate<ThrownItem> exitImpalementStatePredicate;
-
-    protected TimeArbiter.TaskHandle disposeTask;
-
-    protected boolean setupSuccessful;
-
+    // Landing marker (issue #15)
     private TextDisplay landingMarker;
     private TimeArbiter.TaskHandle landingParticleTask;
-    private ItemThrowStyle throwStyle;
     private float landingMarkerSize = 4.0f;
 
+    /**
+     * Constructs and begins spawning the thrown item display.
+     *
+     * @param thrower                   the combatant performing the throw
+     * @param displaySetupInstructions  applied to the {@link ItemDisplay} immediately after it spawns
+     * @param setupPeriod               polling interval in ticks for the spawn-check loop
+     */
     public ThrownItem(Combatant thrower, Consumer<ItemDisplay> displaySetupInstructions, int setupPeriod) {
         this.thrower = thrower;
         this.displaySetupInstructions = displaySetupInstructions;
@@ -130,6 +88,12 @@ public class ThrownItem extends SimulatedDisplay {
         setup(setupPeriod);
     }
 
+    /**
+     * Spawns the display at the thrower's eye location when the server tick fires.
+     * Keeps using {@link ThrowAction}'s task identifier for backward compatibility.
+     *
+     * @param period polling interval in ticks
+     */
     protected void setup(int period) {
         TimeArbiter.runTimeIndependentBukkitTaskOnTimer(
             null,
@@ -152,28 +116,20 @@ public class ThrownItem extends SimulatedDisplay {
         );
     }
 
+    /**
+     * Snapshots the thrower's hand items after the display spawns.
+     * For players, this uses the item held at the time of the hold input.
+     */
+    @Override
     protected void afterSpawn() {
-        blockTrail = display.getItemStack().getType().isBlock() ?
-                new ParticleWrapper(Particle.BLOCK, 5, 0.25,  0.25,  0.25,
-                        display.getItemStack().getType().createBlockData()) :
-                null;
-
+        super.afterSpawn();
         if (thrower instanceof SwordPlayer sp) {
             sp.setMainHandItemStackDuringThrow(sp.getMainItemStackAtTimeOfHold());
             sp.setOffHandItemStackDuringThrow(sp.getOffItemStackAtTimeOfHold());
-        }
-        else {
+        } else {
             thrower.setMainHandItemStackDuringThrow(thrower.getItemStackInHand(true));
             thrower.setOffHandItemStackDuringThrow(thrower.getItemStackInHand(false));
         }
-        // Base values for where the ItemDisplay is held in relation to the player's eye location
-        xDisplayOffset = Config.Physics.THROWN_ITEMS_DISPLAY_OFFSET_X;
-        yDisplayOffset = Config.Physics.THROWN_ITEMS_DISPLAY_OFFSET_Y;
-        zDisplayOffset = Config.Physics.THROWN_ITEMS_DISPLAY_OFFSET_Z;
-    }
-
-    public void setTimeScalingFactor(double numberOfIterations) {
-        this.timeScalingFactor = (this.timeCutoff > 0 ? timeCutoff : 1)/numberOfIterations;
     }
 
     /**
@@ -186,12 +142,10 @@ public class ThrownItem extends SimulatedDisplay {
             sp.setThrewItem(false);
             sp.setThrownItemIndex();
 
-            // Interacting with an entity will cause the shield holding mechanic to falter
             if (sp.isInteractingWithEntity()) {
                 sp.setAttemptingThrow(false);
                 sp.setActivationContext(ActivationContext.NORMAL);
                 sp.setThrowSuccessful(true);
-                // this throw should be weaker because it's automatic. Could turn into a lunge or thrust or smth else
                 sp.getThrownItem().onRelease(2);
                 thrower.setItemTypeInHand(Material.AIR, true);
                 sp.endHoldingRight();
@@ -204,7 +158,7 @@ public class ThrownItem extends SimulatedDisplay {
         final int[] iteration = {0};
 
         TimeArbiter.runTimeIndependentBukkitTaskOnTimer(
-          null,
+            null,
             () -> {
                 if (thrower instanceof SwordPlayer sp) {
                     if (!sp.isChangingHandIndex() && sp.getCurrentInvIndex() == sp.getThrownItemIndex()) {
@@ -246,8 +200,9 @@ public class ThrownItem extends SimulatedDisplay {
      * Called by state classes (e.g. LungingState) that drive physics via {@link #stepFlight()} each tick
      * instead of using the self-contained {@link #onRelease(double)} loop.
      *
-     * @param initialVelocity The starting velocity magnitude.
+     * @param initialVelocity the starting velocity magnitude
      */
+    @Override
     public void initFlight(double initialVelocity) {
         if (thrower instanceof SwordPlayer sp) {
             sp.setThrewItem(true);
@@ -257,305 +212,176 @@ public class ThrownItem extends SimulatedDisplay {
             );
         }
 
-        generateFunctions(initialVelocity);
+        super.initFlight(initialVelocity);
 
         if (shouldShowLandingMarker()) {
             spawnLandingMarker(precomputeLanding());
         }
-
-        handleOnReleaseActions();
-
-        xDisplayOffset = yDisplayOffset = zDisplayOffset = 0;
-        determineOrientation();
     }
 
     /**
-     * Executes one physics tick: applies functions, teleports, rotates, emits particles, evaluates collisions.
+     * Called when the flight loop ends. Removes the landing marker before delegating to the parent.
      */
-    protected void tickFlight() {
-        applyFunctions();
-
-        if (!prev.equals(cur) && cur.clone().subtract(prev).toVector().dot(velocity) > 0) {
-            DisplayUtil.setSmoothTeleportDuration(display, 1);
-        }
-
-        teleport();
-        rotate();
-
-        Prefab.Particles.THROW_TRAIl.display(prev); // TODO: #119 - Make type of particles dynamic
-        if (blockTrail != null && timeStep.get() % 3 == 0) // TODO: #119 - Make period dynamic
-            blockTrail.display(prev);
-
-        evaluate();
-        prev = cur.clone();
-
-        timeStep.incrementAndGet();
-    }
-
-    /**
-     * Runs one physics tick and returns {@code true} if the flight is over.
-     * <p>
-     * Used by FSM state classes (e.g. LungingState) to drive physics synchronously from {@code onTick()}.
-     *
-     * @return {@code true} when a termination condition is met (grounded, hit, caught, dead display, or timed out)
-     */
-    public boolean stepFlight() {
-        tickFlight();
-        return grounded || hit || caught || display.isDead()
-            || (timeCutoff > 0 && timeStep.get() * timeScalingFactor > timeCutoff);
-    }
-
-    /**
-     * Called when the item is released (actually thrown).
-     * <p>
-     * Initializes trajectory, physics parameters, and continuous motion updates.
-     *
-     * @param initialVelocity The starting velocity magnitude of the throw.
-     */
-    public void onRelease(double initialVelocity) {
-        initFlight(initialVelocity);
-
-        TimeArbiter.runTimeBoundBukkitTaskOnTimer(
-            null,
-            this::tickFlight,
-            null,
-            0, 50,
-            ThrownItem.class, "onRelease",
-            new PredicateRunnablePair(
-                () -> grounded || hit || caught || display.isDead() ||
-                    (timeCutoff > 0 && timeStep.get() * timeScalingFactor > timeCutoff),
-                () -> {
-                    String reason = grounded ? "grounded" :
-                        hit ? "hit" :
-                            caught ? "caught" :
-                                display.isDead() ? "display dead" :
-                                    (timeCutoff > 0 && timeStep.get() * timeScalingFactor > timeCutoff) ? "time cutoff" :
-                                        "unknown";
-                    thrower.combatInfo("Ending due to: " + reason);
-
-                    onEnd();
-                }
-            )
-        );
-    }
-
-    protected void teleport() {
-        ItemThrowStyle style = getThrowStyle();
-        if (style == ItemThrowStyle.SPEAR || style == ItemThrowStyle.HATCHET) {
-            // Tip tracks velocity direction — spear stays pointed, hatchet flips around that axis
-            TimeArbiter.teleportDisplay(display, cur, velocity, 2, ThrownItem.class, 320);
-        }
-        else {
-            TimeArbiter.teleportDisplay(display, cur, currentBasis.forward(), 2, ThrownItem.class, 323);
-        }
-    }
-
-    protected void applyFunctions() {
-        double time;
-        if (timeScalingFactor < 0) {
-            time = timeStep.get();
-        }
-        else {
-            time = timeStep.get() * timeScalingFactor;
-        }
-        cur = origin.clone().add(positionFunction.apply(time));
-        if (prev != null) to = cur.clone().subtract(prev).toVector();
-        velocity = velocityFunction.apply(time);
-    }
-
-    /**
-     * Play sounds and remove the item in the main hand of the player. Should be overridden for different logic.
-     */
-    protected void handleOnReleaseActions() {
-        Prefab.Sounds.THROW.playForAllInRadius(thrower.self());
-        thrower.setItemStackInHand(ItemStack.of(Material.AIR), true);
-        InteractiveItemArbiter.put(this);
-    }
-
-    protected void generateFunctions(double initialVelocity) {
-        calculatePhysicsFunctions(initialVelocity);
-    }
-
-    private void calculatePhysicsFunctions(double initialVelocity) {
-        this.initialVelocity = initialVelocity;
-
-        LivingEntity ex = thrower.self();
-        Location o = ex.getEyeLocation();
-        this.currentBasis = VectorUtil.getBasisWithoutPitch(ex);
-
-        // clamp the pitch between these values so that strange undefined vertical vector behavior doesn't occur.
-        double min = Math.toRadians(-89);
-        double max = Math.toRadians(89);
-        double phi = Math.max(min, Math.min(max, Math.toRadians(-1 * o.getPitch())));
-
-        double cosPhi = Math.cos(phi);
-        double sinPhi = Math.sin(phi);
-        double forwardCoefficient = initialVelocity * cosPhi;
-        double upwardCoefficient = initialVelocity * sinPhi;
-
-        origin = o.add(currentBasis.right().multiply(Config.Physics.THROWN_ITEMS_ORIGIN_OFFSET_FORWARD))
-            .add(currentBasis.up().multiply(Config.Physics.THROWN_ITEMS_ORIGIN_OFFSET_UP))
-            .add(currentBasis.forward().multiply(Config.Physics.THROWN_ITEMS_ORIGIN_OFFSET_BACK));
-        cur = origin.clone();
-        prev = cur.clone();
-        Vector flatDir = thrower.getFlatDir().rotateAroundY(Config.Physics.THROWN_ITEMS_TRAJECTORY_ROTATION);
-        velocity = flatDir.clone();
-        Vector forwardVelocity = flatDir.clone().multiply(forwardCoefficient);
-        Vector upwardVelocity = Config.Direction.UP().multiply(upwardCoefficient);
-
-        double gravDamper = Config.Physics.THROWN_ITEMS_GRAVITY_DAMPER;
-
-        positionFunction = t -> flatDir.clone().multiply(forwardCoefficient * t)
-            .add(Config.Direction.UP().multiply((upwardCoefficient * t) - (initialVelocity * (1 / gravDamper) * t * t)));
-
-        velocityFunction = t -> forwardVelocity.clone()
-            .add(upwardVelocity.clone().add(Config.Direction.UP().multiply(-initialVelocity * (2 / (gravDamper)) * t)));
-    }
-
-    /**
-     * Applies appropriate rotation to the display based on the item's {@link ItemThrowStyle}.
-     * <p>
-     * SPEAR items keep their tip pointed forward with no spin. HATCHET items flip forward
-     * on the Z-axis (like a knife throw). LOB items tumble slowly. Everything else spins
-     * at the default rate.
-     */
-    protected void rotate() {
-        switch (getThrowStyle()) {
-            case SPEAR -> {} // tip stays pointed forward, no spin
-            case HATCHET -> applyRotation(false, (float) Config.Physics.THROWN_ITEMS_ROTATION_SPEED_AXE);
-            case LOB -> applyRotation(true, (float) (Config.Physics.THROWN_ITEMS_ROTATION_SPEED_DEFAULT_SPEED * 0.4));
-            default -> applyRotation(true, (float) Config.Physics.THROWN_ITEMS_ROTATION_SPEED_DEFAULT_SPEED);
-        }
-    }
-
-    private void applyRotation(boolean rotateX, float speed) {
-        Transformation curTr = display.getTransformation();
-        Quaternionf curRotation = curTr.getLeftRotation();
-        Quaternionf newRotation = rotateX
-            ? curRotation.rotateX(speed)
-            : curRotation.rotateZ(speed);
-        display.setTransformation(new Transformation(
-            curTr.getTranslation(), newRotation, curTr.getScale(), curTr.getRightRotation()
-        ));
-    }
-
-    /**
-     * Called once the throw has completed its trajectory or interaction.
-     * <p>
-     * Delegates to the correct outcome handler depending on state flags.
-     */
+    @Override
     protected void onEnd() {
         removeLandingMarker();
-        if (caught) onCatch();
-        else if (hit) onHit();
-        else if (grounded) onGrounded();
-        timeStep.set(0);
+        String reason = grounded ? "grounded"
+            : hit ? "hit"
+            : caught ? "caught"
+            : display.isDead() ? "display dead" : "time cutoff";
+        thrower.combatInfo("Ending due to: " + reason);
+        super.onEnd();
     }
 
     /**
-     * Handles logic when the thrown item hits the ground or block.
-     * <p>
-     * Creates marker particles, positions the display, and schedules timed cleanup.
+     * Handles impalement and knockback when the thrown item hits a living entity.
      */
-    protected void onGrounded() {
-        if (stuckBlock != null) {
-            new ParticleWrapper(Particle.BLOCK, 50, 1, 1, 1, stuckBlock.getBlockData()).display(cur);
-        }
-
-        double offset = 0.1;
-        Vector n = velocity.normalize();
-        Vector step = n.clone().multiply(offset);
-
-        Location probe = cur.clone();
-        Vector backwards = velocity.normalize().multiply(-0.1);
-
-        int x = 1;
-        while (!probe.getBlock().isPassable()) {
-            probe.add(backwards);
-            x++;
-            if (x > 30) break;
-        }
-
-        SwordScheduler.runBukkitTaskLater(() -> {
-            Location land = probe.clone();
-            land.setDirection(to.normalize());
-            TimeArbiter.teleportDisplay(display, land, null, 1, ThrownItem.class, 456);
-            },
-            51, TimeUnit.MILLISECONDS
-        );
-
-        startGroundedDisposeTask(step);
-    }
-
-    protected void startGroundedDisposeTask(Vector step) {
-        AtomicInteger iteration = new AtomicInteger(0);
-        disposeTask = TimeArbiter.runTimeBoundBukkitTaskOnTimer(
-            null,
-            () -> {
-                Prefab.Particles.THROWN_ITEM_MARKER.display(cur.clone().add(step));
-                Prefab.Particles.THROWN_ITEM_MARKER.display(cur);
-                Prefab.Particles.THROWN_ITEM_MARKER.display(cur.clone().subtract(step));
-
-                iteration.set(iteration.get() + Config.Timing.THROWN_ITEMS_DISPOSAL_CHECK_INTERVAL);
-            },
-            null,
-            1, Config.Timing.THROWN_ITEMS_DISPOSAL_CHECK_INTERVAL,
-            ThrowAction.class, "startGroundedDisposeTask",
-            new PredicateRunnablePair(
-                () -> display.isDead(), null
-            ),
-            new PredicateRunnablePair(
-                () -> iteration.get() > Config.Timing.THROWN_ITEMS_DISPOSAL_TIMEOUT,
-                () -> {
-                    if (!display.isDead()) display.remove();
-                }
-            )
-        );
-    }
-
-    /**
-     * Handles logic when the thrown item successfully hits a living entity.
-     * <p>
-     * Manages impalement, knockback, pinning, and delayed disposal.
-     */
+    @Override
     public void onHit() {
         if (hitEntity == null) return;
 
         String name = display.getItemStack().getType().toString();
-
         handleItemDamageAndCheckIfBroken();
 
-        // TODO: #127 - Better checks for weapon, can tag with impactType = 'impale'
+        // TODO: #127 - Better checks for weapon; can tag with impactType = 'impale'
         if (name.endsWith("_SWORD") || name.endsWith("AXE")) {
             startImpalementTask(hitEntity);
-        }
-        else {
+        } else {
             nonImpalingImpact(hitEntity);
         }
     }
 
+    /**
+     * Returns the item to the thrower's inventory when caught.
+     */
+    @Override
+    protected void onCatch() {
+        thrower.giveItem(display.getItemStack());
+        dispose();
+    }
+
+    /**
+     * Plays the throw sound and removes the item from the correct hand.
+     * <ul>
+     *   <li>For {@link SwordPlayer}: clears the slot at {@code thrownItemIndex}.</li>
+     *   <li>For mobs: detects which hand holds the thrown item and clears that hand.</li>
+     * </ul>
+     */
+    @Override
+    protected void handleOnReleaseActions() {
+        Prefab.Sounds.THROW.playForAllInRadius(thrower.self());
+        if (thrower instanceof SwordPlayer sp) {
+            sp.setItemAtIndex(ItemStack.of(Material.AIR), sp.getThrownItemIndex());
+        } else {
+            boolean isMainHand = thrower.getItemStackInHand(true).isSimilar(itemStack);
+            thrower.setItemStackInHand(ItemStack.of(Material.AIR), isMainHand);
+        }
+        super.handleOnReleaseActions(); // InteractiveItemArbiter.put(this)
+    }
+
+    /**
+     * Damages the thrown item on a successful hit, potentially breaking it.
+     */
+    @Override
     public void handleItemDamageAndCheckIfBroken() {
         if (display == null || itemStack == null) return;
-
-        if (itemStack.isEmpty() ||
-            ItemUsageManager.isUnbreakable(itemStack)) return;
+        if (itemStack.isEmpty() || ItemUsageManager.isUnbreakable(itemStack)) return;
 
         int currentDamage = ItemUsageManager.currentItemDamage(itemStack);
-
         int maxThrownItemUses = 3;
         int onThrowHitDamageToItem = ItemUsageManager.maxItemDamage(itemStack) / maxThrownItemUses;
 
         if (currentDamage >= onThrowHitDamageToItem * (maxThrownItemUses - 1)) {
             Prefab.Particles.ITEM_THROW_BREAK.display(display.getLocation());
-
             itemStack.damage(77777777, thrower.self());
             display.remove();
-        }
-        else {
+        } else {
             ItemUsageManager.damageItemStack(itemStack, onThrowHitDamageToItem, thrower.self());
         }
     }
 
+    /**
+     * Excludes the thrower from the hit filter during the catch grace period.
+     *
+     * @return the adjusted filter predicate
+     */
+    @Override
+    protected Predicate<Entity> getFilter() {
+        Predicate<Entity> filter = entity ->
+            entity.getUniqueId() != display.getUniqueId()
+                && (entity instanceof LivingEntity l)
+                && !l.isDead();
+        return timeStep.get() < Config.Timing.THROWN_ITEMS_CATCH_GRACE_PERIOD
+            ? entity -> filter.test(entity) && entity.getUniqueId() != thrower.getUniqueId()
+            : filter;
+    }
+
+    /**
+     * Returns {@code true} if the given entity is the thrower.
+     */
+    @Override
+    protected boolean isOwnerEntity(LivingEntity entity) {
+        return thrower.isSelf(entity);
+    }
+
+    // -----------------------------------------------------------------------
+    // Trajectory hook overrides — supply thrower-derived values
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns the thrower's eye location offset by throw origin config values.
+     */
+    @Override
+    protected Location resolveOriginLocation() {
+        LivingEntity ex = thrower.self();
+        Location o = ex.getEyeLocation();
+        Basis basis = VectorUtil.getBasisWithoutPitch(ex);
+        return o.add(basis.right().multiply(Config.Physics.THROWN_ITEMS_ORIGIN_OFFSET_FORWARD))
+            .add(basis.up().multiply(Config.Physics.THROWN_ITEMS_ORIGIN_OFFSET_UP))
+            .add(basis.forward().multiply(Config.Physics.THROWN_ITEMS_ORIGIN_OFFSET_BACK));
+    }
+
+    /**
+     * Returns the thrower's horizontal basis (ignoring pitch).
+     */
+    @Override
+    protected Basis resolveBasis() {
+        return VectorUtil.getBasisWithoutPitch(thrower.self());
+    }
+
+    /**
+     * Returns the flat throw direction: {@link #launchDirection} if set, otherwise the thrower's look direction
+     * with the configured trajectory rotation applied.
+     */
+    @Override
+    protected Vector resolveFlatDir() {
+        if (launchDirection != null) return launchDirection.clone().setY(0).normalize();
+        return thrower.getFlatDir().rotateAroundY(Config.Physics.THROWN_ITEMS_TRAJECTORY_ROTATION);
+    }
+
+    /**
+     * Returns the vertical launch angle in radians: derived from {@link #launchDirection} if set,
+     * otherwise from the thrower's eye pitch.
+     */
+    @Override
+    protected double resolvePitch() {
+        if (launchDirection != null) {
+            Vector nd = launchDirection.clone().normalize();
+            double horiz = Math.sqrt(nd.getX() * nd.getX() + nd.getZ() * nd.getZ());
+            return Math.atan2(nd.getY(), horiz);
+        }
+        return Math.toRadians(-1 * thrower.self().getEyeLocation().getPitch());
+    }
+
+    // -----------------------------------------------------------------------
+    // Hit outcome helpers — require thrower attribution
+    // -----------------------------------------------------------------------
+
+    /**
+     * Applies knockback and a small explosion to a target that was not impaled.
+     *
+     * @param target the struck entity
+     */
     protected void nonImpalingImpact(SwordEntity target) {
         target.hit(thrower, Prefab.Attacks.thrownWeapon,
             velocity.clone().multiply(Config.Combat.THROWN_DAMAGE_OTHER_KNOCKBACK_MULTIPLIER));
@@ -570,10 +396,16 @@ public class ThrownItem extends SimulatedDisplay {
         }
     }
 
+    /**
+     * Starts the impalement sequence for sword/axe hits.
+     *
+     * @param target the struck entity
+     */
     public void startImpalementTask(SwordEntity target) {
-        Vector kb = EntityUtil.isOnGround(target.self()) ?
-            velocity.clone().multiply(Config.Combat.THROWN_DAMAGE_SWORD_AXE_KNOCKBACK_GROUNDED) :
-            VectorUtil.getProjOntoPlane(velocity, Config.Direction.UP()).multiply(Config.Combat.THROWN_DAMAGE_SWORD_AXE_KNOCKBACK_AIRBORNE);
+        Vector kb = EntityUtil.isOnGround(target.self())
+            ? velocity.clone().multiply(Config.Combat.THROWN_DAMAGE_SWORD_AXE_KNOCKBACK_GROUNDED)
+            : VectorUtil.getProjOntoPlane(velocity, Config.Direction.UP())
+                .multiply(Config.Combat.THROWN_DAMAGE_SWORD_AXE_KNOCKBACK_AIRBORNE);
 
         if (display.isValid()) {
             impale(target.self());
@@ -582,9 +414,9 @@ public class ThrownItem extends SimulatedDisplay {
     }
 
     /**
-     * Impales a {@link LivingEntity} when struck, embedding the item visually and applying follow behavior.
+     * Embeds the display entity into the struck living entity, making it follow on impact.
      *
-     * @param hit The living entity being impaled.
+     * @param hit the entity being impaled
      */
     public void impale(LivingEntity hit) {
         thisImpalement = new Impalement(hitEntity);
@@ -594,189 +426,12 @@ public class ThrownItem extends SimulatedDisplay {
         double max = hit.getEyeLocation().getY();
         double feet = hit.getLocation().getY();
         double diff = max - feet;
-
         double heightOffset = Math.max(0, Math.min(cur.getY() - feet, hit.getHeight()));
 
         boolean followHead = !Config.Combat.IMPALEMENT_HEAD_FOLLOW_EXCEPTIONS.contains(hitEntity.type())
             && heightOffset >= diff * Config.Combat.IMPALEMENT_HEAD_ZONE_RATIO;
-        DisplayUtil.itemDisplayFollow(hitEntity, display,  velocity.clone().normalize(), heightOffset, followHead,
+        DisplayUtil.itemDisplayFollow(hitEntity, display, velocity.clone().normalize(), heightOffset, followHead,
             exitImpalementStatePredicate, this, null, null);
-    }
-
-    public void setRetrieved(boolean retrieved) {
-        this.retrieved = retrieved;
-        SwordScheduler.runBukkitTaskLater(() -> setRetrieved(false), 60, TimeUnit.MILLISECONDS);
-    }
-
-    /**
-     * Handles when the thrower catches their own thrown item midair.
-     * <p>
-     * Returns the item to inventory and disposes of the display.
-     */
-    protected void onCatch() {
-        thrower.giveItem(display.getItemStack());
-        dispose();
-    }
-
-    /**
-     * Evaluates the item’s current interaction state each tick.
-     * <p>
-     * Checks for collisions with entities or blocks.
-     */
-    public void evaluate() {
-        if (hit || grounded || caught) return;
-        hitCheck();
-        groundedCheck();
-    }
-
-    /**
-     * Checks if the thrown item has collided with a block and become grounded.
-     */
-    public void groundedCheck() {
-        RayTraceResult hitBlock = display.getWorld()
-            .rayTraceBlocks(cur, velocity,
-                cur.toVector()
-                    .subtract(prev.toVector())
-                    .lengthSquared() * Config.Detection.THROW_GROUND_CHECK_MULTIPLIER,
-                FluidCollisionMode.NEVER, true);
-
-        if (hitBlock == null) {
-            return;
-        }
-
-        if (hitBlock.getHitBlock() == null || hitBlock.getHitBlock().getType().isAir())
-            return;
-
-        grounded = true;
-        stuckBlock = hitBlock.getHitBlock();
-        cur = hitBlock.getHitPosition().toLocation(display.getWorld());
-    }
-
-    /**
-     * Checks for collision with entities using ray tracing.
-     * <p>
-     * Determines whether the item hits an enemy or is caught by its thrower.
-     */
-    public void hitCheck() {
-        Predicate<Entity> effFilter = getFilter();
-
-        if (prev == null) {
-            disposeWithNewInteractiveItem();
-        }
-
-        RayTraceResult hitEntity = display.getWorld()
-            .rayTraceEntities(prev, velocity,
-                cur.toVector()
-                    .subtract(prev.toVector())
-                    .lengthSquared() * Config.Detection.THROW_HIT_CHECK_DIST_MULTIPLIER,
-                Config.Detection.THROW_HIT_CHECK_DIST_MULTIPLIER, effFilter);
-
-        if (hitEntity == null) return; // Again, might change this later for non-living damageables.
-
-        if (!(hitEntity.getHitEntity() instanceof LivingEntity)) return;
-
-        if (thrower.isSelf((LivingEntity) hitEntity.getHitEntity())) {
-            caught = true;
-        }
-        else {
-            hit = true;
-            // Assign the hit entity (can only be one), maybe more actually effect though AOE damage from blocks or larger weapons
-            this.hitEntity = SwordEntityArbiter.getOrAdd((LivingEntity) hitEntity.getHitEntity());
-        }
-    }
-
-    private @NotNull Predicate<Entity> getFilter() {
-        Predicate<Entity> filter = entity ->
-                        entity.getUniqueId() != display.getUniqueId() &&
-                        (entity instanceof LivingEntity l) &&
-                        !l.isDead();
-        // Throwing a weapon should not immediately result in catching it, therefore a grace period is in place.
-        return timeStep.get() < Config.Timing.THROWN_ITEMS_CATCH_GRACE_PERIOD ?
-            entity -> filter.test(entity) && entity.getUniqueId() != thrower.getUniqueId() :
-            filter;
-    }
-
-    /**
-     * Determines the correct {@link Transformation} for the item display based on its type.
-     * <p>
-     * Ensures proper orientation in-hand and mid-flight.
-     */
-    public void determineOrientation() {
-        String name = display.getItemStack().getType().toString();
-        Vector3f base = new Vector3f(xDisplayOffset, yDisplayOffset, zDisplayOffset);
-
-        // *** These numbers are fine for now, config later but this system may change.
-
-        if (name.endsWith("_SWORD")) {
-            display.setTransformation(new Transformation(
-                    base.add(new Vector3f()),
-                    new Quaternionf()
-                            .rotateY((float) Math.PI/2)
-                            .rotateZ((float) Math.PI/2),
-                    new Vector3f(1,1,1),
-                    new Quaternionf()
-            ));
-        }
-        else if (name.endsWith("AXE") || name.endsWith("_HOE") || name.endsWith("_SHOVEL")) {
-            display.setTransformation(new Transformation(
-                    base.add(new Vector3f()),
-                    new Quaternionf().rotateY((float) -Math.PI/2)
-                            .rotateZ((float) Math.PI/4),
-                    new Vector3f(1.5f,1.5f,1.5f),
-                    new Quaternionf()
-            ));
-        }
-        else if (display.getItemStack().getType() == Material.SHIELD) {
-            display.setTransformation(new Transformation(
-                    base.add(new Vector3f(0,0,0)),
-                    new Quaternionf().rotateY((float) (Math.PI/1.01f) * 0),
-                    new Vector3f(1,1,1),
-                    new Quaternionf()
-            ));
-        }
-        else {
-            display.setTransformation(new Transformation(
-                    base.add(new Vector3f()),
-                    new Quaternionf().rotateZ((float) Math.PI/8),
-                    new Vector3f(1,1,1),
-                    new Quaternionf()
-            ));
-        }
-    }
-
-    // -----------------------------------------------------------------------
-    // Throw style
-    // -----------------------------------------------------------------------
-
-    /**
-     * Returns the {@link ItemThrowStyle} for this item, reading from the item's PDC first,
-     * then falling back to a material-based default.
-     * <p>
-     * The result is cached after the first call.
-     */
-    protected ItemThrowStyle getThrowStyle() {
-        if (throwStyle != null) return throwStyle;
-        if (itemStack != null && !itemStack.isEmpty()) {
-            String stored = KeyRegistry.getKeyField(itemStack, KeyRegistry.THROW_STYLE_KEY, PersistentDataType.STRING);
-            if (stored != null) {
-                try {
-                    throwStyle = ItemThrowStyle.valueOf(stored);
-                    return throwStyle;
-                } catch (IllegalArgumentException ignored) { }
-            }
-        }
-        throwStyle = deriveThrowStyle();
-        return throwStyle;
-    }
-
-    private ItemThrowStyle deriveThrowStyle() {
-        if (itemStack == null || itemStack.isEmpty()) return ItemThrowStyle.PITCH;
-        String name = itemStack.getType().toString();
-        if (name.endsWith("_SWORD")) return ItemThrowStyle.SPEAR;
-        if (name.endsWith("_AXE") || name.endsWith("_HOE")
-                || name.endsWith("_SHOVEL") || name.endsWith("_PICKAXE")) return ItemThrowStyle.HATCHET;
-        if (itemStack.getType().isBlock()) return ItemThrowStyle.LOB;
-        return ItemThrowStyle.PITCH;
     }
 
     // -----------------------------------------------------------------------
@@ -786,14 +441,15 @@ public class ThrownItem extends SimulatedDisplay {
     /**
      * Whether this thrown item should display a landing prediction marker.
      * Subclasses that handle their own landing feedback (e.g. UmbralBlade) may override this.
+     *
+     * @return {@code true} by default
      */
     protected boolean shouldShowLandingMarker() {
         return true;
     }
 
     /**
-     * Simulates the flight trajectory to find the first block that will be struck,
-     * returning the hit position and the face that was hit.
+     * Simulates the flight trajectory to find the first block that will be struck.
      *
      * @return the predicted landing, or {@code null} if no block is found within range
      */
@@ -806,7 +462,6 @@ public class ThrownItem extends SimulatedDisplay {
         Location prevLoc = origin.clone();
         for (double t = step; t <= maxTime + step; t += step) {
             Location nextLoc = origin.clone().add(positionFunction.apply(t));
-
             Vector diff = nextLoc.toVector().subtract(prevLoc.toVector());
             double len = diff.length();
             if (len < 1e-6) {
@@ -829,9 +484,8 @@ public class ThrownItem extends SimulatedDisplay {
 
     /**
      * Spawns the landing prediction marker at the precomputed landing location.
-     * <p>
-     * Ground landings get a flat ⊗ marker lying 0.2 blocks above the surface with an upward
-     * particle stream. Wall landings get a vertical marker with {@link Display.Billboard#FIXED}.
+     *
+     * @param prediction the precomputed landing position and face, or {@code null} to skip
      */
     private void spawnLandingMarker(LandingPrediction prediction) {
         if (prediction == null || display == null || !display.isValid()) return;
@@ -844,7 +498,6 @@ public class ThrownItem extends SimulatedDisplay {
         if (!isWall) {
             markerPos.add(0, 0.2, 0);
         } else {
-            // Float the marker slightly off the wall surface
             markerPos.add(
                 prediction.face().getModX() * 0.05,
                 prediction.face().getModY() * 0.05,
@@ -869,7 +522,6 @@ public class ThrownItem extends SimulatedDisplay {
         Transformation tr;
         if (!isWall) {
             markerPos.setDirection(thrower.getFlatDir());
-            // Rotate the text face to point upward so the marker lies flat on the ground
             tr = new Transformation(
                 new Vector3f(0, 0, 1.5f),
                 new Quaternionf().rotateX((float) (-Math.PI / 2)),
@@ -886,7 +538,6 @@ public class ThrownItem extends SimulatedDisplay {
         }
         landingMarker.setTransformation(tr);
 
-        // Particle stream from the exact landing point (at ground/wall surface, below the text)
         Location streamBase = prediction.position().clone();
         landingParticleTask = TimeArbiter.runTimeBoundBukkitTaskOnTimer(
             null,
@@ -924,56 +575,17 @@ public class ThrownItem extends SimulatedDisplay {
     /** Holds the precomputed landing position and the block face that was struck. */
     private record LandingPrediction(Location position, BlockFace face) {}
 
-    public void setTimeStep(int timeStep) {
-        this.timeStep.set(timeStep);
-    }
-
-    public Location getOrigin() {
-        return origin.clone();
-    }
-
-    public Location getCur() {
-        return cur.clone();
-    }
-
-    public Location getPrev() {
-        return prev.clone();
-    }
-
-    public Vector getTo() {
-        return to.clone();
-    }
-
-    public Vector getVelocity() {
-        return velocity.clone();
-    }
-
+    // -----------------------------------------------------------------------
+    // Dispose override — also removes the landing marker
+    // -----------------------------------------------------------------------
 
     /**
-     * Disposes of the item by naturally dropping its item form into the world.
-     * <p>
-     * Used after hitting entities or ending its trajectory naturally.
+     * Disposes of the item display, cancels tasks, and removes any landing marker.
      */
-    public void disposeWithNewInteractiveItem() {
-        if (display == null) return;
-
-        final Location dropLocation = hitEntity != null ? hitEntity.self().getLocation() : display.getLocation();
-
-        InteractiveItemArbiter.dropNaturally(dropLocation, display.getItemStack());
-
-        dispose();
-    }
-
-    /**
-     * Cleanly disposes of the item display and cancels any running tasks.
-     * <p>
-     * Should be called when the thrown item is collected or deleted.
-     */
+    @Override
     public void dispose() {
         removeLandingMarker();
-        if (display != null) {
-            display.remove(); // TODO: load chunks whenever something is being despawned.
-        }
-        if (disposeTask != null && !disposeTask.isCancelled()) disposeTask.cancel();
+        super.dispose();
     }
+
 }

--- a/src/main/java/btm/sword/system/action/throwing/types/VisualProjectile.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/VisualProjectile.java
@@ -1,0 +1,743 @@
+package btm.sword.system.action.throwing.types;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.bukkit.FluidCollisionMode;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.ItemDisplay;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.util.RayTraceResult;
+import org.bukkit.util.Transformation;
+import org.bukkit.util.Vector;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+
+import btm.sword.config.Config;
+import btm.sword.system.action.throwing.InteractiveItemArbiter;
+import btm.sword.system.action.throwing.ItemThrowStyle;
+import btm.sword.system.control.PredicateRunnablePair;
+import btm.sword.system.control.SwordScheduler;
+import btm.sword.system.control.TimeArbiter;
+import btm.sword.system.entity.SwordEntityArbiter;
+import btm.sword.system.entity.base.SwordEntity;
+import btm.sword.system.item.KeyRegistry;
+import btm.sword.utility.Debug;
+import btm.sword.utility.Prefab;
+import btm.sword.utility.display.DisplayUtil;
+import btm.sword.utility.display.ParticleWrapper;
+import btm.sword.utility.math.Basis;
+import btm.sword.utility.math.VectorUtil;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * A display-backed simulated projectile with parametric physics.
+ * <p>
+ * Extends {@link SimulatedDisplay} to add trajectory physics, collision detection,
+ * and event hooks. Does not require a {@link btm.sword.system.entity.impl.Combatant}
+ * owner — for thrower-aware behaviour see {@link ThrownItem}.
+ * </p>
+ * <p>
+ * Subclasses override the protected hook methods ({@link #resolveOriginLocation()},
+ * {@link #resolveBasis()}, {@link #resolveFlatDir()}, {@link #resolvePitch()}) to
+ * provide context-specific trajectory parameters.
+ * </p>
+ */
+@Getter
+@Setter
+public class VisualProjectile extends SimulatedDisplay {
+    /** Instructions run on the spawned {@link ItemDisplay} immediately after it exists. */
+    protected Consumer<ItemDisplay> displaySetupInstructions;
+
+    private ParticleWrapper blockTrail;
+
+    /** In-hand display offsets relative to the spawn point, in blocks. */
+    protected float xDisplayOffset;
+    protected float yDisplayOffset;
+    protected float zDisplayOffset;
+
+    /** Current world position of the projectile display. */
+    protected Location origin;
+    protected Location cur;
+    protected Location prev;
+
+    /** Displacement from the previous position to the current one this tick. */
+    protected Vector to;
+    protected Vector velocity;
+
+    /**
+     * Overrides the trajectory direction used by {@link #calculatePhysicsFunctions}.
+     * When non-null, pitch and flat direction are derived from this vector instead of
+     * the thrower's look direction.
+     */
+    protected Vector launchDirection;
+
+    /**
+     * Scales the time parameter fed to {@link #positionFunction}.
+     * Negative value means no scaling (raw tick count is used).
+     */
+    protected double timeScalingFactor = -1;
+    protected double timeCutoff = -1;
+
+    /** Current physics step counter. Main-thread only — do not use AtomicInteger operations off-thread. */
+    protected AtomicInteger timeStep = new AtomicInteger(0);
+
+    protected Basis currentBasis;
+    protected double initialVelocity;
+
+    protected Function<Double, Vector> positionFunction;
+    protected Function<Double, Vector> velocityFunction;
+
+    protected boolean grounded;
+    protected Block stuckBlock;
+    protected ParticleWrapper blockDustPillarParticle;
+
+    protected boolean retrieved;
+    protected boolean hit;
+    protected SwordEntity hitEntity;
+    protected boolean caught;
+    protected boolean inFlight;
+
+    /** When non-null, used by {@link DisplayUtil#itemDisplayFollow} to decide when impalement ends. */
+    protected Predicate<VisualProjectile> exitImpalementStatePredicate;
+
+    protected TimeArbiter.TaskHandle disposeTask;
+    protected boolean setupSuccessful;
+
+    // Event hooks — set before launch, no subclass required for simple use cases
+    /** Called with the hit entity when the projectile strikes a living entity. */
+    public Consumer<SwordEntity> onHitCallback;
+    /** Called when the projectile embeds in a block. */
+    public Runnable onGroundCallback;
+    /** Called when the time cutoff is exceeded. */
+    public Runnable onExpireCallback;
+
+    private ItemThrowStyle throwStyle;
+
+    /**
+     * Spawns the {@link ItemDisplay} at the given location, runs display setup instructions
+     * once successful, and then calls {@link #afterSpawn()}.
+     *
+     * @param spawnLocation the world location at which to spawn the display
+     * @param period        tick interval for the spawn-check polling loop
+     */
+    protected void setup(Location spawnLocation, int period) {
+        TimeArbiter.runTimeIndependentBukkitTaskOnTimer(
+            null,
+            () -> {
+                try {
+                    display = (ItemDisplay) spawnLocation.getWorld().spawnEntity(spawnLocation, EntityType.ITEM_DISPLAY);
+                    displaySetupInstructions.accept(display);
+                    setupSuccessful = true;
+                } catch (Exception e) {
+                    e.addSuppressed(e);
+                }
+            },
+            0, period,
+            VisualProjectile.class, "setup",
+            new PredicateRunnablePair(
+                () -> setupSuccessful,
+                this::afterSpawn
+            )
+        );
+    }
+
+    /**
+     * Called once the {@link ItemDisplay} has been spawned successfully.
+     * Initialises the block-trail particle and resets display offsets from config.
+     */
+    protected void afterSpawn() {
+        blockTrail = display.getItemStack().getType().isBlock()
+            ? new ParticleWrapper(Particle.BLOCK, 5, 0.25, 0.25, 0.25,
+                display.getItemStack().getType().createBlockData())
+            : null;
+
+        xDisplayOffset = Config.Physics.THROWN_ITEMS_DISPLAY_OFFSET_X;
+        yDisplayOffset = Config.Physics.THROWN_ITEMS_DISPLAY_OFFSET_Y;
+        zDisplayOffset = Config.Physics.THROWN_ITEMS_DISPLAY_OFFSET_Z;
+    }
+
+    /**
+     * Sets {@link #timeScalingFactor} so that {@code numberOfIterations} ticks span the full cutoff.
+     *
+     * @param numberOfIterations desired number of physics steps
+     */
+    public void setTimeScalingFactor(double numberOfIterations) {
+        this.timeScalingFactor = (this.timeCutoff > 0 ? timeCutoff : 1) / numberOfIterations;
+    }
+
+    /**
+     * Initializes flight state: generates physics functions, fires release actions, resets display offsets.
+     * <p>
+     * Called by {@link #onRelease(double)} and overridden in {@link ThrownItem} to prepend player-specific logic.
+     *
+     * @param initialVelocity the starting velocity magnitude
+     */
+    public void initFlight(double initialVelocity) {
+        generateFunctions(initialVelocity);
+        handleOnReleaseActions();
+        xDisplayOffset = yDisplayOffset = zDisplayOffset = 0;
+        determineOrientation();
+    }
+
+    /**
+     * Executes one physics tick: apply functions, teleport display, rotate, emit particles, evaluate collisions.
+     */
+    protected void tickFlight() {
+        applyFunctions();
+
+        if (!prev.equals(cur) && cur.clone().subtract(prev).toVector().dot(velocity) > 0) {
+            DisplayUtil.setSmoothTeleportDuration(display, 1);
+        }
+
+        teleport();
+        rotate();
+
+        Prefab.Particles.THROW_TRAIl.display(prev); // TODO: #119 - Make type of particles dynamic
+        if (blockTrail != null && timeStep.get() % 3 == 0) // TODO: #119 - Make period dynamic
+            blockTrail.display(prev);
+
+        evaluate();
+        prev = cur.clone();
+        timeStep.incrementAndGet();
+    }
+
+    /**
+     * Runs one physics tick and returns {@code true} if the flight is over.
+     * <p>
+     * Used by FSM state classes (e.g. LungingState) to drive physics synchronously from {@code onTick()}.
+     *
+     * @return {@code true} when a termination condition is met
+     */
+    public boolean stepFlight() {
+        tickFlight();
+        return grounded || hit || caught || display.isDead()
+            || (timeCutoff > 0 && timeStep.get() * timeScalingFactor > timeCutoff);
+    }
+
+    /**
+     * Releases the projectile and starts the self-contained physics loop.
+     *
+     * @param initialVelocity the starting velocity magnitude
+     */
+    public void onRelease(double initialVelocity) {
+        initFlight(initialVelocity);
+
+        TimeArbiter.runTimeBoundBukkitTaskOnTimer(
+            null,
+            this::tickFlight,
+            null,
+            0, 50,
+            VisualProjectile.class, "onRelease",
+            new PredicateRunnablePair(
+                () -> grounded || hit || caught || display.isDead()
+                    || (timeCutoff > 0 && timeStep.get() * timeScalingFactor > timeCutoff),
+                this::onEnd
+            )
+        );
+    }
+
+    /**
+     * Teleports the display to {@link #cur}, pointing in the direction appropriate for this item's throw style.
+     */
+    protected void teleport() {
+        ItemThrowStyle style = getThrowStyle();
+        if (style == ItemThrowStyle.SPEAR || style == ItemThrowStyle.HATCHET) {
+            TimeArbiter.teleportDisplay(display, cur, velocity, 2, VisualProjectile.class, 201);
+        } else {
+            TimeArbiter.teleportDisplay(display, cur, currentBasis.forward(), 2, VisualProjectile.class, 203);
+        }
+    }
+
+    /**
+     * Advances the position and velocity from the parametric functions.
+     */
+    protected void applyFunctions() {
+        double time = timeScalingFactor < 0 ? timeStep.get() : timeStep.get() * timeScalingFactor;
+        cur = origin.clone().add(positionFunction.apply(time));
+        if (prev != null) to = cur.clone().subtract(prev).toVector();
+        velocity = velocityFunction.apply(time);
+    }
+
+    /**
+     * Applies the item's spin rotation each tick based on its {@link ItemThrowStyle}.
+     */
+    protected void rotate() {
+        switch (getThrowStyle()) {
+            case SPEAR -> {}
+            case HATCHET -> applyRotation(false, (float) Config.Physics.THROWN_ITEMS_ROTATION_SPEED_AXE);
+            case LOB -> applyRotation(true, (float) (Config.Physics.THROWN_ITEMS_ROTATION_SPEED_DEFAULT_SPEED * 0.4));
+            default -> applyRotation(true, (float) Config.Physics.THROWN_ITEMS_ROTATION_SPEED_DEFAULT_SPEED);
+        }
+    }
+
+    private void applyRotation(boolean rotateX, float speed) {
+        Transformation curTr = display.getTransformation();
+        Quaternionf curRotation = curTr.getLeftRotation();
+        Quaternionf newRotation = rotateX ? curRotation.rotateX(speed) : curRotation.rotateZ(speed);
+        display.setTransformation(new Transformation(
+            curTr.getTranslation(), newRotation, curTr.getScale(), curTr.getRightRotation()
+        ));
+    }
+
+    /**
+     * Called when the flight loop ends. Delegates to the appropriate outcome handler.
+     */
+    protected void onEnd() {
+        if (caught) onCatch();
+        else if (hit) onHit();
+        else if (grounded) onGrounded();
+        else if (onExpireCallback != null) onExpireCallback.run();
+        timeStep.set(0);
+    }
+
+    /**
+     * Called when the projectile hits a living entity.
+     * Base implementation invokes {@link #onHitCallback} if set.
+     */
+    public void onHit() {
+        if (onHitCallback != null && hitEntity != null) onHitCallback.accept(hitEntity);
+    }
+
+    /**
+     * Called when the projectile embeds in a block.
+     * Base implementation positions the display at the impact site and schedules disposal.
+     */
+    protected void onGrounded() {
+        if (stuckBlock != null) {
+            new ParticleWrapper(Particle.BLOCK, 50, 1, 1, 1, stuckBlock.getBlockData()).display(cur);
+        }
+
+        Vector step = velocity.clone().normalize().multiply(0.1);
+        Location probe = cur.clone();
+        Vector backwards = velocity.normalize().multiply(-0.1);
+
+        int x = 1;
+        while (!probe.getBlock().isPassable()) {
+            probe.add(backwards);
+            if (++x > 30) break;
+        }
+
+        SwordScheduler.runBukkitTaskLater(() -> {
+            Location land = probe.clone();
+            land.setDirection(to.normalize());
+            TimeArbiter.teleportDisplay(display, land, null, 1, VisualProjectile.class, 267);
+        }, 51, TimeUnit.MILLISECONDS);
+
+        startGroundedDisposeTask(step);
+
+        if (onGroundCallback != null) onGroundCallback.run();
+    }
+
+    /**
+     * Schedules the disposal timer that shows grounded-item marker particles until the display is removed.
+     *
+     * @param step the half-step vector used to place the three marker particles
+     */
+    protected void startGroundedDisposeTask(Vector step) {
+        AtomicInteger iteration = new AtomicInteger(0);
+        disposeTask = TimeArbiter.runTimeBoundBukkitTaskOnTimer(
+            null,
+            () -> {
+                Prefab.Particles.THROWN_ITEM_MARKER.display(cur.clone().add(step));
+                Prefab.Particles.THROWN_ITEM_MARKER.display(cur);
+                Prefab.Particles.THROWN_ITEM_MARKER.display(cur.clone().subtract(step));
+                iteration.set(iteration.get() + Config.Timing.THROWN_ITEMS_DISPOSAL_CHECK_INTERVAL);
+            },
+            null,
+            1, Config.Timing.THROWN_ITEMS_DISPOSAL_CHECK_INTERVAL,
+            VisualProjectile.class, "startGroundedDisposeTask",
+            new PredicateRunnablePair(() -> display.isDead(), null),
+            new PredicateRunnablePair(
+                () -> iteration.get() > Config.Timing.THROWN_ITEMS_DISPOSAL_TIMEOUT,
+                () -> { if (!display.isDead()) display.remove(); }
+            )
+        );
+    }
+
+    /**
+     * Called when the projectile is caught by the owner entity. Base implementation disposes the display.
+     */
+    protected void onCatch() {
+        dispose();
+    }
+
+    /**
+     * Evaluates collision state each tick. Short-circuits if a terminal state is already set.
+     */
+    public void evaluate() {
+        if (hit || grounded || caught) return;
+        hitCheck();
+        groundedCheck();
+    }
+
+    /**
+     * Checks whether the projectile has embedded in a block this tick.
+     */
+    public void groundedCheck() {
+        RayTraceResult hitBlock = display.getWorld()
+            .rayTraceBlocks(cur, velocity,
+                cur.toVector().subtract(prev.toVector()).lengthSquared()
+                    * Config.Detection.THROW_GROUND_CHECK_MULTIPLIER,
+                FluidCollisionMode.NEVER, true);
+
+        if (hitBlock == null) return;
+        if (hitBlock.getHitBlock() == null || hitBlock.getHitBlock().getType().isAir()) return;
+
+        grounded = true;
+        stuckBlock = hitBlock.getHitBlock();
+        cur = hitBlock.getHitPosition().toLocation(display.getWorld());
+    }
+
+    /**
+     * Checks for entity collision via raytrace from the previous to the current position.
+     * Catch detection uses {@link #isOwnerEntity(LivingEntity)} so subclasses can identify their owner.
+     */
+    public void hitCheck() {
+        Predicate<Entity> effFilter = getFilter();
+
+        if (prev == null) {
+            disposeWithNewInteractiveItem();
+            return;
+        }
+
+        RayTraceResult result = display.getWorld()
+            .rayTraceEntities(prev, velocity,
+                cur.toVector().subtract(prev.toVector()).lengthSquared()
+                    * Config.Detection.THROW_HIT_CHECK_DIST_MULTIPLIER,
+                Config.Detection.THROW_HIT_CHECK_DIST_MULTIPLIER, effFilter);
+
+        if (result == null) return;
+        if (!(result.getHitEntity() instanceof LivingEntity le)) return;
+
+        if (isOwnerEntity(le)) {
+            caught = true;
+        } else {
+            hit = true;
+            this.hitEntity = SwordEntityArbiter.getOrAdd(le);
+        }
+    }
+
+    /**
+     * Returns {@code true} if the given entity is the owner of this projectile.
+     * Base returns {@code false} (no owner). Override in {@link ThrownItem} to use the thrower.
+     *
+     * @param entity the candidate entity
+     * @return whether the entity is considered the owner/thrower
+     */
+    protected boolean isOwnerEntity(LivingEntity entity) {
+        return false;
+    }
+
+    /**
+     * Returns the entity filter applied during raytrace hit detection.
+     * Base excludes the display entity and dead entities.
+     *
+     * @return the filter predicate
+     */
+    protected Predicate<Entity> getFilter() {
+        return entity ->
+            entity.getUniqueId() != display.getUniqueId()
+                && (entity instanceof LivingEntity l)
+                && !l.isDead();
+    }
+
+    /**
+     * Applies a material-based {@link Transformation} to the display so items are correctly oriented,
+     * taking display-offset fields into account.
+     */
+    @Override
+    public void determineOrientation() {
+        if (display == null) {
+            Debug.combatDebug(VisualProjectile.class, 463, "Display was null... determineOrientation()");
+            return;
+        }
+
+        String name = display.getItemStack().getType().toString();
+        Vector3f base = new Vector3f(xDisplayOffset, yDisplayOffset, zDisplayOffset);
+
+        if (name.endsWith("_SWORD")) {
+            display.setTransformation(new Transformation(
+                base.add(new Vector3f()),
+                new Quaternionf().rotateY((float) Math.PI / 2).rotateZ((float) Math.PI / 2),
+                new Vector3f(1, 1, 1),
+                new Quaternionf()
+            ));
+        } else if (name.endsWith("AXE") || name.endsWith("_HOE") || name.endsWith("_SHOVEL")) {
+            display.setTransformation(new Transformation(
+                base.add(new Vector3f()),
+                new Quaternionf().rotateY((float) -Math.PI / 2).rotateZ((float) Math.PI / 4),
+                new Vector3f(1.5f, 1.5f, 1.5f),
+                new Quaternionf()
+            ));
+        } else if (display.getItemStack().getType() == Material.SHIELD) {
+            display.setTransformation(new Transformation(
+                base.add(new Vector3f(0, 0, 0)),
+                new Quaternionf().rotateY((float) (Math.PI / 1.01f) * 0),
+                new Vector3f(1, 1, 1),
+                new Quaternionf()
+            ));
+        } else {
+            display.setTransformation(new Transformation(
+                base.add(new Vector3f()),
+                new Quaternionf().rotateZ((float) Math.PI / 8),
+                new Vector3f(1, 1, 1),
+                new Quaternionf()
+            ));
+        }
+    }
+
+    /**
+     * Returns the {@link ItemThrowStyle} for this item, reading PDC first, then falling back to material.
+     * Result is cached after the first call.
+     *
+     * @return the throw style
+     */
+    protected ItemThrowStyle getThrowStyle() {
+        if (throwStyle != null) return throwStyle;
+        if (itemStack != null && !itemStack.isEmpty()) {
+            String stored = KeyRegistry.getKeyField(itemStack, KeyRegistry.THROW_STYLE_KEY, PersistentDataType.STRING);
+            if (stored != null) {
+                try {
+                    throwStyle = ItemThrowStyle.valueOf(stored);
+                    return throwStyle;
+                } catch (IllegalArgumentException ignored) {}
+            }
+        }
+        throwStyle = deriveThrowStyle();
+        return throwStyle;
+    }
+
+    private ItemThrowStyle deriveThrowStyle() {
+        if (itemStack == null || itemStack.isEmpty()) return ItemThrowStyle.PITCH;
+        String name = itemStack.getType().toString();
+        if (name.endsWith("_SWORD")) return ItemThrowStyle.SPEAR;
+        if (name.endsWith("_AXE") || name.endsWith("_HOE")
+            || name.endsWith("_SHOVEL") || name.endsWith("_PICKAXE")) return ItemThrowStyle.HATCHET;
+        if (itemStack.getType().isBlock()) return ItemThrowStyle.LOB;
+        return ItemThrowStyle.PITCH;
+    }
+
+    /**
+     * Marks this projectile as retrieved, then schedules a reset after 60 ms.
+     *
+     * @param retrieved the retrieved state
+     */
+    public void setRetrieved(boolean retrieved) {
+        this.retrieved = retrieved;
+        SwordScheduler.runBukkitTaskLater(() -> setRetrieved(false), 60, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Registers this projectile with {@link InteractiveItemArbiter}, then removes it and
+     * drops a new interactable item at the hit or current location.
+     */
+    public void disposeWithNewInteractiveItem() {
+        if (display == null) return;
+        Location dropLocation = hitEntity != null ? hitEntity.self().getLocation() : display.getLocation();
+        InteractiveItemArbiter.dropNaturally(dropLocation, display.getItemStack());
+        dispose();
+    }
+
+    /**
+     * Cleans up the display and cancels any pending tasks.
+     */
+    @Override
+    public void dispose() {
+        if (display != null) {
+            display.remove();
+        }
+        if (disposeTask != null && !disposeTask.isCancelled()) disposeTask.cancel();
+    }
+
+    /**
+     * Registers this projectile with {@link InteractiveItemArbiter}.
+     * Subclasses may override to add additional release actions (e.g., clearing the thrower's hand).
+     */
+    protected void handleOnReleaseActions() {
+        InteractiveItemArbiter.put(this);
+    }
+
+    /**
+     * Damages the held item on a successful throw hit. Base is a no-op; overridden in {@link ThrownItem}.
+     */
+    public void handleItemDamageAndCheckIfBroken() {
+        // no-op in base; ThrownItem implements with thrower attribution
+    }
+
+    /**
+     * Delegates to {@link #calculatePhysicsFunctions(double)}.
+     * Overriding in subclasses (e.g. UmbralBlade) swaps in alternate trajectory math.
+     *
+     * @param initialVelocity the starting speed
+     */
+    protected void generateFunctions(double initialVelocity) {
+        calculatePhysicsFunctions(initialVelocity);
+    }
+
+    /**
+     * Computes the {@link #positionFunction} and {@link #velocityFunction} for a parabolic throw.
+     * Uses hook methods to resolve origin, direction, and pitch so subclasses can supply their own values.
+     *
+     * @param initialVelocity the starting speed
+     */
+    private void calculatePhysicsFunctions(double initialVelocity) {
+        this.initialVelocity = initialVelocity;
+
+        this.currentBasis = resolveBasis();
+
+        double min = Math.toRadians(-89);
+        double max = Math.toRadians(89);
+        double phi = Math.max(min, Math.min(max, resolvePitch()));
+
+        double cosPhi = Math.cos(phi);
+        double sinPhi = Math.sin(phi);
+        double forwardCoefficient = initialVelocity * cosPhi;
+        double upwardCoefficient = initialVelocity * sinPhi;
+
+        origin = resolveOriginLocation();
+        cur = origin.clone();
+        prev = cur.clone();
+
+        Vector flatDir = resolveFlatDir();
+        velocity = flatDir.clone();
+        Vector forwardVelocity = flatDir.clone().multiply(forwardCoefficient);
+        Vector upwardVelocity = Config.Direction.UP().multiply(upwardCoefficient);
+
+        double gravDamper = Config.Physics.THROWN_ITEMS_GRAVITY_DAMPER;
+
+        positionFunction = t -> flatDir.clone().multiply(forwardCoefficient * t)
+            .add(Config.Direction.UP().multiply(
+                (upwardCoefficient * t) - (initialVelocity * (1.0 / gravDamper) * t * t)));
+
+        velocityFunction = t -> forwardVelocity.clone()
+            .add(upwardVelocity.clone()
+                .add(Config.Direction.UP().multiply(-initialVelocity * (2.0 / gravDamper) * t)));
+    }
+
+    // -----------------------------------------------------------------------
+    // Hook methods — override in ThrownItem to supply thrower-derived values
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns the world location at which the trajectory originates.
+     * Requires {@link #origin} to be pre-set if not overridden.
+     *
+     * @return the origin location (must not be null)
+     */
+    protected Location resolveOriginLocation() {
+        if (origin != null) return origin.clone();
+        throw new IllegalStateException("VisualProjectile requires origin to be set or resolveOriginLocation() to be overridden");
+    }
+
+    /**
+     * Returns the horizontal basis (yaw only) for the projectile's local coordinate frame.
+     * Requires {@link #launchDirection} to be set if not overridden.
+     *
+     * @return the basis
+     */
+    protected Basis resolveBasis() {
+        if (launchDirection != null) {
+            float yaw = (float) Math.toDegrees(Math.atan2(-launchDirection.getX(), launchDirection.getZ()));
+            Location temp = new Location(
+                origin != null ? origin.getWorld() : null,
+                0, 0, 0, yaw, 0);
+            return VectorUtil.getBasisWithoutPitch(temp);
+        }
+        throw new IllegalStateException("VisualProjectile requires launchDirection or overridden resolveBasis()");
+    }
+
+    /**
+     * Returns the normalized horizontal direction vector for the throw.
+     * Requires {@link #launchDirection} to be set if not overridden.
+     *
+     * @return the flat direction (Y component should be zero)
+     */
+    protected Vector resolveFlatDir() {
+        if (launchDirection != null) return launchDirection.clone().setY(0).normalize();
+        throw new IllegalStateException("VisualProjectile requires launchDirection or overridden resolveFlatDir()");
+    }
+
+    /**
+     * Returns the vertical angle (radians) of the throw, positive = upward.
+     * Requires {@link #launchDirection} to be set if not overridden.
+     *
+     * @return the pitch in radians
+     */
+    protected double resolvePitch() {
+        if (launchDirection != null) {
+            Vector nd = launchDirection.clone().normalize();
+            double horiz = Math.sqrt(nd.getX() * nd.getX() + nd.getZ() * nd.getZ());
+            return Math.atan2(nd.getY(), horiz);
+        }
+        throw new IllegalStateException("VisualProjectile requires launchDirection or overridden resolvePitch()");
+    }
+
+    // -----------------------------------------------------------------------
+    // Position accessors (defensive copies)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Sets the physics step counter to the given value.
+     *
+     * @param timeStep the new step count
+     */
+    public void setTimeStep(int timeStep) {
+        this.timeStep.set(timeStep);
+    }
+
+    /**
+     * Returns a clone of the trajectory origin.
+     *
+     * @return the origin location
+     */
+    public Location getOrigin() {
+        return origin.clone();
+    }
+
+    /**
+     * Returns a clone of the current position.
+     *
+     * @return the current location
+     */
+    public Location getCur() {
+        return cur.clone();
+    }
+
+    /**
+     * Returns a clone of the previous position.
+     *
+     * @return the previous location
+     */
+    public Location getPrev() {
+        return prev.clone();
+    }
+
+    /**
+     * Returns a clone of the displacement vector from the previous to current position.
+     *
+     * @return the displacement vector
+     */
+    public Vector getTo() {
+        return to.clone();
+    }
+
+    /**
+     * Returns a clone of the current velocity vector.
+     *
+     * @return the velocity
+     */
+    public Vector getVelocity() {
+        return velocity.clone();
+    }
+}

--- a/src/main/java/btm/sword/system/attack/MobSweepAttack.java
+++ b/src/main/java/btm/sword/system/attack/MobSweepAttack.java
@@ -1,0 +1,33 @@
+package btm.sword.system.attack;
+
+import org.bukkit.inventory.ItemStack;
+
+import btm.sword.system.attack.style.AttackProfile;
+import btm.sword.utility.Prefab;
+
+/**
+ * A sweep attack used by hostile mobs.
+ *
+ * <p>Extends {@link SweepAttack} and overrides {@link #hit()} to apply
+ * {@link btm.sword.utility.Prefab.Attacks#defaultMobHit} instead of the default player hit packet.
+ */
+public class MobSweepAttack extends SweepAttack {
+
+    /**
+     * Constructs a {@code MobSweepAttack}.
+     *
+     * @param itemUsedInAttack the item used in the attack
+     * @param profile          the {@link AttackProfile} defining the sweep path and knockback
+     * @param orientWithPitch  whether to orient the attack with the attacker's pitch
+     */
+    public MobSweepAttack(ItemStack itemUsedInAttack, AttackProfile profile, boolean orientWithPitch) {
+        super(itemUsedInAttack, profile, orientWithPitch);
+    }
+
+    @Override
+    protected void hit() {
+        currentTarget.hit(attacker, Prefab.Attacks.defaultMobHit,
+            attackProfile.knockbackFunction().apply(this));
+        Prefab.Particles.TEST_HIT.display(currentTarget.getChestLocation());
+    }
+}

--- a/src/main/java/btm/sword/system/entity/ai/HostileStateMachine.java
+++ b/src/main/java/btm/sword/system/entity/ai/HostileStateMachine.java
@@ -138,11 +138,11 @@ public class HostileStateMachine extends StateMachine<Hostile> {
             h -> h.setFrontSlot(false)
         ));
 
-        // 8. PreAttackState → AttackState: wind-up timer expired
+        // 8. PreAttackState → AttackState: wind-up timer expired and mob is not incapacitated
         addTransition(new Transition<>(
             PreAttackState.class,
             AttackState.class,
-            h -> h.getPreAttackTimer() <= 0,
+            h -> h.getPreAttackTimer() <= 0 && !h.isIncapacitated(),
             h -> {}
         ));
 
@@ -203,18 +203,8 @@ public class HostileStateMachine extends StateMachine<Hostile> {
             }
         ));
 
-        // 13. AttackState → ApproachState: target escaped aggro range before attack landed
-        addTransition(new Transition<>(
-            AttackState.class,
-            ApproachState.class,
-            h -> {
-                if (h.isAttackDone()) return false;
-                if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return true;
-                return h.self().getLocation()
-                    .distanceSquared(h.getCurrentTarget().self().getLocation()) > Config.Hostile.AGGRO_RANGE_SQUARED;
-            },
-            h -> {}
-        ));
+        // 13. (removed) AttackState → ApproachState on target escape is obsolete:
+        //     attack now fires immediately on entry, so attackDone is always true before any tick.
 
         // 14. OnGuardState → PreAttackState: on-guard timer expired and target still in range
         addTransition(new Transition<>(

--- a/src/main/java/btm/sword/system/entity/ai/README.md
+++ b/src/main/java/btm/sword/system/entity/ai/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This package implements a finite state machine (FSM) driven AI for `Hostile` entities. It governs every phase of enemy behaviour — idle patrol, player detection, approach, group coordination, attack wind-up, attack execution, three post-attack branches, and low-health flight — through nine concrete states wired together with twenty transitions.
+This package implements a finite state machine (FSM) driven AI for `Hostile` entities. It governs every phase of enemy behaviour — idle patrol, player detection, approach, group coordination, attack wind-up, attack execution, three post-attack branches, and low-health flight — through nine concrete states wired together with nineteen transitions.
 
 The design mirrors the `UmbralBlade` FSM found in `system/entity/umbral/statemachine/`. `HostileAIFacade` plays the same role as `UmbralStateFacade`: a common abstract base that enables wildcard transitions (transitions whose `from` type matches any concrete state in the machine). The generic `StateMachine<T>` / `State<T>` / `Transition<T>` infrastructure in `utility/statemachine/` is shared between both machines without modification.
 
@@ -34,12 +34,12 @@ The design mirrors the `UmbralBlade` FSM found in `system/entity/umbral/statemac
            |       v        v                                  |
            |   +------------+--+                               |
            |   |  PRE_ATTACK   |                               |
-           |   +---------------+                               |
+           |   +---------------+  <- mob moves during wind-up  |
            |          |                                        |
-           |          | [pre_attack_timer <= 0]                |
+           |          | [timer <= 0 && !incapacitated]         |
            |          v                                        |
            |      +--------+                                   |
-           |      | ATTACK |                                   |
+           |      | ATTACK |  <- fires ability immediately      |
            |      +---+----+                                   |
            |          |                                        |
            |          | [attack landed]                        |
@@ -55,9 +55,6 @@ The design mirrors the `UmbralBlade` FSM found in `system/entity/umbral/statemac
            |        |           |                              |
            +--------+-----------+  [target in range] -> PRE_ATTACK
                     |              [target lost]     -> IDLE (above)
-                    |
-                    | [target left range before attack lands]
-                    +----> APPROACH
 
   ANY STATE --[health < flee_health_fraction]--> +------+
                                                  | FLEE |
@@ -69,9 +66,8 @@ The design mirrors the `UmbralBlade` FSM found in `system/entity/umbral/statemac
   ANY STATE --[target switches to creative/spectator]--> IDLE
 ```
 
-Transitions `SURROUND → APPROACH` (ally count drops), `ATTACK → APPROACH` (target escapes mid-charge),
-and the `RETREAT` sub-graph (orphaned but retained) are omitted from the ASCII art for readability;
-see the transition table below.
+Transitions `SURROUND → APPROACH` (ally count drops) and the `RETREAT` sub-graph (orphaned but retained)
+are omitted from the ASCII art for readability; see the transition table below.
 
 ---
 
@@ -86,12 +82,12 @@ see the transition table below.
 | 5 | `ApproachState` | `PreAttackState` | `distanceSquared(target) < APPROACH_DISTANCE_SQUARED` | None |
 | 6 | `SurroundState` | `ApproachState` | `nearbyAlliesCount < SURROUND_MIN_ALLIES` | None |
 | 7 | `SurroundState` | `PreAttackState` | `isFrontSlot()` | Set `frontSlot = false` |
-| 8 | `PreAttackState` | `AttackState` | `preAttackTimer <= 0` | None |
+| 8 | `PreAttackState` | `AttackState` | `preAttackTimer <= 0` **AND** `!isIncapacitated()` | None |
 | 9 | `AttackState` | `OnGuardState` | `isAttackDone() && attackPostRoll == 0` AND target in aggro range | None |
 | 10 | `AttackState` | `AttackReadyState` | `isAttackDone() && attackPostRoll == 1` AND target in aggro range | None |
 | 11 | `AttackState` | `AttackState` (combo) | `isAttackDone() && attackPostRoll == 2` AND target in aggro range | Set `combo = true` |
 | 12 | `AttackState` | `IdleState` | `isAttackDone()` AND target lost or left aggro range | Clear `currentTarget`; clear `aggroTarget` only if target is dead/invalid |
-| 13 | `AttackState` | `ApproachState` | Attack NOT done AND target invalid or `distanceSquared > AGGRO_RANGE_SQUARED` | None |
+| ~~13~~ | ~~`AttackState` → `ApproachState`~~ | *(removed)* | Was: attack not done AND target escaped — obsolete because `attackDone` is always set on `AttackState` entry | |
 | 14 | `OnGuardState` | `PreAttackState` | `onGuardTimer <= 0` AND target still in aggro range | None |
 | 15 | `OnGuardState` | `IdleState` | `onGuardTimer <= 0` AND target lost or left aggro range | Clear `currentTarget`; clear `aggroTarget` only if target dead/invalid |
 | 16 | `AttackReadyState` | `AttackState` | `attackReadyTimer <= 0` AND target in aggro range | None |
@@ -123,19 +119,33 @@ The mob is part of a coordinated group attack. Every 20 ticks each mob in the gr
 
 ### `PreAttackState`
 
-The mob has committed to an attack. Pathfinding stops immediately. On entry: `TRIAL_SPAWNER_DETECTION_OMINOUS` particles are spawned at the mob's eye location (count 25, spread 0.4), and `BLOCK_TRIAL_SPAWNER_AMBIENT_OMINOUS` sound is broadcast to all players within 20 blocks. The `preAttackTimer` is set to `PRE_ATTACK_TICKS` and counts down by 1 each tick. Throughout the wind-up, `Mob.lookAt()` is called with maximum yaw and pitch speed so the mob continuously faces its target. When the timer reaches zero, transition #8 fires.
+The mob has committed to an attack. On entry:
+
+1. `preAttackTimer` is set to `PRE_ATTACK_TICKS`.
+2. `selectAbility()` is called to pick a `MobAbility` from the available (non-cooldown) pool and store it in `pendingAbility`.
+3. `TRIAL_SPAWNER_DETECTION_OMINOUS` particles are spawned at the mob's eye location (count 25, spread 0.4), and `PRE_ATTACK` sound is broadcast to all players within 10 blocks.
+4. Depending on the selected ability's category, a movement goal is registered:
+   - **`MELEE`**: `ApproachGoal` (MOVE, priority 1) + `LookAtTargetGoal` (LOOK, priority 2) — mob closes in on the target during the wind-up.
+   - **`RANGED`**: `PreAttackRetreatGoal` (MOVE, priority 1) + `LookAtTargetGoal` (LOOK, priority 2) — mob retreats from the target during the wind-up.
+   - **No ability available**: pathfinding stops; mob holds position.
+
+The `preAttackTimer` counts down by 1 each tick. When it reaches zero (and the mob is not incapacitated), transition #8 fires. On exit, all MOVE and LOOK goals are removed.
+
+This design makes attack timing predictable from the telegraph: the mob **moves** during the wind-up and fires the ability **immediately** when the timer expires — the player's cue is the wind-up start, not a proximity threshold.
 
 ### `AttackState`
 
-The mob charges toward its target at 160% speed via `AttackChargeGoal`. On entry, if the `combo` flag is set, a `Particle.CRIT` burst (8 particles) is spawned at the mob's eye location to signal the combo continuation, and `combo` is immediately reset to `false`.
+On entry, if the `combo` flag is set, a `Particle.CRIT` burst (8 particles) is spawned at the mob's eye location to signal the combo continuation, and `combo` is immediately reset to `false`.
 
-Each tick, once the distance squared drops to 6.25 (2.5-block melee reach), `Hostile.randomAttack()` is called, `attackDone` is set to `true`, and `attackPostRoll` is set to a random integer 0–2. Three post-attack branches are selected by the roll:
+**Incapacitation guard**: if `isIncapacitated()` is `true` (e.g., the mob was grabbed during pre-attack), the ability is not executed and `attackDone` is **not** set. The transition out of `AttackState` requires `attackDone = true`, so the state holds until the mob is released and the post-attack roll fires on the next re-entry attempt.
+
+Otherwise, `pendingAbility.execute(h)` is called immediately — no charge, no distance gate — then `setAbilityCooldown()` sets the per-ability cooldown, `attackDone` is set to `true`, and `attackPostRoll` is set to a random integer 0–2. Three post-attack branches are selected by the roll:
 
 - **Roll 0** → `OnGuardState` (transition #9): back off and strafe laterally.
 - **Roll 1** → `AttackReadyState` (transition #10): pause and telegraph a follow-up.
 - **Roll 2** → `AttackState` (combo, transition #11): immediate re-entry with a crit visual.
 
-If the attack lands but the target has left aggro range, transition #12 returns to `IdleState`. If the target escapes before melee reach is achieved (attack not yet done), transition #13 re-enters `ApproachState`.
+If the attack lands but the target has left aggro range, transition #12 returns to `IdleState`.
 
 ### `OnGuardState`
 
@@ -161,6 +171,56 @@ The mob's health has dropped below `FLEE_HEALTH_FRACTION` of its maximum. `curre
 
 ---
 
+## MobAbility System
+
+`MobAbility` (interface, `ability/`) is the abstraction for what a mob does at the end of its wind-up. Each ability declares:
+
+| Method | Purpose |
+|--------|---------|
+| `name()` | Unique string key; used as the cooldown map key in `Hostile.abilityCooldowns` |
+| `category()` | `AbilityCategory.MELEE` or `AbilityCategory.RANGED` — controls movement during pre-attack |
+| `canUse(Hostile)` | Returns `true` if the cooldown has elapsed and preconditions are met |
+| `execute(Hostile)` | Performs the ability — called once on `AttackState` entry |
+| `cooldownTicks()` | How many ticks must pass before the ability can be selected again |
+
+**Built-in abilities:**
+
+| Class | Category | Description |
+|-------|----------|-------------|
+| `MobSlashAbility` | `MELEE` | Randomly selects `SLASH1`/`SLASH2`/`SLASH3` and runs a `MobSweepAttack` with `defaultMobHit` |
+| `MobThrowAbility` | `RANGED` | Launches the mob's off-hand item as a `DroppedItem` with a parabolic arc toward the target |
+
+**Selection flow in `PreAttackState.onEnter`:**
+1. `selectAbility()` filters `possibleAbilities` by `canUse()` and picks one at random; stores it in `pendingAbility`.
+2. If no ability is available, `pendingAbility = null` and pathfinding stops.
+3. If an ability is selected, its `category()` determines which movement goal is registered.
+
+**Execution flow in `AttackState.onEnter`:**
+1. Guard: `if (isIncapacitated()) return;`
+2. `pendingAbility.execute(h)` fires the ability.
+3. `setAbilityCooldown(pendingAbility.name(), pendingAbility.cooldownTicks())` starts the cooldown.
+4. `attackDone = true`, `attackPostRoll` is rolled.
+
+**Cooldown tracking:** `Hostile.abilityCooldowns` is a `HashMap<String, Integer>` decremented every tick in `tickAbilityCooldowns()`. Entries are removed (not zeroed) when they reach 0, so `canUse()` checks `cooldowns.get(name()) == null || cooldown <= 0`.
+
+---
+
+## Grab Incapacitation
+
+When a `Hostile` is grabbed by a `Combatant`, `SwordEntity.onGrabbed()` is called (wired in `Combatant.onGrab()`), which triggers `Hostile.onGrabbed()`:
+
+- Sets `incapacitated = true`
+- Calls `mob.setAware(false)` — stops all pathfinding
+- Calls `MobGoalArbiter.GOALS.removeAllGoals(mob, GoalType.MOVE)` — clears any active movement goals
+
+When released (`onGrabLetGo` or `onGrabThrow`), `Hostile.onReleased()`:
+- Sets `incapacitated = false`
+- Calls `mob.setAware(true)` — re-enables pathfinding
+
+The FSM continues to tick during incapacitation. Transition #8 (`PreAttackState → AttackState`) has an `!isIncapacitated()` guard so the attack cannot fire while the mob is held. The `AttackState.onEnter` also has a guard: if incapacitated on entry (rare edge case), the ability is not executed and `attackDone` is not set, keeping the state stable until the mob is released and the next re-entry attempt.
+
+---
+
 ## Cadence Table
 
 | Timer field | Owner state(s) | Cadence | Action |
@@ -169,7 +229,7 @@ The mob's health has dropped below `FLEE_HEALTH_FRACTION` of its maximum. `curre
 | `aggroScanTimer` | `IdleState` | 10 ticks (0.5 s) | Scan for nearby players; set `nearestScannedTarget` |
 | `allyScanTimer` | `ApproachState`, `SurroundState` | 20 ticks (1 s) | Count allies targeting the same player; recompute arc in `SurroundState` |
 | `fleeScanTimer` | `FleeState` | 20 ticks (1 s) | Recalculate flee direction toward nearest player |
-| `preAttackTimer` | `PreAttackState` | counts down from `PRE_ATTACK_TICKS` | Fires attack on reaching 0 |
+| `preAttackTimer` | `PreAttackState` | counts down from `PRE_ATTACK_TICKS` | Fires ability on reaching 0 (if not incapacitated) |
 | `retreatTimer` | `RetreatState` | counts down from `RETREAT_TICKS` | Allows re-engage on reaching 0 |
 | `onGuardTimer` | `OnGuardState` | counts down from `ON_GUARD_TICKS` | Allows re-engage on reaching 0 |
 | `attackReadyTimer` | `AttackReadyState` | counts down from `ATTACK_READY_TICKS` | Triggers follow-up attack on reaching 0 |
@@ -185,6 +245,15 @@ Timers that count upward reset to zero at their cadence threshold and are stored
 3. If the state requires its own timer or flag, add the field (and Lombok annotations) to `Hostile.java`.
 4. Add any config values needed to `Config.Hostile` (see the section below).
 5. All concrete state classes must have a public no-argument constructor because `StateMachine.createState()` instantiates them via `clazz.getDeclaredConstructor().newInstance()`.
+
+---
+
+## How to Add a New MobAbility
+
+1. Create a class in `btm.sword.system.entity.ai.ability` implementing `MobAbility`.
+2. Choose `AbilityCategory.MELEE` (mob approaches) or `AbilityCategory.RANGED` (mob retreats) for `category()`.
+3. Add config entries in `Config.Hostile` for cooldown and any tunable parameters.
+4. Register an instance in `Hostile`'s constructor via `possibleAbilities.add(new YourAbility())`.
 
 ---
 
@@ -233,12 +302,16 @@ static { register(
 | File | Role |
 |------|------|
 | `HostileAIFacade.java` | Abstract base for all Hostile AI states; enables wildcard transitions |
-| `HostileStateMachine.java` | Extends `StateMachine<Hostile>`; registers all 20 transitions |
+| `HostileStateMachine.java` | Extends `StateMachine<Hostile>`; registers all 19 active transitions |
+| `ability/MobAbility.java` | Interface for discrete mob combat abilities |
+| `ability/AbilityCategory.java` | Enum: `MELEE` (approach) / `RANGED` (retreat) during pre-attack |
+| `ability/MobSlashAbility.java` | Melee slash using `SLASH1`/`SLASH2`/`SLASH3` Bezier curves |
+| `ability/MobThrowAbility.java` | Ranged throw: launches off-hand item as `DroppedItem` with arc |
 | `state/IdleState.java` | Patrol, aggro scan; prioritises `aggroTarget` for fast re-engagement |
 | `state/ApproachState.java` | Pathfind toward target; ally scan; look goal wired |
 | `state/SurroundState.java` | Arc formation; front-slot attack delegation; look goal wired |
-| `state/PreAttackState.java` | Wind-up timer; ominous particles and sound |
-| `state/AttackState.java` | Charge and melee hit via `randomAttack()`; `attackPostRoll` selects post-attack branch |
+| `state/PreAttackState.java` | Wind-up with mobile movement; selects ability; wires movement goal by category |
+| `state/AttackState.java` | Fires `pendingAbility` immediately on entry; rolls post-attack branch |
 | `state/OnGuardState.java` | Post-attack branch (roll 0): orbit target at safe distance; face target continuously |
 | `state/AttackReadyState.java` | Post-attack branch (roll 1): hold position and telegraph follow-up attack |
 | `state/RetreatState.java` | Back off 8 blocks; hold for `RETREAT_TICKS`; look goal wired (currently unreachable) |
@@ -246,11 +319,12 @@ static { register(
 | `goal/IdleWanderGoal.java` | Three-phase idle patrol: IDLE → LOOK → WALK |
 | `goal/ApproachGoal.java` | Pathfind toward target at 1.1x; swivel delay on entry |
 | `goal/SurroundHoldGoal.java` | Pathfind to arc position around target |
-| `goal/AttackChargeGoal.java` | Charge toward target at 1.6x |
+| `goal/AttackChargeGoal.java` | Charge toward target at 1.6x (legacy; no longer used in `AttackState`) |
+| `goal/PreAttackRetreatGoal.java` | RANGED pre-attack: retreat from target each tick while `preAttackTimer > 0` |
 | `goal/OnGuardBackoffGoal.java` | Orbit target at safe distance; strafe via advancing orbit angle |
 | `goal/RetreatBackoffGoal.java` | One-shot backoff 8 blocks away from target |
 | `goal/FleeGoal.java` | Recalculate flee direction every 20 ticks; pathfind away from nearest player |
-| `goal/LookAtTargetGoal.java` | Look goal that faces `currentTarget` each tick (Approach, Surround, Attack, OnGuard) |
+| `goal/LookAtTargetGoal.java` | Look goal that faces `currentTarget` each tick |
 | `goal/LookWhereGoingGoal.java` | Look goal that faces the mob's velocity direction (Retreat, Flee) |
 | `goal/ObserveGoal.java` | Look goal that pans to random nearby points; available for future states |
 
@@ -281,12 +355,13 @@ Each FSM state owns one custom `Goal` subclass in the `goal/` subpackage. The go
 | `IdleState` | `false` | Prevents vanilla AI from interfering with custom idle wander |
 | `ApproachState` | `true` | Target pursuit and pathfinding require awareness |
 | `SurroundState` | `true` | Arc positioning requires active pathfinding |
-| `PreAttackState` | `true` | Mob must track and face its target during wind-up |
-| `AttackState` | `true` | Charge and melee reach require active pathfinding |
+| `PreAttackState` | `true` | Mob moves toward/away from target during wind-up |
+| `AttackState` | `true` | Goals may still be active on entry (cleared in `onExit`) |
 | `OnGuardState` | `true` | Orbit pathfinding requires awareness |
 | `AttackReadyState` | `true` | Mob is stationary but aware, facing target |
 | `RetreatState` | `true` | Retreat direction pathfinding requires awareness |
 | `FleeState` | `true` | Flee pathfinding requires awareness |
+| **Grabbed (incapacitated)** | `false` | `Hostile.onGrabbed()` disables awareness; re-enabled in `onReleased()` |
 
 `Mob.setAi(false)` is not used in the current system. It would be appropriate for a future stunned or frozen state where all AI processing should halt.
 
@@ -301,8 +376,10 @@ All vanilla goals are cleared immediately after mob spawn via `MobGoalArbiter.GO
 | `IdleState` | `IdleWanderGoal` (`MOVE`) | (none — IdleWanderGoal handles look internally) | Patrol near spawn origin in a three-phase IDLE → LOOK → WALK cycle |
 | `ApproachState` | `ApproachGoal` (`MOVE`) | `LookAtTargetGoal` (`LOOK`) | Pathfind at 1.1x; swivel phase delays pathfinding on entry until mob has turned to face target |
 | `SurroundState` | `SurroundHoldGoal` (`MOVE`) | `LookAtTargetGoal` (`LOOK`) | Pathfind to arc slot position; face target while holding |
-| `PreAttackState` | (none) | (none — manual `lookAt` with high turn speed) | Pathfinding stopped on entry; mob faces target via direct `lookAt` calls |
-| `AttackState` | `AttackChargeGoal` (`MOVE`) | `LookAtTargetGoal` (`LOOK`) | Charge at 1.6x speed; face target during charge |
+| `PreAttackState (MELEE)` | `ApproachGoal` (`MOVE`) | `LookAtTargetGoal` (`LOOK`) | Mob closes in at 1.1x during the wind-up |
+| `PreAttackState (RANGED)` | `PreAttackRetreatGoal` (`MOVE`) | `LookAtTargetGoal` (`LOOK`) | Mob retreats 5 blocks; direction recomputed each tick |
+| `PreAttackState (none)` | (none — pathfinding stopped) | (none) | No ability available; mob holds position |
+| `AttackState` | (none) | (none) | Ability fires immediately on entry; no charge goal |
 | `OnGuardState` | `OnGuardBackoffGoal` (`MOVE`) | `LookAtTargetGoal` (`LOOK`) | Orbit target at safe distance (priority 2 MOVE, priority 3 LOOK) |
 | `AttackReadyState` | (none — pathfinding stopped) | (none — manual `lookAt` at 100f/100f) | Hold position; face target via direct `lookAt` calls each tick |
 | `RetreatState` | `RetreatBackoffGoal` (`MOVE`) | `LookWhereGoingGoal` (`LOOK`) | Back off 8 blocks; face direction of travel |

--- a/src/main/java/btm/sword/system/entity/ai/ability/AbilityCategory.java
+++ b/src/main/java/btm/sword/system/entity/ai/ability/AbilityCategory.java
@@ -1,0 +1,17 @@
+package btm.sword.system.entity.ai.ability;
+
+/**
+ * Categorizes a {@link MobAbility} by its combat range and movement pattern during the pre-attack wind-up.
+ *
+ * <p>The category determines how the mob moves during {@link btm.sword.system.entity.ai.state.PreAttackState}:
+ * <ul>
+ *   <li>{@link #MELEE} — mob closes in on the target at 110% speed during the wind-up.</li>
+ *   <li>{@link #RANGED} — mob retreats from the target during the wind-up.</li>
+ * </ul>
+ */
+public enum AbilityCategory {
+    /** Mob approaches the target during pre-attack. Used for melee attacks. */
+    MELEE,
+    /** Mob retreats from the target during pre-attack. Used for ranged abilities. */
+    RANGED
+}

--- a/src/main/java/btm/sword/system/entity/ai/ability/MobAbility.java
+++ b/src/main/java/btm/sword/system/entity/ai/ability/MobAbility.java
@@ -1,0 +1,52 @@
+package btm.sword.system.entity.ai.ability;
+
+import btm.sword.system.entity.impl.Hostile;
+
+/**
+ * Represents a discrete combat ability available to a {@link Hostile} mob.
+ *
+ * <p>Abilities are selected at the start of {@link btm.sword.system.entity.ai.state.PreAttackState}
+ * and executed at the start of {@link btm.sword.system.entity.ai.state.AttackState} — immediately
+ * when the wind-up timer expires, with no proximity gate.
+ */
+public interface MobAbility {
+
+    /**
+     * Returns the unique name of this ability, used as the cooldown map key.
+     *
+     * @return the ability name
+     */
+    String name();
+
+    /**
+     * Returns the {@link AbilityCategory} of this ability, which determines mob movement during
+     * the wind-up.
+     *
+     * @return the ability category
+     */
+    AbilityCategory category();
+
+    /**
+     * Returns {@code true} if this ability is currently usable by the given mob —
+     * i.e., the cooldown has elapsed and any preconditions are met.
+     *
+     * @param h the {@link Hostile} attempting to use the ability
+     * @return {@code true} if the ability can be selected
+     */
+    boolean canUse(Hostile h);
+
+    /**
+     * Executes this ability for the given mob.
+     * Called at the start of {@link btm.sword.system.entity.ai.state.AttackState}.
+     *
+     * @param h the {@link Hostile} executing the ability
+     */
+    void execute(Hostile h);
+
+    /**
+     * Returns the cooldown duration in ticks after this ability is used.
+     *
+     * @return cooldown in ticks
+     */
+    int cooldownTicks();
+}

--- a/src/main/java/btm/sword/system/entity/ai/ability/MobSlashAbility.java
+++ b/src/main/java/btm/sword/system/entity/ai/ability/MobSlashAbility.java
@@ -1,0 +1,53 @@
+package btm.sword.system.entity.ai.ability;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import btm.sword.config.Config;
+import btm.sword.system.attack.MobSweepAttack;
+import btm.sword.system.attack.style.AttackType;
+import btm.sword.system.entity.impl.Hostile;
+
+/**
+ * A melee slash ability for hostile mobs.
+ *
+ * <p>Randomly selects one of {@link AttackType#SLASH1}, {@link AttackType#SLASH2}, or
+ * {@link AttackType#SLASH3} and executes a {@link MobSweepAttack} using
+ * {@link btm.sword.utility.Prefab.Attacks#defaultMobHit}.
+ * The mob approaches the target during the wind-up (category: {@link AbilityCategory#MELEE}).
+ */
+public class MobSlashAbility implements MobAbility {
+
+    private static final AttackType[] SLASH_TYPES = {AttackType.SLASH1, AttackType.SLASH2, AttackType.SLASH3};
+
+    @Override
+    public String name() {
+        return "mob_slash";
+    }
+
+    @Override
+    public AbilityCategory category() {
+        return AbilityCategory.MELEE;
+    }
+
+    @Override
+    public boolean canUse(Hostile h) {
+        Integer cooldown = h.getAbilityCooldowns().get(name());
+        return cooldown == null || cooldown <= 0;
+    }
+
+    @Override
+    public void execute(Hostile h) {
+        if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return;
+        AttackType type = SLASH_TYPES[ThreadLocalRandom.current().nextInt(SLASH_TYPES.length)];
+        MobSweepAttack attack = new MobSweepAttack(new ItemStack(Material.STONE_SWORD), type, false);
+        attack.execute(h);
+    }
+
+    @Override
+    public int cooldownTicks() {
+        return Config.Hostile.MOB_SLASH_COOLDOWN_TICKS;
+    }
+}

--- a/src/main/java/btm/sword/system/entity/ai/ability/MobThrowAbility.java
+++ b/src/main/java/btm/sword/system/entity/ai/ability/MobThrowAbility.java
@@ -1,18 +1,23 @@
 package btm.sword.system.entity.ai.ability;
 
+import java.util.concurrent.TimeUnit;
+
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
 import btm.sword.config.Config;
-import btm.sword.system.action.throwing.types.DroppedItem;
+import btm.sword.system.action.throwing.ThrowAction;
+import btm.sword.system.control.SwordScheduler;
+import btm.sword.system.entity.ai.MobGoalArbiter;
+import btm.sword.system.entity.ai.goal.LookAtTargetGoal;
 import btm.sword.system.entity.impl.Hostile;
 
 /**
  * A ranged throwing ability for hostile mobs.
  *
- * <p>Launches the mob's off-hand item as a {@link DroppedItem} with a parabolic arc toward the
- * current target. The mob retreats from the target during the wind-up
- * (category: {@link AbilityCategory#RANGED}).
+ * <p>Launches the mob's off-hand item as a projectile with a parabolic arc toward the
+ * current target. The arc height and cooldown are controlled via {@link Config.Hostile}.
+ * Ability category: {@link AbilityCategory#RANGED}.
  */
 public class MobThrowAbility implements MobAbility {
 
@@ -35,7 +40,16 @@ public class MobThrowAbility implements MobAbility {
     @Override
     public void execute(Hostile h) {
         if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return;
-        ItemStack projectile = h.getItemStackInHand(false);
+
+        // Guard: combo re-entry (roll=2) re-calls execute() before the first throw's delayed
+        // throwItem() fires. Without this check, a second ThrownItem is created and the first
+        // one's display + landing marker are orphaned and never cleaned up.
+        if (h.isAttemptingThrow()) return;
+
+        MobGoalArbiter.GOALS.addGoal(h.mob(), 1, new LookAtTargetGoal(h.mob(), h));
+
+        // Bug 1 fix: use the explicit item so ThrowAction uses it instead of inferring from hand
+        ItemStack projectile = h.getItemStackInHand(true);
         if (projectile == null || projectile.isEmpty()) return;
 
         Vector toTarget = h.getCurrentTarget().self().getLocation()
@@ -46,10 +60,22 @@ public class MobThrowAbility implements MobAbility {
         if (distance < 0.001) return;
 
         toTarget.normalize();
-        toTarget.setY(toTarget.getY() + Config.Hostile.MOB_THROW_ARC_HEIGHT * distance / 8.0);
+//        // Add vertical arc so the projectile curves up and lands on the target
+//        toTarget.setY(toTarget.getY() + Config.Hostile.MOB_THROW_ARC_HEIGHT * distance / 8.0);
 
-        DroppedItem thrown = new DroppedItem(h.getChestLocation(), toTarget, projectile.clone());
-        thrown.register();
+        // Bug 1 fix: pass the explicit off-hand item so ThrowAction uses it instead of main-hand
+        ThrowAction.throwReady(h, projectile);
+
+        // Bug 2 fix: apply the arc direction to the ThrownItem before it is released
+        if (h.getThrownItem() != null) {
+            h.getThrownItem().setLaunchDirection(toTarget);
+        }
+
+        SwordScheduler.runBukkitTaskLater(
+            () -> ThrowAction.throwItem(h),
+            400,
+            TimeUnit.MILLISECONDS
+        );
     }
 
     @Override

--- a/src/main/java/btm/sword/system/entity/ai/ability/MobThrowAbility.java
+++ b/src/main/java/btm/sword/system/entity/ai/ability/MobThrowAbility.java
@@ -1,0 +1,59 @@
+package btm.sword.system.entity.ai.ability;
+
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
+
+import btm.sword.config.Config;
+import btm.sword.system.action.throwing.types.DroppedItem;
+import btm.sword.system.entity.impl.Hostile;
+
+/**
+ * A ranged throwing ability for hostile mobs.
+ *
+ * <p>Launches the mob's off-hand item as a {@link DroppedItem} with a parabolic arc toward the
+ * current target. The mob retreats from the target during the wind-up
+ * (category: {@link AbilityCategory#RANGED}).
+ */
+public class MobThrowAbility implements MobAbility {
+
+    @Override
+    public String name() {
+        return "mob_throw";
+    }
+
+    @Override
+    public AbilityCategory category() {
+        return AbilityCategory.RANGED;
+    }
+
+    @Override
+    public boolean canUse(Hostile h) {
+        Integer cooldown = h.getAbilityCooldowns().get(name());
+        return cooldown == null || cooldown <= 0;
+    }
+
+    @Override
+    public void execute(Hostile h) {
+        if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return;
+        ItemStack projectile = h.getItemStackInHand(false);
+        if (projectile == null || projectile.isEmpty()) return;
+
+        Vector toTarget = h.getCurrentTarget().self().getLocation()
+            .subtract(h.self().getLocation())
+            .toVector();
+
+        double distance = toTarget.length();
+        if (distance < 0.001) return;
+
+        toTarget.normalize();
+        toTarget.setY(toTarget.getY() + Config.Hostile.MOB_THROW_ARC_HEIGHT * distance / 8.0);
+
+        DroppedItem thrown = new DroppedItem(h.getChestLocation(), toTarget, projectile.clone());
+        thrown.register();
+    }
+
+    @Override
+    public int cooldownTicks() {
+        return Config.Hostile.MOB_THROW_COOLDOWN_TICKS;
+    }
+}

--- a/src/main/java/btm/sword/system/entity/ai/goal/PreAttackRetreatGoal.java
+++ b/src/main/java/btm/sword/system/entity/ai/goal/PreAttackRetreatGoal.java
@@ -1,0 +1,102 @@
+package btm.sword.system.entity.ai.goal;
+
+import java.util.EnumSet;
+
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Mob;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+
+import com.destroystokyo.paper.entity.ai.Goal;
+import com.destroystokyo.paper.entity.ai.GoalKey;
+import com.destroystokyo.paper.entity.ai.GoalType;
+
+import btm.sword.Sword;
+import btm.sword.system.entity.impl.Hostile;
+
+/**
+ * Pathfinds the {@link Hostile} away from its target during a ranged pre-attack wind-up.
+ *
+ * <p>Recomputes the backoff vector each tick to continuously retreat even if the target moves.
+ * Stays active while {@code preAttackTimer > 0}.
+ * Registered by {@code PreAttackState.onEnter} for
+ * {@link btm.sword.system.entity.ai.ability.AbilityCategory#RANGED} abilities and removed by
+ * {@code PreAttackState.onExit}.
+ */
+public class PreAttackRetreatGoal implements Goal<@NotNull Mob> {
+
+    /** Unique key for this goal; used for lookup and removal. */
+    public static final GoalKey<@NotNull Mob> KEY =
+        GoalKey.of(Mob.class, new NamespacedKey(Sword.getInstance(), "pre_attack_retreat"));
+
+    private static final double RETREAT_DISTANCE = 5.0;
+    private static final double RETREAT_SPEED = 1.1;
+
+    private final Mob mob;
+    private final Hostile hostile;
+
+    /**
+     * Constructs a {@code PreAttackRetreatGoal} for the given mob and its Sword wrapper.
+     *
+     * @param mob     the Bukkit {@link Mob} to pathfind
+     * @param hostile the {@link Hostile} wrapper supplying target and timer references
+     */
+    public PreAttackRetreatGoal(Mob mob, Hostile hostile) {
+        this.mob = mob;
+        this.hostile = hostile;
+    }
+
+    /** Activates immediately on registration. */
+    @Override
+    public boolean shouldActivate() {
+        return true;
+    }
+
+    /** Stays active while the pre-attack wind-up timer is still counting down. */
+    @Override
+    public boolean shouldStayActive() {
+        return hostile.getPreAttackTimer() > 0;
+    }
+
+    @Override
+    public void start() {
+        retreatFromTarget();
+    }
+
+    @Override
+    public void stop() {
+        mob.getPathfinder().stopPathfinding();
+    }
+
+    /** Re-issues the retreat path each tick so the mob tracks the target's movement. */
+    @Override
+    public void tick() {
+        retreatFromTarget();
+    }
+
+    @Override
+    public @NotNull GoalKey<@NotNull Mob> getKey() {
+        return KEY;
+    }
+
+    @Override
+    public @NotNull EnumSet<GoalType> getTypes() {
+        return EnumSet.of(GoalType.MOVE);
+    }
+
+    private void retreatFromTarget() {
+        if (hostile.getCurrentTarget() == null || !hostile.getCurrentTarget().self().isValid()) return;
+
+        Vector away = mob.getLocation()
+            .subtract(hostile.getCurrentTarget().self().getLocation())
+            .toVector();
+
+        if (away.lengthSquared() < 0.001) {
+            away = new Vector(1, 0, 0);
+        }
+
+        Location retreatPos = mob.getLocation().add(away.normalize().multiply(RETREAT_DISTANCE));
+        mob.getPathfinder().moveTo(retreatPos, RETREAT_SPEED);
+    }
+}

--- a/src/main/java/btm/sword/system/entity/ai/state/AttackState.java
+++ b/src/main/java/btm/sword/system/entity/ai/state/AttackState.java
@@ -8,28 +8,23 @@ import com.destroystokyo.paper.entity.ai.GoalType;
 
 import btm.sword.system.entity.ai.HostileAIFacade;
 import btm.sword.system.entity.ai.MobGoalArbiter;
-import btm.sword.system.entity.ai.goal.AttackChargeGoal;
-import btm.sword.system.entity.ai.goal.LookAtTargetGoal;
 import btm.sword.system.entity.impl.Hostile;
 
 /**
  * Attack AI state for Hostile entities.
  *
- * <p>Charges toward the target at 160% speed via {@link AttackChargeGoal}. Once within
- * melee distance (2.5 blocks), executes one of the mob's available attacks via
- * {@link Hostile#randomAttack()}, then sets a random {@code attackPostRoll} (0–2) that
- * selects the post-attack branch:
+ * <p>Fires the mob's {@link btm.sword.system.entity.ai.ability.MobAbility#execute pending ability}
+ * immediately on entry — no charge, no distance gate. Rolls a random
+ * {@code attackPostRoll} (0–2) to select the post-attack branch:
  * <ul>
  *   <li>0 → {@link OnGuardState}</li>
  *   <li>1 → {@link AttackReadyState}</li>
  *   <li>2 → {@link AttackState} (combo re-entry)</li>
  * </ul>
  * A {@link org.bukkit.Particle#CRIT} burst is played on entry when this is a combo re-entry.
+ * Entry is a no-op if the mob is currently incapacitated (e.g., grabbed).
  */
 public class AttackState extends HostileAIFacade {
-
-    /** Melee reach threshold in blocks squared (2.5 blocks). */
-    private static final double MELEE_REACH_SQ = 6.25;
 
     @Override
     public String name() {
@@ -38,7 +33,6 @@ public class AttackState extends HostileAIFacade {
 
     @Override
     public void onEnter(Hostile h) {
-        h.setAttackDone(false);
         if (h.isCombo()) {
             h.self().getWorld().spawnParticle(
                 Particle.CRIT,
@@ -47,23 +41,21 @@ public class AttackState extends HostileAIFacade {
             );
             h.setCombo(false);
         }
-        if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return;
-        MobGoalArbiter.GOALS.addGoal(h.mob(), 1, new AttackChargeGoal(h.mob(), h));
-        MobGoalArbiter.GOALS.addGoal(h.mob(), 2, new LookAtTargetGoal(h.mob(), h));
+
+        if (h.isIncapacitated()) return;
+
+        if (h.getPendingAbility() != null) {
+            h.getPendingAbility().execute(h);
+            h.setAbilityCooldown(h.getPendingAbility().name(), h.getPendingAbility().cooldownTicks());
+        }
+
+        h.setAttackDone(true);
+        h.setAttackPostRoll(ThreadLocalRandom.current().nextInt(3));
     }
 
     @Override
     public void onTick(Hostile h) {
-        if (h.isAttackDone()) return;
-        if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return;
-        if (h.getPossibleAttacks().isEmpty()) return;
-
-        double distSq = h.self().getLocation().distanceSquared(h.getCurrentTarget().self().getLocation());
-        if (distSq <= MELEE_REACH_SQ) {
-            h.randomAttack();
-            h.setAttackDone(true);
-            h.setAttackPostRoll(ThreadLocalRandom.current().nextInt(3));
-        }
+        // Attack fires on entry; nothing to do per-tick.
     }
 
     @Override

--- a/src/main/java/btm/sword/system/entity/ai/state/AttackState.java
+++ b/src/main/java/btm/sword/system/entity/ai/state/AttackState.java
@@ -8,6 +8,7 @@ import com.destroystokyo.paper.entity.ai.GoalType;
 
 import btm.sword.system.entity.ai.HostileAIFacade;
 import btm.sword.system.entity.ai.MobGoalArbiter;
+import btm.sword.system.entity.ai.goal.LookAtTargetGoal;
 import btm.sword.system.entity.impl.Hostile;
 
 /**
@@ -43,6 +44,8 @@ public class AttackState extends HostileAIFacade {
         }
 
         if (h.isIncapacitated()) return;
+
+        MobGoalArbiter.GOALS.addGoal(h.mob(), 1, new LookAtTargetGoal(h.mob(), h));
 
         if (h.getPendingAbility() != null) {
             h.getPendingAbility().execute(h);

--- a/src/main/java/btm/sword/system/entity/ai/state/PreAttackState.java
+++ b/src/main/java/btm/sword/system/entity/ai/state/PreAttackState.java
@@ -1,20 +1,33 @@
 package btm.sword.system.entity.ai.state;
 
-
 import org.bukkit.Particle;
+
+import com.destroystokyo.paper.entity.ai.GoalType;
 
 import btm.sword.config.Config;
 import btm.sword.system.entity.ai.HostileAIFacade;
+import btm.sword.system.entity.ai.MobGoalArbiter;
+import btm.sword.system.entity.ai.ability.AbilityCategory;
+import btm.sword.system.entity.ai.goal.ApproachGoal;
+import btm.sword.system.entity.ai.goal.LookAtTargetGoal;
+import btm.sword.system.entity.ai.goal.PreAttackRetreatGoal;
 import btm.sword.system.entity.impl.Hostile;
 import btm.sword.utility.Prefab;
 
 /**
  * Pre-attack (wind-up) AI state for Hostile entities.
- * <p>
- * Stops the mob in place, plays ominous visual and audio cues, then after the
- * configured wind-up period fires the {@link AttackState} transition. While winding up,
- * the mob continuously faces its target.
- * </p>
+ *
+ * <p>Selects a {@link btm.sword.system.entity.ai.ability.MobAbility} and then moves the mob
+ * during the telegraph:
+ * <ul>
+ *   <li>{@link AbilityCategory#MELEE} — mob approaches the target at 110% speed via
+ *       {@link ApproachGoal}.</li>
+ *   <li>{@link AbilityCategory#RANGED} — mob retreats from the target via
+ *       {@link PreAttackRetreatGoal}.</li>
+ *   <li>No ability available — mob stops pathfinding.</li>
+ * </ul>
+ * After the configured wind-up ticks, transitions to {@link AttackState} which fires the ability
+ * immediately — no proximity gate.
  */
 public class PreAttackState extends HostileAIFacade {
 
@@ -26,7 +39,9 @@ public class PreAttackState extends HostileAIFacade {
     @Override
     public void onEnter(Hostile h) {
         h.setPreAttackTimer(Config.Hostile.PRE_ATTACK_TICKS);
-        h.getPathfinder().stopPathfinding();
+        h.selectAbility();
+
+        h.getMob().setAware(true);
 
         h.self().getWorld().spawnParticle(
             Particle.TRIAL_SPAWNER_DETECTION_OMINOUS,
@@ -38,22 +53,26 @@ public class PreAttackState extends HostileAIFacade {
 
         Prefab.Sounds.PRE_ATTACK.playForAllInRadius(h.self());
 
-        faceTarget(h);
+        if (h.getPendingAbility() == null) {
+            h.getPathfinder().stopPathfinding();
+        } else if (h.getPendingAbility().category() == AbilityCategory.MELEE) {
+            MobGoalArbiter.GOALS.addGoal(h.mob(), 1, new ApproachGoal(h.mob(), h));
+            MobGoalArbiter.GOALS.addGoal(h.mob(), 2, new LookAtTargetGoal(h.mob(), h));
+        } else {
+            MobGoalArbiter.GOALS.addGoal(h.mob(), 1, new PreAttackRetreatGoal(h.mob(), h));
+            MobGoalArbiter.GOALS.addGoal(h.mob(), 2, new LookAtTargetGoal(h.mob(), h));
+        }
     }
 
     @Override
     public void onTick(Hostile h) {
         h.setPreAttackTimer(h.getPreAttackTimer() - 1);
-        faceTarget(h);
     }
 
     @Override
     public void onExit(Hostile h) {
         h.setPreAttackTimer(0);
-    }
-
-    private void faceTarget(Hostile h) {
-        if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return;
-        h.getMob().lookAt(h.getCurrentTarget().self(), 100f, 100f);
+        MobGoalArbiter.GOALS.removeAllGoals(h.mob(), GoalType.MOVE);
+        MobGoalArbiter.GOALS.removeAllGoals(h.mob(), GoalType.LOOK);
     }
 }

--- a/src/main/java/btm/sword/system/entity/ai/state/PreAttackState.java
+++ b/src/main/java/btm/sword/system/entity/ai/state/PreAttackState.java
@@ -60,7 +60,7 @@ public class PreAttackState extends HostileAIFacade {
             MobGoalArbiter.GOALS.addGoal(h.mob(), 2, new LookAtTargetGoal(h.mob(), h));
         } else {
             MobGoalArbiter.GOALS.addGoal(h.mob(), 1, new PreAttackRetreatGoal(h.mob(), h));
-            MobGoalArbiter.GOALS.addGoal(h.mob(), 2, new LookAtTargetGoal(h.mob(), h));
+            MobGoalArbiter.GOALS.addGoal(h.mob(), 1, new LookAtTargetGoal(h.mob(), h));
         }
     }
 

--- a/src/main/java/btm/sword/system/entity/base/SwordEntity.java
+++ b/src/main/java/btm/sword/system/entity/base/SwordEntity.java
@@ -536,6 +536,18 @@ public abstract class SwordEntity {
     }
 
     /**
+     * Called when this entity is grabbed by a {@link Combatant}.
+     * Override in subclasses to react to being grabbed (e.g., to disable AI).
+     */
+    public void onGrabbed() {}
+
+    /**
+     * Called when this entity is released from a grab.
+     * Override in subclasses to re-enable behaviour suppressed during the grab.
+     */
+    public void onReleased() {}
+
+    /**
      * Returns true if a parry hit-detection window is currently active on this entity.
      * Overridden in {@link SwordPlayer} to check the real parry window timestamp.
      *

--- a/src/main/java/btm/sword/system/entity/impl/Combatant.java
+++ b/src/main/java/btm/sword/system/entity/impl/Combatant.java
@@ -192,6 +192,7 @@ public abstract class Combatant extends SwordEntity {
         LivingEntity t = target.self();
         setGrabbing(true);
         target.setGrabbed(true);
+        target.onGrabbed();
         if (target instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.INCAPACITATED);
         setGrabbedEntity(target);
         Prefab.Particles.GRAB_CLOUD.display(t.getLocation().add(new Vector(0, 1, 0)));
@@ -204,6 +205,7 @@ public abstract class Combatant extends SwordEntity {
     public void onGrabLetGo() {
         isGrabbing = false;
         grabbedEntity.setGrabbed(false);
+        grabbedEntity.onReleased();
         if (grabbedEntity instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.NORMAL);
     }
 
@@ -216,6 +218,7 @@ public abstract class Combatant extends SwordEntity {
 
         isGrabbing = false;
         grabbedEntity.setGrabbed(false);
+        grabbedEntity.onReleased();
         if (grabbedEntity instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.NORMAL);
         MovementAction.toss(this, grabbedEntity);
     }

--- a/src/main/java/btm/sword/system/entity/impl/Hostile.java
+++ b/src/main/java/btm/sword/system/entity/impl/Hostile.java
@@ -1,9 +1,11 @@
 package btm.sword.system.entity.impl;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
-import java.util.function.Consumer;
 
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -17,19 +19,22 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
 import com.destroystokyo.paper.entity.Pathfinder;
+import com.destroystokyo.paper.entity.ai.GoalType;
 
 import btm.sword.system.action.throwing.types.DroppedItem;
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.ai.HostileStateMachine;
 import btm.sword.system.entity.ai.MobGoalArbiter;
 import btm.sword.system.entity.ai.WanderProfile;
+import btm.sword.system.entity.ai.ability.MobAbility;
+import btm.sword.system.entity.ai.ability.MobSlashAbility;
+import btm.sword.system.entity.ai.ability.MobThrowAbility;
 import btm.sword.system.entity.ai.state.IdleState;
 import btm.sword.system.entity.aspect.AspectType;
 import btm.sword.system.entity.aspect.Resource;
 import btm.sword.system.entity.base.CombatProfile;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.item.prefab.ItemLibrary;
-import btm.sword.utility.Prefab;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -48,7 +53,18 @@ public class Hostile extends Combatant {
     private final Mob mob;
     private final Pathfinder pathfinder;
     private Location origin;
-    private final List<Consumer<Combatant>> possibleAttacks;
+
+    /** Ordered list of abilities this mob can select from during pre-attack. */
+    private final List<MobAbility> possibleAbilities;
+
+    /** The ability selected at the start of PreAttackState; executed on AttackState entry. */
+    private MobAbility pendingAbility;
+
+    /** Per-ability cooldown counters (ticks remaining). Decremented each tick; removed at 0. */
+    private final Map<String, Integer> abilityCooldowns;
+
+    /** {@code true} while this mob is grabbed — suppresses AI movement and attack execution. */
+    private boolean incapacitated;
 
     // AI state machine
     private HostileStateMachine aiStateMachine;
@@ -106,33 +122,13 @@ public class Hostile extends Combatant {
         pathfinder = mob.getPathfinder();
         pathfinder.setCanFloat(false);
         pathfinder.setCanOpenDoors(true);
-//        pathfinder.
 
         origin = mob.getLocation();
-        possibleAttacks = new ArrayList<>();
+        possibleAbilities = new ArrayList<>();
+        abilityCooldowns = new HashMap<>();
 
-        // Register the basic melee attack
-        possibleAttacks.add(c -> {
-            Hostile h = (Hostile) c;
-            SwordEntity target = h.getCurrentTarget();
-            if (target == null || !target.self().isValid()) return;
-            Vector knockback = target.self().getLocation()
-                .subtract(h.self().getLocation())
-                .toVector();
-            if (knockback.lengthSquared() > 0.001) knockback.normalize();
-            knockback.multiply(0.5);
-            target.hit(h, Prefab.Attacks.defaultMobHit, knockback);
-        });
-
-//        // Register the grab attack — stuns the player for ~400 ms before releasing
-//        possibleAttacks.add(c -> {
-//            Hostile h = (Hostile) c;
-//            SwordEntity target = h.getCurrentTarget();
-//            if (target == null || !target.self().isValid()) return;
-//            h.onGrab(target);
-//            SwordScheduler.runBukkitTaskLater(h::onGrabHit, 400, TimeUnit.MILLISECONDS);
-//            SwordScheduler.runBukkitTaskLater(h::onGrabLetGo, 800, TimeUnit.MILLISECONDS);
-//        });
+        possibleAbilities.add(new MobSlashAbility());
+        possibleAbilities.add(new MobThrowAbility());
 
         EntityEquipment equipment = associatedEntity.getEquipment();
         if (equipment != null) {
@@ -150,6 +146,7 @@ public class Hostile extends Combatant {
     @Override
     public void onTick() {
         super.onTick();
+        tickAbilityCooldowns();
         if (aiStateMachine != null) {
             aiStateMachine.tick();
         }
@@ -185,6 +182,19 @@ public class Hostile extends Combatant {
             }
         }
         super.onZeroHealth();
+    }
+
+    @Override
+    public void onGrabbed() {
+        incapacitated = true;
+        mob.setAware(false);
+        MobGoalArbiter.GOALS.removeAllGoals(mob, GoalType.MOVE);
+    }
+
+    @Override
+    public void onReleased() {
+        incapacitated = false;
+        mob.setAware(true);
     }
 
     public void broadcastMessage(double radius, String message) {
@@ -230,13 +240,46 @@ public class Hostile extends Combatant {
     }
 
     /**
-     * Executes a random attack from {@link #possibleAttacks}.
-     * No-op if the attack list is empty.
+     * Selects a random available ability from {@link #possibleAbilities} and stores it in
+     * {@link #pendingAbility}. If no ability passes {@link MobAbility#canUse(Hostile)},
+     * {@code pendingAbility} is set to {@code null}.
      */
-    public void randomAttack() {
-        if (possibleAttacks.isEmpty()) return;
-        Random random = new Random();
-        possibleAttacks.get(random.nextInt(possibleAttacks.size())).accept(this);
+    public void selectAbility() {
+        List<MobAbility> available = new ArrayList<>();
+        for (MobAbility ability : possibleAbilities) {
+            if (ability.canUse(this)) {
+                available.add(ability);
+            }
+        }
+        if (available.isEmpty()) {
+            pendingAbility = null;
+            return;
+        }
+        pendingAbility = available.get(new Random().nextInt(available.size()));
+    }
+
+    /**
+     * Sets the cooldown for the named ability.
+     *
+     * @param name  the ability name (from {@link MobAbility#name()})
+     * @param ticks the cooldown duration in ticks
+     */
+    public void setAbilityCooldown(String name, int ticks) {
+        abilityCooldowns.put(name, ticks);
+    }
+
+    /** Decrements all per-ability cooldown counters and removes entries that reach zero. */
+    private void tickAbilityCooldowns() {
+        Iterator<Map.Entry<String, Integer>> it = abilityCooldowns.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<String, Integer> entry = it.next();
+            int remaining = entry.getValue() - 1;
+            if (remaining <= 0) {
+                it.remove();
+            } else {
+                entry.setValue(remaining);
+            }
+        }
     }
 
     public Location getOrigin() {

--- a/src/main/java/btm/sword/system/entity/impl/Hostile.java
+++ b/src/main/java/btm/sword/system/entity/impl/Hostile.java
@@ -132,8 +132,8 @@ public class Hostile extends Combatant {
 
         EntityEquipment equipment = associatedEntity.getEquipment();
         if (equipment != null) {
-            equipment.setItemInMainHand(itemInLeftHand);
-            equipment.setItemInOffHand(itemInRightHand);
+            equipment.setItemInMainHand(itemInRightHand);
+            equipment.setItemInOffHand(itemInLeftHand);
             equipment.setChestplate(new ItemStack(Material.NETHERITE_CHESTPLATE));
         }
     }
@@ -169,7 +169,7 @@ public class Hostile extends Combatant {
     @Override
     public void onZeroHealth() {
         if (!dead) {
-            ItemStack offHand = getItemStackInHand(false);
+            ItemStack offHand = getItemStackInHand(true);
             if (!offHand.isEmpty()) {
                 Vector dropVel = new Vector(
                     Math.random() - 0.5,

--- a/src/main/java/btm/sword/utility/Debug.java
+++ b/src/main/java/btm/sword/utility/Debug.java
@@ -38,6 +38,11 @@ public class Debug {
         }
     }
 
+    public static void combatDebug(Class<?> clazz, int lineNum, String message) {
+        if (!Config.Debug.LOGGING_VERBOSE_COMBAT) return;
+        debug(clazz, lineNum, "[Combat] " + message);
+    }
+
     public static void debugBlob(Location debugLocation) {
         Prefab.Particles.DEBUG_BLOB.display(debugLocation);
     }

--- a/src/main/java/btm/sword/utility/Prefab.java
+++ b/src/main/java/btm/sword/utility/Prefab.java
@@ -65,7 +65,7 @@ public class Prefab {
         public static final ParticleWrapper UMBRAL_FLAME = new ParticleWrapper(Particle.DUST_COLOR_TRANSITION, 3, 0.05, 0.05, 0.05, 1,
             new Particle.DustTransition(Color.fromRGB(53, 166, 240), Color.fromRGB(52, 72, 81), 0.5f));
 
-        public static final ParticleWrapper THROW_TRAIl = new ParticleWrapper(Particle.CRIT, 2, 0.1, 0.1, 0.1, 0);
+        public static final ParticleWrapper THROW_TRAIl = new ParticleWrapper(Particle.CRIT, 1, 0, 0, 0, 0);
 //        public static final ParticleWrapper THROW_TRAIl = new ParticleWrapper(Particle.DUST, 1, 0.2, 0.2, 0.2,
 //                new Particle.DustOptions(Color.WHITE, 2.5f));
 
@@ -202,6 +202,18 @@ public class Prefab {
             () -> Config.Audio.THROW_SOUND,
             () -> Config.Audio.THROW_VOLUME,
             () -> Config.Audio.THROW_PITCH
+        );
+
+        public static final SoundWrapper BLOCK_BROKEN = new SoundWrapper(
+            () -> Config.Audio.BLOCK_BROKEN_SOUND,
+            () -> Config.Audio.BLOCK_BROKEN_VOLUME,
+            () -> Config.Audio.BLOCK_BROKEN_PITCH
+        );
+
+        public static final SoundWrapper PARRY_ATTEMPT = new SoundWrapper(
+            () -> Config.Audio.PARRY_ATTEMPT_SOUND,
+            () -> Config.Audio.PARRY_ATTEMPT_VOLUME,
+            () -> Config.Audio.PARRY_ATTEMPT_PITCH
         );
 
         public static final SoundWrapper PRE_ATTACK = new SoundWrapper(

--- a/src/main/java/btm/sword/utility/sound/SoundUtil.java
+++ b/src/main/java/btm/sword/utility/sound/SoundUtil.java
@@ -3,10 +3,13 @@ package btm.sword.utility.sound;
 import org.bukkit.entity.LivingEntity;
 
 import btm.sword.Sword;
+import btm.sword.config.Config;
 import net.kyori.adventure.sound.Sound;
 
 public class SoundUtil {
     public static void playSound(LivingEntity target, SoundType type, float volume, float pitch) {
+        if (!Config.Audio.SOUNDS_ENABLED) return;
+
         try {
             Sound sound = Sound.sound(type, Sound.Source.PLAYER, volume, pitch);
             target.playSound(sound, Sound.Emitter.self());

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -378,6 +378,9 @@ hostile:
   pre_attack_ticks: 24
   retreat_ticks: 40
   flee_health_fraction: 0.2
+  mob_slash_cooldown_ticks: 20
+  mob_throw_cooldown_ticks: 60
+  mob_throw_arc_height: 0.4
 
 
 umbral:

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -1,123 +1,123 @@
 color:
-
+  
   text_resource_color: '#DEDEDE'
-
+  
   text_aspect_color: '#009FFF'
-
+  
   title_input_string: '#970000'
-
+  
   text_item_name: '#006E97'
   text_cool: '#F0A10C'
   text_item_controls: '#AD6DFF'
   text_item_header: '#E1E1E1'
   text_item_base: '#787878'
   text_cool_dark: '#333C4B'
-
+  
   umbral_glow: '#FFFFFF'
   ferocious_sweep: '#FF0000'
 
 
 angle:
-
+  
   umbral_blade_idle_period: 0.3926991 # π/8
 
 
 physics:
-
+  
   thrown_items_gravity_damper: 46.0
   thrown_items_trajectory_rotation: 0.03696
-
+  
   thrown_items_display_offset_x: -0.5
   thrown_items_display_offset_y: 0.1
   thrown_items_display_offset_z: 0.5
-
+  
   thrown_items_origin_offset_forward: 0.5
   thrown_items_origin_offset_up: 0.1
   thrown_items_origin_offset_back: -0.25
-
+  
   thrown_items_rotation_speed_sword: 0.0
   thrown_items_rotation_speed_axe: -0.3926991 # -π/8
   thrown_items_rotation_speed_hoe: -0.3926991
   thrown_items_rotation_speed_pickaxe: -0.3926991
   thrown_items_rotation_speed_shovel: -0.3926991
   thrown_items_rotation_speed_shield: -0.3926991
-
+  
   thrown_items_rotation_speed_default_speed: 0.09817477 # π/32
-
+  
   attack_velocity_grounded_damping_horizontal: 0.3
   attack_velocity_grounded_damping_vertical: 0.4
-
+  
   attack_velocity_knockback_vertical_base: 0.25
   attack_velocity_knockback_horizontal_modifier: 0.1
   attack_velocity_knockback_normal_multiplier: 0.7
 
 
 combat:
-
+  
   shards_lost_percent_toughness_reset: 0.3
   toughness_recharge_percent: 0.75
-
+  
   attacks_base_damage: 20.0
-
+  
   attacks_down_air_threshold: -0.4
-
+  
   attacks_cast_timing_min_duration: 25
   attacks_cast_timing_max_duration: 200
   attacks_cast_timing_reduction_rate: 0.2
   attacks_cooldown_mult: 2.0
-
-
+  
+  
   attacks_duration_multiplier: 500
-
+  
   attacks_range_multipliers_basic_1: 1.4
   attacks_range_multipliers_basic_2: 1.4
   attacks_range_multipliers_basic_3: 1.4
   attacks_range_multipliers_neutral_air: 1.3
   attacks_range_multipliers_down_air: 1.2
-
+  
   sweep_attack_x_scale: 0.25
   sweep_attack_y_scale: 1
   sweep_attack_z_scale: 0.25
-
+  
   hitboxes_basic_reach: 1.5
   hitboxes_basic_width: 1.5
   hitboxes_basic_height: 1.5
-
+  
   hitboxes_down_air_reach: 1.6
   hitboxes_down_air_width: 1.4
   hitboxes_down_air_height: 2.5
-
+  
   hitboxes_secant_radius: 1.0
-
+  
   thrown_damage_sword_damage_multiplier: 1.0
   thrown_damage_item_velocity_multiplier: 1.5
   thrown_damage_base_thrown_damage: 12.0
-
+  
   thrown_damage_sword_axe_invulnerability_ticks: 0
   thrown_damage_sword_axe_base_shards: 2
   thrown_damage_sword_axe_toughness_damage: 75.0
   thrown_damage_sword_axe_soulfire_reduction: 50.0
   thrown_damage_sword_axe_knockback_grounded: 0.7
   thrown_damage_sword_axe_knockback_airborne: 1.0
-
+  
   thrown_damage_other_invulnerability_ticks: 0
   thrown_damage_other_base_shards: 2
   thrown_damage_other_toughness_damage: 75.0
   thrown_damage_other_soulfire_reduction: 50.0
   thrown_damage_other_knockback_multiplier: 0.7
   thrown_damage_other_explosion_power: 1.0
-
+  
   impalement_damage_per_tick: 2.0
   impalement_ticks_between_damage: 10
   impalement_max_impalements: 3
   impalement_head_zone_ratio: 0.8
-
+  
   impalement_head_follow_exceptions:
   - SPIDER
-
+  
   impalement_pin_max_iterations: 200
   impalement_pin_check_interval: 100
-
+  
   attack_class_exempt_from_combat:
   - ARMOR_STAND
   - ITEM_FRAME
@@ -127,145 +127,134 @@ combat:
   - BLOCK_DISPLAY
   - TEXT_DISPLAY
   - INTERACTION
-
+  
   attack_class_timing_attack_duration: 750
   attack_class_timing_attack_iterations: 50
   attack_class_timing_attack_start_value: 0.0
   attack_class_timing_attack_end_value: 1.0
-
+  
   attack_class_modifiers_range_multiplier: 1.0
-
+  
   attack_class_hit_invuln_ticks: 5
   attack_class_hit_shards: 1
   attack_class_hit_toughness: 15
   attack_class_hit_soulfire: 6
 
-  block_soulfire_drain_per_second: 5.0
-  block_soulfire_cost_on_hit: 20.0
-  block_break_stagger_ms: 1000
-
-  parry_available_ms: 400
-  parry_window_ms: 200
-  parry_soulfire_gain: 25.0
-  parry_stagger_ms: 1000
-  parry_shield_cooldown_ticks: 100
-
-  shield_passing_bypass_power: 0.5
-
 
 timing:
-
+  
   thrown_items_catch_grace_period: 3
-
+  
   thrown_items_disposal_timeout: 30000
   thrown_items_disposal_check_interval: 500
-
+  
   thrown_items_pin_delay: 2
   thrown_items_throw_completion_delay: 6
-
+  
   intervals_entity_tick: 1
   intervals_status_display_update: 5
   intervals_combat_cleanup: 20
-
+  
   attacks_combo_window_base: 3
 
 
 display:
-
+  
   default_teleport_duration: 2
-
+  
   status_display_enabled: true
   status_display_height_offset: 2.0
   status_display_update_interval: 5
   status_display_block_brightness: 15
   status_display_sky_brightness: 15
-
+  
   item_display_follow_update_interval: 100
   item_display_follow_particle_interval: 4
   item_display_follow_billboard_mode: FIXED
-
+  
   particles_enabled: true
   particles_density: 10
 
 
 detection:
-
+  
   ground_check_max_distance: 0.3
-
+  
   raytrace_max_distance: 50.0
   raytrace_step_size: 0.1
   raytrace_ignore_passable_blocks: true
-
+  
   throw_pin_ray_distance: 1.0
   throw_ground_check_multiplier: 0.1
   throw_hit_check_dist_multiplier: 0.6
   throw_hit_check_ray_size: 1.0
-
+  
   entity_detection_search_radius: 10.0
   entity_detection_include_spectators: false
 
 
 audio:
-
+  
   sounds_enabled: true
-
+  
   sounds_global_volume: 1.0
   sounds_global_pitch: 1.0
-
+  
   throw_sound: ENTITY_ENDER_DRAGON_FLAP
   throw_volume: 0.35
   throw_pitch: 0.4
-
+  
   attack_sound: ITEM_TRIDENT_THROW
   attack_volume: 0.6
   attack_pitch: 0.7
-
+  
   entity_hit_connect_volume: 0.9
   entity_hit_connect_pitch: 1.0
-
+  
   punch_attempt: ENTITY_PLAYER_ATTACK_SWEEP
   punch_attempt_vol: 1.5
   punch_attempt_pitch: 0.5
-
+  
   punch_connect: BLOCK_ENDER_CHEST_OPEN
   punch_connect_vol: 1.5
   punch_connect_pitch: 1.0
   pre_attack_sound: ENTITY_DOLPHIN_JUMP
+  parry_attempt_sound: ENTITY_EVOKER_FANGS_ATTACK
 
 
 entity:
-
+  
   player_base_health: 100.0
   player_base_toughness: 10.0
   player_base_soulfire: 100.0
-
+  
   hostile_health_multiplier: 1.0
   hostile_damage_multiplier: 1.0
-
+  
   combat_profile_max_air_dodges: 1
   combat_profile_shards_current: 5
   combat_profile_shards_regen_period: 5000
   combat_profile_shards_regen_amount: 1
-
+  
   combat_profile_toughness_current: 20.0
   combat_profile_toughness_regen_period: 1000
   combat_profile_toughness_regen_amount: 0.25
-
+  
   combat_profile_soulfire_current: 100.0
   combat_profile_soulfire_regen_period: 200
-  combat_profile_soulfire_regen_amount: 0.002
-
+  combat_profile_soulfire_regen_amount: 0.009999999776482582
+  
   combat_profile_form_current: 10.0
   combat_profile_form_regen_period: 60
   combat_profile_form_regen_amount: 1.0
-
+  
   hit_tough_break_recharge_amount_percent: 2.0
   hit_tough_break_recharge_period_percent: 0.2
   hit_tough_break_recharge_cutoff_percent: 0.6
 
 
 movement:
-
+  
   dash_max_distance: 12.0
   dash_flat_item_dash_scaler: 0.35
   speed_duration: 5
@@ -286,9 +275,9 @@ movement:
   dash_particle_task_period: 2
   dash_particle_timer_increment: 2
   dash_particle_timer_threshold: 4
-
+  
   dash_grab_check_delay: 200
-
+  
   dash_velocity_task_delay: 0
   dash_velocity_task_period: 1
   dash_particle_count: 100
@@ -299,7 +288,7 @@ movement:
   dash_flap_sound_pitch: 1.0
   dash_sweep_sound_volume: 0.3
   dash_sweep_sound_pitch: 0.6
-
+  
   toss_base_force: 1.5
   toss_might_multiplier_base: 2.5
   toss_might_multiplier_increment: 0.1
@@ -314,12 +303,12 @@ movement:
   toss_knockback_multiplier: 0.3
   toss_explosion_power: 2.0
   toss_hit_invulnerability_ticks: 3
-
+  
   toss_hit_shard_damage: 1
   toss_hit_toughness_damage: 10.0
-
+  
   toss_hit_soulfire_reduction: 5.0
-
+  
   grab_pull_strength: 0.8
   grab_max_range: 3.0
   grab_hold_duration: 40
@@ -327,64 +316,61 @@ movement:
 
 
 world:
-
+  
   block_interaction_allow_block_breaking: false
   block_interaction_respect_world_guard: true
-
+  
   explosions_set_fire: false
   explosions_break_blocks: false
 
 
 debug:
-
+  
   logging_verbose_combat: false
   logging_verbose_movement: false
-
+  
   logging_verbose_config: false
-
+  
   visualization_show_hitboxes: false
   visualization_show_raytraces: false
 
 
 grab:
-
+  
   case_duration: 12
   base_duration: 60
   base_range: 3.0
   base_thickness: 0.6
-
+  
   duration_scaling: 0.2
   range_scaling: 0.1
   thickness_scaling: 0.1
-
+  
   hold_distance: 2.0
   hold_buffer: 0.4
   pull_speed: 0.6
-
+  
   vertical_force_threshold: 1.2
   close_y_velocity_scale: 0.25
-
+  
   jump_boost_amplifier: 1
   jump_boost_duration: 2
-
+  
   executor_horizontal_dampening: 0.2
 
 
 hostile:
-
+  
   aggro_range: 16.0
   approach_distance: 6.0
   surround_min_allies: 2
   pre_attack_ticks: 24
   retreat_ticks: 40
   flee_health_fraction: 0.2
-  mob_slash_cooldown_ticks: 20
-  mob_throw_cooldown_ticks: 60
-  mob_throw_arc_height: 0.4
 
 
 umbral:
-
+  
   time_cutoff: 1.2
   time_scaling_factor: 9
   on_release: 3


### PR DESCRIPTION
## Summary
- Refactored `ThrownItem` to extend new `VisualProjectile` base class, decoupling physics/display from thrower entity
- Added `Projectile` (headless standalone physics) and `ProjectileManager` (single Bukkit tick loop registered on plugin enable)
- Fixed 3 bugs in `MobThrowAbility`: wrong hand item (Bug 1), arc direction ignored (Bug 2), double-execute on combo re-entry (Bug 3)
- `ThrowAction` gains `throwReady(Combatant, ItemStack)` overload for mob AI to inject an explicit item
- `PreAttackState` now retreats for ranged abilities and approaches for melee; plays a pre-attack sound
- Added `WorldListener` to cancel block placement during testing
- Added `PRE_ATTACK` sound config entries and `Prefab.Sounds.PRE_ATTACK` wrapper

## Test plan
- [x] Player throw — item flies from correct hand, wind-up display shown, hand cleared after release
- [x] Mob throw — off-hand/main-hand item thrown with arc toward target; item cleared from hand after throw
- [x] Stand completely still near a mob in throw combo — only one ItemDisplay + marker pair created, no orphaned entities
- [x] UmbralBlade lunge — FSM `stepFlight()` still works; blade not registered in ProjectileManager
- [x] Mob melee ability — mob approaches during pre-attack, attacks on entry
- [x] Mob ranged ability — mob retreats during pre-attack, pre-attack sound plays