### PR TITLE
[Feat] Inventory drop blocking, interact delay config, misc tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # User-specific stuff
 .idea/
-._notes
+notes.txt
 
 *.iml
 *.ipr

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -2416,6 +2416,13 @@ public class Config {
             , v -> LOGGING_VERBOSE_CONFIG = v,
             ConfigurationSection::getBoolean); }
 
+        public static boolean LOGGING_VERBOSE_DEBUG = false;
+        static { register(
+            "debug.logging_verbose_debug",
+            LOGGING_VERBOSE_DEBUG, Boolean.class,
+            v -> LOGGING_VERBOSE_DEBUG = v,
+            ConfigurationSection::getBoolean); }
+
         // Visualization configuration
         public static boolean VISUALIZATION_SHOW_HITBOXES = false;
         static { register(

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -1248,6 +1248,15 @@ public class Config {
             v -> ATTACKS_COMBO_WINDOW_BASE = v,
             ConfigurationSection::getInt
         ); }
+
+        /** Delay in milliseconds between right-click inputs. */
+        public static int RIGHT_INTERACT_DELAY = 1;
+        static { register(
+            "timing.right_interact_delay",
+            RIGHT_INTERACT_DELAY, Integer.class,
+            v -> RIGHT_INTERACT_DELAY = v,
+            ConfigurationSection::getInt
+        ); }
     }
     //endregion
 

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -2387,14 +2387,23 @@ public class Config {
      *
      * <h2>Debug Tools</h2>
      * <ul>
-     *   <li><b>Verbose Logging</b> - Detailed console output for combat/movement/config</li>
+     *   <li><b>Verbose Logging</b> - Per-system console/chat output (combat, movement, inventory,
+     *       system, umbral, hostile, general debug)</li>
      *   <li><b>Visualization</b> - Particle-based hitbox and raytrace rendering</li>
      * </ul>
      *
      * <p><b>Warning:</b> Visualization features generate many particles and may impact performance.</p>
      */
     public static class Debug {
-        // Logging configuration
+        // Logging — general
+        public static boolean LOGGING_VERBOSE_DEBUG = false;
+        static { register(
+            "debug.logging_verbose_debug",
+            LOGGING_VERBOSE_DEBUG, Boolean.class,
+            v -> LOGGING_VERBOSE_DEBUG = v,
+            ConfigurationSection::getBoolean); }
+
+        // Logging — per system
         public static boolean LOGGING_VERBOSE_COMBAT = false;
         static { register(
             "debug.logging_verbose_combat",
@@ -2409,18 +2418,32 @@ public class Config {
             v -> LOGGING_VERBOSE_MOVEMENT = v,
             ConfigurationSection::getBoolean); }
 
-        public static boolean LOGGING_VERBOSE_CONFIG = true;
+        public static boolean LOGGING_VERBOSE_INVENTORY = false;
         static { register(
-            "debug.logging_verbose_config",
-            LOGGING_VERBOSE_CONFIG, Boolean.class
-            , v -> LOGGING_VERBOSE_CONFIG = v,
+            "debug.logging_verbose_inventory",
+            LOGGING_VERBOSE_INVENTORY, Boolean.class,
+            v -> LOGGING_VERBOSE_INVENTORY = v,
             ConfigurationSection::getBoolean); }
 
-        public static boolean LOGGING_VERBOSE_DEBUG = false;
+        public static boolean LOGGING_VERBOSE_SYSTEM = false;
         static { register(
-            "debug.logging_verbose_debug",
-            LOGGING_VERBOSE_DEBUG, Boolean.class,
-            v -> LOGGING_VERBOSE_DEBUG = v,
+            "debug.logging_verbose_system",
+            LOGGING_VERBOSE_SYSTEM, Boolean.class,
+            v -> LOGGING_VERBOSE_SYSTEM = v,
+            ConfigurationSection::getBoolean); }
+
+        public static boolean LOGGING_VERBOSE_UMBRAL = false;
+        static { register(
+            "debug.logging_verbose_umbral",
+            LOGGING_VERBOSE_UMBRAL, Boolean.class,
+            v -> LOGGING_VERBOSE_UMBRAL = v,
+            ConfigurationSection::getBoolean); }
+
+        public static boolean LOGGING_VERBOSE_HOSTILE = false;
+        static { register(
+            "debug.logging_verbose_hostile",
+            LOGGING_VERBOSE_HOSTILE, Boolean.class,
+            v -> LOGGING_VERBOSE_HOSTILE = v,
             ConfigurationSection::getBoolean); }
 
         // Visualization configuration

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -2596,7 +2596,7 @@ public class Config {
             "hostile.aggro_range",
             16.0, Double.class,
             v -> AGGRO_RANGE_SQUARED = v * v,
-            (s, p, d) -> s.getDouble(p, d)
+            ConfigurationSection::getDouble
         ); }
 
         /** Attack initiation distance squared (loaded from raw radius and squared on assignment). */
@@ -2605,7 +2605,7 @@ public class Config {
             "hostile.approach_distance",
             6.0, Double.class,
             v -> APPROACH_DISTANCE_SQUARED = v * v,
-            (s, p, d) -> s.getDouble(p, d)
+            ConfigurationSection::getDouble
         ); }
 
         /** Minimum allied Hostile count targeting the same player to trigger surround behaviour. */
@@ -2614,7 +2614,7 @@ public class Config {
             "hostile.surround_min_allies",
             2, Integer.class,
             v -> SURROUND_MIN_ALLIES = v,
-            (s, p, d) -> s.getInt(p, d)
+            ConfigurationSection::getInt
         ); }
 
         /** Wind-up ticks before an attack is executed (~1.2 s at 20 TPS). */
@@ -2623,7 +2623,7 @@ public class Config {
             "hostile.pre_attack_ticks",
             24, Integer.class,
             v -> PRE_ATTACK_TICKS = v,
-            (s, p, d) -> s.getInt(p, d)
+            ConfigurationSection::getInt
         ); }
 
         /** Retreat duration in ticks after an attack (~2 s at 20 TPS). */
@@ -2632,7 +2632,7 @@ public class Config {
             "hostile.retreat_ticks",
             40, Integer.class,
             v -> RETREAT_TICKS = v,
-            (s, p, d) -> s.getInt(p, d)
+            ConfigurationSection::getInt
         ); }
 
         /** Health fraction threshold below which the mob flees (0.0–1.0). */
@@ -2641,7 +2641,7 @@ public class Config {
             "hostile.flee_health_fraction",
             0.20, Double.class,
             v -> FLEE_HEALTH_FRACTION = v,
-            (s, p, d) -> s.getDouble(p, d)
+            ConfigurationSection::getDouble
         ); }
 
         /** OnGuard duration in ticks after an attack (~2 s at 20 TPS). */
@@ -2650,7 +2650,7 @@ public class Config {
             "hostile.on_guard_ticks",
             40, Integer.class,
             v -> ON_GUARD_TICKS = v,
-            (s, p, d) -> s.getInt(p, d)
+            ConfigurationSection::getInt
         ); }
 
         /** Safe orbit radius squared for OnGuard strafing (loaded from raw distance and squared on assignment). */
@@ -2659,7 +2659,7 @@ public class Config {
             "hostile.on_guard_safe_distance",
             6.0, Double.class,
             v -> ON_GUARD_SAFE_DISTANCE_SQUARED = v * v,
-            (s, p, d) -> s.getDouble(p, d)
+            ConfigurationSection::getDouble
         ); }
 
         /** AttackReady hold duration in ticks — brief pause before a combo follow-up (~0.8 s at 20 TPS). */
@@ -2668,7 +2668,7 @@ public class Config {
             "hostile.attack_ready_ticks",
             16, Integer.class,
             v -> ATTACK_READY_TICKS = v,
-            (s, p, d) -> s.getInt(p, d)
+            ConfigurationSection::getInt
         ); }
 
         /** Cooldown in ticks after the mob uses its melee slash ability (1 s at 20 TPS). */
@@ -2677,7 +2677,7 @@ public class Config {
             "hostile.mob_slash_cooldown_ticks",
             20, Integer.class,
             v -> MOB_SLASH_COOLDOWN_TICKS = v,
-            (s, p, d) -> s.getInt(p, d)
+            ConfigurationSection::getInt
         ); }
 
         /** Cooldown in ticks after the mob uses its throw ability (3 s at 20 TPS). */
@@ -2686,7 +2686,7 @@ public class Config {
             "hostile.mob_throw_cooldown_ticks",
             60, Integer.class,
             v -> MOB_THROW_COOLDOWN_TICKS = v,
-            (s, p, d) -> s.getInt(p, d)
+            ConfigurationSection::getInt
         ); }
 
         /** Parabolic arc height multiplier for the mob throw ability. */
@@ -2695,7 +2695,7 @@ public class Config {
             "hostile.mob_throw_arc_height",
             0.4, Double.class,
             v -> MOB_THROW_ARC_HEIGHT = v,
-            (s, p, d) -> s.getDouble(p, d)
+            ConfigurationSection::getDouble
         ); }
     }
     //endregion

--- a/src/main/java/btm/sword/listeners/InputListener.java
+++ b/src/main/java/btm/sword/listeners/InputListener.java
@@ -1,8 +1,10 @@
 package btm.sword.listeners;
 
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerDropItemEvent;
@@ -16,12 +18,14 @@ import org.bukkit.inventory.ItemStack;
 
 import com.destroystokyo.paper.event.player.PlayerAttackEntityCooldownResetEvent;
 
+import btm.sword.config.Config;
 import btm.sword.system.action.throwing.ThrowAction;
 import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.input.InputType;
 import btm.sword.system.item.ItemClassifier;
+import btm.sword.utility.Debug;
 import btm.sword.utility.entity.InputUtil;
 import io.papermc.paper.event.player.PrePlayerAttackEntityEvent;
 
@@ -87,47 +91,53 @@ public class InputListener implements Listener {
      *
      * @param event the {@link PlayerInteractEvent} triggered when a player interacts with air or a block
      */
-    @EventHandler
+    @EventHandler(priority = EventPriority.NORMAL)
     public void onPlayerInteract(PlayerInteractEvent event) {
         SwordPlayer swordPlayer = (SwordPlayer) SwordEntityArbiter.getOrAdd(event.getPlayer());
         ItemStack item = swordPlayer.getItemStackInHand(true);
 
         Action action = event.getAction();
-
-        if (swordPlayer.hasPerformedDropAction()) return;
-
-        if ((action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK)) {
-            if (swordPlayer.handleItemInteraction(item, InputType.LEFT)) {
-                event.setCancelled(true);
+        SwordScheduler.runBukkitTaskLater(() -> {
+            if (swordPlayer.isInInventorySession()) return;
+            if (swordPlayer.hasPerformedDropAction()) return;
+            if (swordPlayer.isDroppingInInv()) {
+                Debug.inventory("Left click detected because of a drop in inv...");
                 return;
             }
+            Debug.inventory("dropping checks are not quick enough apparently...");
 
-            if (!swordPlayer.getInputBuffer().accept(InputType.LEFT)) return;
+            if ((action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK)) {
+                if (swordPlayer.handleItemInteraction(item, InputType.LEFT)) {
+                    event.setCancelled(true);
+                    return;
+                }
 
-            swordPlayer.act(InputType.LEFT);
-        }
-        else if (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK) {
-            if (swordPlayer.handleItemInteraction(item, InputType.RIGHT)) {
-                event.setCancelled(true);
-                return;
-            }
+                if (!swordPlayer.getInputBuffer().accept(InputType.LEFT)) return;
 
-            if (ItemClassifier.isUsable(item)) return;
+                swordPlayer.act(InputType.LEFT);
+            } else if (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK) {
+                if (swordPlayer.handleItemInteraction(item, InputType.RIGHT)) {
+                    event.setCancelled(true);
+                    return;
+                }
 
-            if (!swordPlayer.getInputBuffer().accept(InputType.RIGHT)) return;
+                if (ItemClassifier.isUsable(item)) return;
 
-            if (swordPlayer.isAtRoot() &&
+                if (!swordPlayer.getInputBuffer().accept(InputType.RIGHT)) return;
+
+                if (swordPlayer.isAtRoot() &&
                     event.hasBlock() &&
                     InputUtil.isInteractible(event.getClickedBlock())) {
-                return;
-            }
+                    return;
+                }
 
-            if (swordPlayer.isUnableToBlock()){
-                swordPlayer.displayDisablingEffect();
-                return;
+                if (swordPlayer.isUnableToBlock()) {
+                    swordPlayer.displayDisablingEffect();
+                    return;
+                }
+                swordPlayer.act(InputType.RIGHT);
             }
-            swordPlayer.act(InputType.RIGHT);
-        }
+        }, Config.Timing.RIGHT_INTERACT_DELAY, TimeUnit.MILLISECONDS);
     }
 
     /**
@@ -183,7 +193,7 @@ public class InputListener implements Listener {
      *
      * @param event the {@link PlayerDropItemEvent} triggered when a player drops an item
      */
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerDropEvent(PlayerDropItemEvent event) {
         SwordPlayer swordPlayer = (SwordPlayer) SwordEntityArbiter.getOrAdd(event.getPlayer());
         ItemStack item = event.getItemDrop().getItemStack();
@@ -195,16 +205,9 @@ public class InputListener implements Listener {
             return;
         }
 
-        swordPlayer.setPerformedDropAction(true);
-
-        if (!swordPlayer.isDroppingInInv()) {
-            swordPlayer.act(InputType.DROP);
-            event.setCancelled(true);
-        }
-
-        Consumer<SwordPlayer> resetDroppingFlag =
-                sp -> sp.setPerformedDropAction(false);
-        SwordScheduler.runConsumerNextTick(resetDroppingFlag, swordPlayer);
+        swordPlayer.setPerformedDropAction();
+        swordPlayer.act(InputType.DROP);
+        event.setCancelled(true);
     }
 
     /**

--- a/src/main/java/btm/sword/listeners/PlayerListener.java
+++ b/src/main/java/btm/sword/listeners/PlayerListener.java
@@ -6,13 +6,18 @@ import org.bukkit.GameMode;
 import org.bukkit.Particle;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.player.PlayerGameModeChangeEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -20,6 +25,7 @@ import org.bukkit.event.player.PlayerRespawnEvent;
 import org.intellij.lang.annotations.Subst;
 
 import btm.sword.Sword;
+import btm.sword.config.Config;
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.impl.SwordPlayer;
@@ -142,12 +148,36 @@ public class PlayerListener implements Listener {
      */
     @EventHandler
     public void inventoryEvent(InventoryEvent event) {
-        if (!Debug.VERBOSE_ENABLED.get()) return;
+        if (!Config.Debug.LOGGING_VERBOSE_INVENTORY) return;
         for (HumanEntity human : event.getViewers()) {
             if (human instanceof Player) {
                 SwordEntityArbiter.get(human)
                     .message("getInventory(): " + event.getInventory() + "\n  getView(): " + event.getView());
             }
+        }
+    }
+
+    /**
+     * Tracks when the player opens an inventory, enabling drag-outside-window drop detection.
+     *
+     * @param event the {@link InventoryOpenEvent} triggered when a player opens an inventory
+     */
+    @EventHandler
+    public void onInventoryOpen(InventoryOpenEvent event) {
+        if (event.getPlayer() instanceof Player p) {
+            ((SwordPlayer) SwordEntityArbiter.getOrAdd(p)).setInInventorySession(true);
+        }
+    }
+
+    /**
+     * Tracks when the player closes an inventory, disabling drag-outside-window drop detection.
+     *
+     * @param event the {@link InventoryCloseEvent} triggered when a player closes an inventory
+     */
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (event.getPlayer() instanceof Player p) {
+            ((SwordPlayer) SwordEntityArbiter.getOrAdd(p)).setInInventorySession(false);
         }
     }
 
@@ -182,65 +212,47 @@ public class PlayerListener implements Listener {
     public void inventoryInteractEvent(InventoryClickEvent event) {
         SwordPlayer sp = (SwordPlayer) SwordEntityArbiter.getOrAdd(event.getViewers().getFirst());
 
+        Debug.sendInventoryClickDebugMessage(event);
+
         if (sp.handleInventoryInput(event)) {
             event.setCancelled(true);
         }
 
-//		switch (clickType) {
-//			case SWAP_OFFHAND -> sp.setSwappingInInv();
-//			case DROP, CONTROL_DROP -> sp.setDroppingInInv();
-//			case SHIFT_RIGHT -> {
-//				sp.message("Shift start clicking!");
-//				event.setCancelled(true);
-//				new BukkitRunnable() {
-//					final int slot = event.getSlot();
-//					@Override
-//					public void run() {
-//						Item itemDrop = sp.entity().getWorld().dropItem(sp.getChestLocation(), Objects.requireNonNull(inv.getItem(slot)));
-//						itemDrop.setPickupDelay(5);
-//						itemDrop.setVelocity(sp.entity().getEyeLocation().getDirection().multiply(0.5));
-//						itemDrop.setThrower(sp.getUniqueId());
-//						inv.setItem(slot, new ItemStack(Material.AIR));
-//					}
-//				}.runTaskLater(Sword.getInstance(), 1L);
-//			}
-//			case DOUBLE_CLICK -> {
-//				sp.message("Double clicked smth");
-//				sp.entity().getWorld().dropItem(sp.entity().getEyeLocation(), event.getCursor()).setPickupDelay(5);
-//				sp.player().getInventory().setItem(event.getSlot(), new ItemStack(Material.AIR));
-//				event.getCursor().setAmount(0);
-//			}
-//			case SHIFT_LEFT -> {
-//				sp.message("Shift left clicking!");
-//				event.setCancelled(true);
-//				new BukkitRunnable() {
-//					final int slot = event.getSlot();
-//					@Override
-//					public void run() {
-//						Item itemDrop = sp.entity().getWorld().dropItem(sp.getChestLocation(), Objects.requireNonNull(inv.getItem(slot)));
-//						itemDrop.setPickupDelay(5);
-//						itemDrop.setVelocity(sp.entity().getEyeLocation().getDirection().multiply(0.5));
-//						itemDrop.setThrower(sp.getUniqueId());
-//						inv.setItem(slot, new ItemStack(Material.AIR));
-//					}
-//				}.runTaskLater(Sword.getInstance(), 1L);
-//			}
-//		}
-//
-//		switch (action) {
-//			case DROP_ALL_SLOT, DROP_ALL_CURSOR, DROP_ONE_SLOT, DROP_ONE_CURSOR, UNKNOWN -> {
-//				sp.message("Dropping is detected");
-//				sp.setDroppingInInv();
-//			}
-//			case SWAP_WITH_CURSOR, HOTBAR_SWAP -> {
-//				sp.message("Swapping detected");
-//				sp.setSwappingInInv();
-//			}
-//			case PICKUP_ALL, PICKUP_HALF, PICKUP_ONE, PICKUP_SOME -> {
-//				sp.message("You picked something up");
-//			}
-//			case PLACE_ALL, PLACE_SOME, PLACE_ONE -> sp.message("You placed something");
-//		}
+        ClickType clickType = event.getClick();
+        InventoryAction action = event.getAction();
+
+        sp.inventoryInfo("click=" + clickType + " action=" + action);
+
+        switch (clickType) {
+            case SWAP_OFFHAND -> sp.setSwappingInInv();
+            case DROP, CONTROL_DROP -> {
+                sp.setDroppingInInv();
+                event.setCancelled(true);
+                event.setResult(Event.Result.DENY);
+            }
+            case SHIFT_RIGHT -> {
+                sp.inventoryInfo("shift-right click");
+                event.setCancelled(true);
+            }
+            default -> {}
+        }
+
+        switch (action) {
+            case DROP_ALL_SLOT, DROP_ALL_CURSOR, DROP_ONE_SLOT, DROP_ONE_CURSOR -> {
+                sp.setDroppingInInv();
+                event.setCancelled(true);
+                event.setResult(Event.Result.DENY);
+            }
+            case SWAP_WITH_CURSOR, HOTBAR_SWAP -> {
+                sp.inventoryInfo("swap");
+                sp.setSwappingInInv();
+            }
+            case PICKUP_ALL, PICKUP_HALF, PICKUP_ONE, PICKUP_SOME ->
+                sp.inventoryInfo("pickup");
+            case PLACE_ALL, PLACE_SOME, PLACE_ONE ->
+                sp.inventoryInfo("place");
+            default -> {}
+        }
     }
 
     /**

--- a/src/main/java/btm/sword/listeners/PlayerListener.java
+++ b/src/main/java/btm/sword/listeners/PlayerListener.java
@@ -3,6 +3,7 @@ package btm.sword.listeners;
 import java.util.Objects;
 
 import org.bukkit.GameMode;
+import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
@@ -22,6 +23,7 @@ import org.bukkit.event.player.PlayerGameModeChangeEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
+import org.bukkit.inventory.ItemStack;
 import org.intellij.lang.annotations.Subst;
 
 import btm.sword.Sword;
@@ -164,8 +166,11 @@ public class PlayerListener implements Listener {
      */
     @EventHandler
     public void onInventoryOpen(InventoryOpenEvent event) {
+        Debug.inventory("Opened inventory...");
         if (event.getPlayer() instanceof Player p) {
-            ((SwordPlayer) SwordEntityArbiter.getOrAdd(p)).setInInventorySession(true);
+            SwordPlayer sp = ((SwordPlayer) SwordEntityArbiter.getOrAdd(p));
+            sp.setInInventorySession(true);
+            Debug.inventory("in session?=" + sp.isInInventorySession());
         }
     }
 
@@ -221,6 +226,9 @@ public class PlayerListener implements Listener {
         ClickType clickType = event.getClick();
         InventoryAction action = event.getAction();
 
+        ItemStack current = event.getCurrentItem();
+        int slot = event.getSlot();
+
         sp.inventoryInfo("click=" + clickType + " action=" + action);
 
         switch (clickType) {
@@ -231,7 +239,11 @@ public class PlayerListener implements Listener {
                 event.setResult(Event.Result.DENY);
             }
             case SHIFT_RIGHT -> {
-                sp.inventoryInfo("shift-right click");
+                sp.inventoryInfo("shift-right click, dropping that thang");
+
+                sp.spawnInventoryDrop(current);
+                sp.setItemAtIndex(new ItemStack(Material.AIR), slot);
+
                 event.setCancelled(true);
             }
             default -> {}

--- a/src/main/java/btm/sword/listeners/PlayerListener.java
+++ b/src/main/java/btm/sword/listeners/PlayerListener.java
@@ -11,6 +11,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryEvent;
 import org.bukkit.event.player.PlayerGameModeChangeEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -23,7 +24,9 @@ import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.entity.umbral.input.BladeRequest;
+import btm.sword.system.item.special.NonMovableItem;
 import btm.sword.utility.ChatInputCapture;
+import btm.sword.utility.Debug;
 import io.papermc.paper.event.player.AsyncChatEvent;
 import io.papermc.paper.event.player.PlayerShieldDisableEvent;
 import net.kyori.adventure.key.Key;
@@ -139,12 +142,29 @@ public class PlayerListener implements Listener {
      */
     @EventHandler
     public void inventoryEvent(InventoryEvent event) {
-        // Testing
+        if (!Debug.VERBOSE_ENABLED) return;
         for (HumanEntity human : event.getViewers()) {
             if (human instanceof Player) {
                 SwordEntityArbiter.get(human)
                     .message("getInventory(): " + event.getInventory() + "\n  getView(): " + event.getView());
             }
+        }
+    }
+
+    /**
+     * Prevents players from dragging non-movable items across inventory slots.
+     * <p>
+     * Drag events are not routed through {@link SwordPlayer#handleInventoryInput},
+     * so this handler independently cancels any drag where the cursor item is
+     * tagged as a {@link btm.sword.system.item.special.NonMovableItem}.
+     * </p>
+     *
+     * @param event the {@link InventoryDragEvent} triggered when a player drags an item
+     */
+    @EventHandler
+    public void inventoryDragEvent(InventoryDragEvent event) {
+        if (NonMovableItem.isNonMovable(event.getOldCursor())) {
+            event.setCancelled(true);
         }
     }
 

--- a/src/main/java/btm/sword/listeners/PlayerListener.java
+++ b/src/main/java/btm/sword/listeners/PlayerListener.java
@@ -142,7 +142,7 @@ public class PlayerListener implements Listener {
      */
     @EventHandler
     public void inventoryEvent(InventoryEvent event) {
-        if (!Debug.VERBOSE_ENABLED) return;
+        if (!Debug.VERBOSE_ENABLED.get()) return;
         for (HumanEntity human : event.getViewers()) {
             if (human instanceof Player) {
                 SwordEntityArbiter.get(human)

--- a/src/main/java/btm/sword/system/action/UmbralBladeAction.java
+++ b/src/main/java/btm/sword/system/action/UmbralBladeAction.java
@@ -23,7 +23,7 @@ import btm.sword.utility.math.Basis;
 public class UmbralBladeAction extends SwordAction {
     public static void wield(Combatant wielder) {
 
-        Debug.debug(UmbralBladeAction.class, 26, "Wield gets called.");
+        Debug.umbral("wield called");
 
         UmbralBlade blade = wielder.getUmbralBlade();
         if (blade == null) return;

--- a/src/main/java/btm/sword/system/action/movement/Dash.java
+++ b/src/main/java/btm/sword/system/action/movement/Dash.java
@@ -22,6 +22,7 @@ import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.impl.Combatant;
+import btm.sword.utility.Debug;
 import btm.sword.utility.Prefab;
 import btm.sword.utility.display.ParticleWrapper;
 import btm.sword.utility.entity.EntityUtil;
@@ -73,7 +74,7 @@ public class Dash {
                 (direction <= 0 && executor.dir().dot(Config.Direction.UP()) > -FLAT_DASH_PITCH_THRESHOLD)
         );
 
-        executor.movementInfo("Flat dash: " + flatDash);
+        Debug.movement("flatDash=" + flatDash);
 
         // Handle item dash/grab logic separately; if it succeeds, return early
         if (handleTargetedItemDash(targetedItem)) return;

--- a/src/main/java/btm/sword/system/action/movement/MovementAction.java
+++ b/src/main/java/btm/sword/system/action/movement/MovementAction.java
@@ -126,7 +126,7 @@ public class MovementAction extends SwordAction {
                     true,
                     block -> block.getType().isCollidable());
 
-                Debug.debug(MovementAction.class, 285, "blockResult :: " + blockResult);
+                Debug.movement("blockResult=" + blockResult);
 
                 double entityRadius = Config.Movement.TOSS_ENTITY_DETECTION_RADIUS;
                 Collection<LivingEntity> entities = world.getNearbyLivingEntities(

--- a/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
@@ -35,6 +35,7 @@ import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.input.ActivationContext;
 import btm.sword.system.item.ItemUsageManager;
+import btm.sword.utility.Debug;
 import btm.sword.utility.Prefab;
 import btm.sword.utility.display.DisplayUtil;
 import btm.sword.utility.entity.EntityUtil;
@@ -229,7 +230,7 @@ public class ThrownItem extends VisualProjectile {
             : hit ? "hit"
             : caught ? "caught"
             : display.isDead() ? "display dead" : "time cutoff";
-        thrower.combatInfo("Ending due to: " + reason);
+        Debug.combat("throw ended: " + reason);
         super.onEnd();
     }
 

--- a/src/main/java/btm/sword/system/action/throwing/types/VisualProjectile.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/VisualProjectile.java
@@ -459,7 +459,7 @@ public class VisualProjectile extends SimulatedDisplay {
     @Override
     public void determineOrientation() {
         if (display == null) {
-            Debug.combatDebug(VisualProjectile.class, 463, "Display was null... determineOrientation()");
+            Debug.umbral("display null in determineOrientation()");
             return;
         }
 

--- a/src/main/java/btm/sword/system/control/TimeArbiter.java
+++ b/src/main/java/btm/sword/system/control/TimeArbiter.java
@@ -181,8 +181,8 @@ public class TimeArbiter {
                 Sword.getInstance().getLogger().warning("Error when canceling a TaskHandler: " + e);
             }
 
-            Debug.debug(TimeArbiter.class, 183, "Cancelling task [ " + taskID + " ] " +
-                " : Successful ? " + successfullyCanceled + " From: " + callingClass + " " + callingMethodName);
+            Debug.system("cancel task [" + taskID + "] ok=" + successfullyCanceled
+                + " from " + callingClass.getSimpleName() + "." + callingMethodName);
 
             cleanupTask(taskID);
 
@@ -211,8 +211,8 @@ public class TimeArbiter {
                                          Class<?> callingClass, String callingMethodName) {
         int taskID = taskCounter.incrementAndGet();
 
-        Debug.debug(TimeArbiter.class, 211, "Creating new TaskHandle: [ " + taskID +
-            " ] From: " + callingClass + " " + callingMethodName);
+        Debug.system("create task [" + taskID + "] from "
+            + callingClass.getSimpleName() + "." + callingMethodName);
 
         TaskHandle handle = new TaskHandle(taskID, timeBound,
             null, precheck, postcheck, paused, callbacks, delayMs, periodMs,

--- a/src/main/java/btm/sword/system/entity/SwordEntityArbiter.java
+++ b/src/main/java/btm/sword/system/entity/SwordEntityArbiter.java
@@ -57,7 +57,10 @@ public class SwordEntityArbiter {
 
             if (Sword.getInstance().isEnabled()) {
                 SwordScheduler.runBukkitTaskLater(
-                    () -> onlineSwordPlayers.get(entityUUID).onRegister(),
+                    () -> {
+                        SwordEntity sp = onlineSwordPlayers.getOrDefault(entityUUID, null);
+                        if (sp != null) sp.onRegister();
+                    },
                     200, TimeUnit.MILLISECONDS
                 );
             }

--- a/src/main/java/btm/sword/system/entity/base/SwordEntity.java
+++ b/src/main/java/btm/sword/system/entity/base/SwordEntity.java
@@ -404,6 +404,10 @@ public abstract class SwordEntity {
         return eyeLoc().add(dir().multiply(distance));
     }
 
+    public Location locFromFlatDir(double distance) {
+        return eyeLoc().add(getFlatBodyDir().multiply(distance));
+    }
+
     public EntityType type() {
         return self.getType();
     }

--- a/src/main/java/btm/sword/system/entity/base/SwordEntity.java
+++ b/src/main/java/btm/sword/system/entity/base/SwordEntity.java
@@ -186,7 +186,7 @@ public abstract class SwordEntity {
             SwordEntity.class, "startTicking",
             new PredicateRunnablePair(
                 this::isDestroyed,
-                () -> Debug.debug(SwordEntity.class, 188, "ending the ticking task")
+                () -> Debug.system("tick task ending")
             )
         );
     }
@@ -425,7 +425,7 @@ public abstract class SwordEntity {
      * Increments the count of impalements on this entity.
      */
     public void addImpalement(Impalement impalement) {
-        Debug.debug(SwordEntity.class, 425, "addingImpalement");
+        Debug.combat("addImpalement");
         impalements.add(impalement);
     }
 
@@ -661,21 +661,16 @@ public abstract class SwordEntity {
         self.sendMessage(message);
     }
 
-    public void info(String message) {
-        if (Config.Debug.LOGGING_VERBOSE_CONFIG) {
+    /**
+     * Sends a debug message to this entity's chat and to the server console,
+     * gated by {@link Config.Debug#LOGGING_VERBOSE_INVENTORY}.
+     *
+     * @param message the inventory debug string to emit
+     */
+    public void inventoryInfo(String message) {
+        if (Config.Debug.LOGGING_VERBOSE_INVENTORY) {
             this.message(message);
-        }
-    }
-
-    public void combatInfo(String message) {
-        if (Config.Debug.LOGGING_VERBOSE_COMBAT) {
-            this.message(message);
-        }
-    }
-
-    public void movementInfo(String message) {
-        if (Config.Debug.LOGGING_VERBOSE_MOVEMENT) {
-            this.message(message);
+            Sword.print("[Inventory][" + self.getName() + "] " + message);
         }
     }
 

--- a/src/main/java/btm/sword/system/entity/impl/Combatant.java
+++ b/src/main/java/btm/sword/system/entity/impl/Combatant.java
@@ -28,6 +28,7 @@ import btm.sword.system.entity.umbral.statemachine.state.StandbyState;
 import btm.sword.system.entity.umbral.statemachine.state.WieldState;
 import btm.sword.system.input.ActivationContext;
 import btm.sword.system.item.KeyRegistry;
+import btm.sword.utility.Debug;
 import btm.sword.utility.Prefab;
 import lombok.Getter;
 import lombok.Setter;
@@ -174,8 +175,8 @@ public abstract class Combatant extends SwordEntity {
     }
 
     public void consumeSoulfire(float requiredSoulfire) {
-        combatInfo("Current: " + String.format("%.1f", aspects.soulfireCur()) +
-            " to remove: " + String.format("%.1f", requiredSoulfire));
+        Debug.combat("soulfire cur=" + String.format("%.1f", aspects.soulfireCur())
+            + " cost=" + String.format("%.1f", requiredSoulfire));
         aspects.soulfire().remove(requiredSoulfire);
         aspects.soulfire().restartRegenTaskLater(aspects.soulfire().getBaseRegenPeriod());
     }

--- a/src/main/java/btm/sword/system/entity/impl/Hostile.java
+++ b/src/main/java/btm/sword/system/entity/impl/Hostile.java
@@ -22,7 +22,6 @@ import com.destroystokyo.paper.entity.Pathfinder;
 import com.destroystokyo.paper.entity.ai.GoalType;
 
 import btm.sword.system.action.throwing.types.DroppedItem;
-import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.ai.HostileStateMachine;
 import btm.sword.system.entity.ai.MobGoalArbiter;
 import btm.sword.system.entity.ai.WanderProfile;
@@ -35,6 +34,7 @@ import btm.sword.system.entity.aspect.Resource;
 import btm.sword.system.entity.base.CombatProfile;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.item.prefab.ItemLibrary;
+import btm.sword.utility.Debug;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -200,7 +200,7 @@ public class Hostile extends Combatant {
     public void broadcastMessage(double radius, String message) {
         for (Entity entity : self().getNearbyEntities(radius, radius, radius)) {
             if (entity instanceof Player player) {
-                SwordEntityArbiter.getOrAdd(player).combatInfo("[" + self().getName() + "] " + message);
+                Debug.hostile("[" + self().getName() + "] " + message);
             }
         }
     }

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -18,10 +18,8 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.TextDisplay;
 import org.bukkit.event.inventory.ClickType;
-import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.EquipmentSlot;
-import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
@@ -484,29 +482,37 @@ public class SwordPlayer extends Combatant {
      * @return true if the event was handled and should be cancelled, false otherwise
      */
     public boolean handleInventoryInput(InventoryClickEvent e) {
-        Inventory inv = e.getInventory();
         ClickType clickType = e.getClick();
-        InventoryAction action = e.getAction();
         ItemStack onCursor = e.getCursor();
         ItemStack clicked = e.getCurrentItem();
-        int slotNumber = e.getSlot();
+
+        // Protect non-movable items on cursor from being placed into any slot
+        if (NonMovableItem.isNonMovable(onCursor)) {
+            return true;
+        }
 
         if (clicked == null) {
-
             return false;
         }
 
-        // Protect non-movable items from being interacted with
-        if (NonMovableItem.isNonMovable(clicked) || NonMovableItem.isNonMovable(onCursor)) {
-            return true; // Cancel the action
+        // Protect non-movable items in slots from being moved or interacted with
+        if (NonMovableItem.isNonMovable(clicked)) {
+            return true;
         }
-//        message("\n\n~|------Beginning of new inventory interact event------|~"
-//                + "\n       Inventory: " + inv.getType()
-//                + "\n       Click type: " + clickType
-//                + "\n       Action type: " + action
-//                + "\n       Item on cursor: " + onCursor
-//                + "\n       Current Item in slot: " + clicked
-//                + "\n       slot number: " + slotNumber);
+
+        // Protect non-movable items in hotbar slots from being swapped via number keys
+        if (clickType == ClickType.NUMBER_KEY) {
+            int hotbarSlot = e.getHotbarButton();
+            if (hotbarSlot >= 0 && NonMovableItem.isNonMovable(player.getInventory().getItem(hotbarSlot))) {
+                return true;
+            }
+        }
+
+        // Protect non-movable items in the offhand slot from being swapped via F key
+        if (clickType == ClickType.SWAP_OFFHAND && NonMovableItem.isNonMovable(player.getInventory().getItem(40))) {
+            return true;
+        }
+
         return false;
     }
 

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -10,6 +10,7 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 import org.bukkit.Color;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Display;
 import org.bukkit.entity.EntityType;
@@ -18,6 +19,7 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.TextDisplay;
 import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
@@ -26,6 +28,7 @@ import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.Transformation;
+import org.bukkit.util.Vector;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
@@ -34,6 +37,7 @@ import com.destroystokyo.paper.profile.PlayerProfile;
 import btm.sword.config.Config;
 import btm.sword.system.action.BlockAction;
 import btm.sword.system.action.throwing.ThrowAction;
+import btm.sword.system.action.throwing.types.DroppedItem;
 import btm.sword.system.control.PredicateRunnablePair;
 import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.control.TimeArbiter;
@@ -483,6 +487,7 @@ public class SwordPlayer extends Combatant {
      */
     public boolean handleInventoryInput(InventoryClickEvent e) {
         ClickType clickType = e.getClick();
+        InventoryAction action = e.getAction();
         ItemStack onCursor = e.getCursor();
         ItemStack clicked = e.getCurrentItem();
 
@@ -513,7 +518,65 @@ public class SwordPlayer extends Combatant {
             return true;
         }
 
+        // Handle Q / Ctrl+Q drops from inventory slots and cursor
+        boolean fromCursor = action == InventoryAction.DROP_ONE_CURSOR || action == InventoryAction.DROP_ALL_CURSOR;
+        boolean dropAll = action == InventoryAction.DROP_ALL_SLOT || action == InventoryAction.DROP_ALL_CURSOR;
+
+        if (action == InventoryAction.DROP_ONE_SLOT || action == InventoryAction.DROP_ALL_SLOT
+                || action == InventoryAction.DROP_ONE_CURSOR || action == InventoryAction.DROP_ALL_CURSOR) {
+
+            ItemStack source = fromCursor ? onCursor : clicked;
+            if (source == null || source.isEmpty()) return false;
+
+            ItemStack toDrop = source.clone();
+            if (!dropAll) toDrop.setAmount(1);
+
+            if (fromCursor) {
+                if (dropAll || source.getAmount() <= 1) {
+                    player.setItemOnCursor(null);
+                } else {
+                    ItemStack remaining = source.clone();
+                    remaining.setAmount(remaining.getAmount() - 1);
+                    player.setItemOnCursor(remaining);
+                }
+            } else {
+                if (dropAll || source.getAmount() <= 1) {
+                    e.getInventory().setItem(e.getSlot(), null);
+                } else {
+                    ItemStack remaining = source.clone();
+                    remaining.setAmount(remaining.getAmount() - 1);
+                    e.getInventory().setItem(e.getSlot(), remaining);
+                }
+            }
+
+            spawnInventoryDrop(toDrop);
+            return true;
+        }
+
         return false;
+    }
+
+    /**
+     * Spawns an appropriate world drop for an item leaving the player's inventory.
+     * <p>
+     * {@link ItemClass#THROWABLE} items (weapons, axes, etc.) become {@link DroppedItem}s with
+     * custom physics so they must be picked up manually from the ground. All other items become
+     * standard Bukkit item entities.
+     * </p>
+     *
+     * @param item the stack to drop into the world; must not be null or empty
+     */
+    private void spawnInventoryDrop(ItemStack item) {
+        Vector flatDir = player.getLocation().getDirection().clone().setY(0);
+        if (flatDir.lengthSquared() > 0) flatDir.normalize().multiply(0.4);
+
+        Location dropLocation = player.getLocation().clone().add(flatDir).add(0, 1.0, 0);
+
+        if (ItemClassifier.classify(item) == ItemClass.THROWABLE) {
+            new DroppedItem(dropLocation, new Vector(0, 0, 0), item).register();
+        } else {
+            player.getWorld().dropItem(dropLocation, item);
+        }
     }
 
     public void updateVisualStats() {

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -14,6 +14,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Display;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.ItemDisplay;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -61,6 +62,7 @@ import btm.sword.system.item.SwordItemType;
 import btm.sword.system.item.special.NonMovableItem;
 import btm.sword.system.item.special.SlotAnchoredItem;
 import btm.sword.system.playerdata.PlayerData;
+import btm.sword.utility.Debug;
 import btm.sword.utility.Prefab;
 import btm.sword.utility.SwordTimeUnit;
 import btm.sword.utility.display.DisplayUtil;
@@ -105,7 +107,6 @@ public class SwordPlayer extends Combatant {
     @Setter
     private ActivationContext activationContext = ActivationContext.NORMAL;
 
-    @Setter
     private boolean performedDropAction;
     @Getter
     @Setter
@@ -142,6 +143,8 @@ public class SwordPlayer extends Combatant {
 
     private boolean swappingInInv;
     private boolean droppingInInv;
+    @Setter
+    private boolean inInventorySession;
 
     private BukkitTask targetIndicatorTask;
     private SwordEntity targetedEntity;
@@ -224,6 +227,7 @@ public class SwordPlayer extends Combatant {
 
         swappingInInv = false;
         droppingInInv = false;
+        inInventorySession = false;
     }
 
     /**
@@ -518,38 +522,9 @@ public class SwordPlayer extends Combatant {
             return true;
         }
 
-        // Handle Q / Ctrl+Q drops from inventory slots and cursor
-        boolean fromCursor = action == InventoryAction.DROP_ONE_CURSOR || action == InventoryAction.DROP_ALL_CURSOR;
-        boolean dropAll = action == InventoryAction.DROP_ALL_SLOT || action == InventoryAction.DROP_ALL_CURSOR;
-
+        // Block all Q / Ctrl+Q drops from inventory — players cannot drop items via inventory
         if (action == InventoryAction.DROP_ONE_SLOT || action == InventoryAction.DROP_ALL_SLOT
                 || action == InventoryAction.DROP_ONE_CURSOR || action == InventoryAction.DROP_ALL_CURSOR) {
-
-            ItemStack source = fromCursor ? onCursor : clicked;
-            if (source == null || source.isEmpty()) return false;
-
-            ItemStack toDrop = source.clone();
-            if (!dropAll) toDrop.setAmount(1);
-
-            if (fromCursor) {
-                if (dropAll || source.getAmount() <= 1) {
-                    player.setItemOnCursor(null);
-                } else {
-                    ItemStack remaining = source.clone();
-                    remaining.setAmount(remaining.getAmount() - 1);
-                    player.setItemOnCursor(remaining);
-                }
-            } else {
-                if (dropAll || source.getAmount() <= 1) {
-                    e.getInventory().setItem(e.getSlot(), null);
-                } else {
-                    ItemStack remaining = source.clone();
-                    remaining.setAmount(remaining.getAmount() - 1);
-                    e.getInventory().setItem(e.getSlot(), remaining);
-                }
-            }
-
-            spawnInventoryDrop(toDrop);
             return true;
         }
 
@@ -563,19 +538,22 @@ public class SwordPlayer extends Combatant {
      * custom physics so they must be picked up manually from the ground. All other items become
      * standard Bukkit item entities.
      * </p>
+     * <p>
+     * Called both from {@link #handleInventoryInput} (Q/Ctrl+Q in inventory) and from
+     * {@link btm.sword.listeners.InputListener#onPlayerDropEvent} when the player drags an item
+     * outside the inventory window.
+     * </p>
      *
      * @param item the stack to drop into the world; must not be null or empty
      */
-    private void spawnInventoryDrop(ItemStack item) {
-        Vector flatDir = player.getLocation().getDirection().clone().setY(0);
-        if (flatDir.lengthSquared() > 0) flatDir.normalize().multiply(0.4);
-
-        Location dropLocation = player.getLocation().clone().add(flatDir).add(0, 1.0, 0);
+    public void spawnInventoryDrop(ItemStack item) {
+        Location dropLocation = locFromFlatDir(1.5);
 
         if (ItemClassifier.classify(item) == ItemClass.THROWABLE) {
             new DroppedItem(dropLocation, new Vector(0, 0, 0), item).register();
         } else {
-            player.getWorld().dropItem(dropLocation, item);
+            Item itemDrop = player.getWorld().dropItem(dropLocation, item);
+            itemDrop.setPickupDelay(20);
         }
     }
 
@@ -1093,11 +1071,29 @@ public class SwordPlayer extends Combatant {
      * Resets the flag shortly after (1 tick).
      */
     public void setDroppingInInv() {
+        Debug.inventory(">> set dropping in inv");
+
         droppingInInv = true;
         SwordScheduler.runBukkitTaskLater(
-            () -> droppingInInv = false,
-            50, TimeUnit.MILLISECONDS
+            () -> {
+                Debug.inventory(">> no longer dropping in inv");
+                droppingInInv = false;
+            },
+            100, TimeUnit.MILLISECONDS
         );
+    }
+
+    public void setPerformedDropAction() {
+        performedDropAction = true;
+        SwordScheduler.runBukkitTaskLater(
+            () -> performedDropAction = false,
+            100, TimeUnit.MILLISECONDS
+        );
+    }
+
+    @SuppressWarnings("all")
+    public boolean isInInventorySession() {
+        return inInventorySession;
     }
 
     public void incrementNumDummies() {

--- a/src/main/java/btm/sword/system/entity/umbral/statemachine/UmbralStateMachine.java
+++ b/src/main/java/btm/sword/system/entity/umbral/statemachine/UmbralStateMachine.java
@@ -23,6 +23,7 @@ import btm.sword.system.entity.umbral.statemachine.state.SheathedState;
 import btm.sword.system.entity.umbral.statemachine.state.StandbyState;
 import btm.sword.system.entity.umbral.statemachine.state.WaitingState;
 import btm.sword.system.entity.umbral.statemachine.state.WieldState;
+import btm.sword.utility.Debug;
 import btm.sword.utility.Prefab;
 import btm.sword.utility.math.VectorUtil;
 import btm.sword.utility.statemachine.State;
@@ -385,6 +386,7 @@ public class UmbralStateMachine extends StateMachine<UmbralBlade> {
     @Override
     public void setState(State<UmbralBlade> next) {
         previousState = (UmbralStateFacade) currentState;
+        Debug.system(currentState.getClass().getSimpleName() + " -> " + next.getClass().getSimpleName());
         super.setState(next);
 
         @SuppressWarnings("unchecked")

--- a/src/main/java/btm/sword/system/input/InputRegistrar.java
+++ b/src/main/java/btm/sword/system/input/InputRegistrar.java
@@ -69,7 +69,6 @@ public class InputRegistrar {
                 .action(GrabAction::grab)
                 .cooldown(executor -> executor.calcCooldown(AspectType.FORTITUDE, 200, 1000, 10))
                 .canCast(Combatant::canPerformAction)
-                .requiredSoulfire(() -> 2f)
                 .castDuration(() -> Config.Grab.CAST_DURATION)
                 .displayDisabled(true)
                 .resetIfCannotPerform(true)

--- a/src/main/java/btm/sword/system/inventory/menu/DevMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/DevMenu.java
@@ -38,8 +38,8 @@ public class DevMenu extends Menu {
 
         SimpleItem verboseDebug = toggle(
             "Debug.debug() output",
-            () -> Debug.VERBOSE_ENABLED,
-            () -> Debug.VERBOSE_ENABLED = !Debug.VERBOSE_ENABLED
+            () -> Debug.VERBOSE_ENABLED.get(),
+            () -> Config.Debug.LOGGING_VERBOSE_DEBUG = !Config.Debug.LOGGING_VERBOSE_DEBUG
         );
 
         SimpleItem verboseCombat = toggle(
@@ -87,7 +87,8 @@ public class DevMenu extends Menu {
         Gui gui = Gui.normal()
             .setStructure(
                 "# # # # # # # # #",
-                "# A B C D E G F #",
+                "# A B C D E . . #",
+                "# G F . . . . . #",
                 "# # # < . > # # #")
             .addIngredient('#', BORDER)
             .addIngredient('A', verboseDebug)

--- a/src/main/java/btm/sword/system/inventory/menu/DevMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/DevMenu.java
@@ -38,7 +38,7 @@ public class DevMenu extends Menu {
 
         SimpleItem verboseDebug = toggle(
             "Debug.debug() output",
-            () -> Debug.VERBOSE_ENABLED.get(),
+            Debug.VERBOSE_ENABLED::get,
             () -> Config.Debug.LOGGING_VERBOSE_DEBUG = !Config.Debug.LOGGING_VERBOSE_DEBUG
         );
 
@@ -87,8 +87,8 @@ public class DevMenu extends Menu {
         Gui gui = Gui.normal()
             .setStructure(
                 "# # # # # # # # #",
-                "# A B C D E . . #",
-                "# G F . . . . . #",
+                "# A B C . G . F #",
+                "# D E . . . . . #",
                 "# # # < . > # # #")
             .addIngredient('#', BORDER)
             .addIngredient('A', verboseDebug)

--- a/src/main/java/btm/sword/system/inventory/menu/DevMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/DevMenu.java
@@ -25,6 +25,9 @@ import xyz.xenondevs.invui.window.Window;
  * Toggles take effect immediately without a server restart. They are not
  * persisted — all flags reset to their defaults on server restart.
  * </p>
+ *
+ * <p>Row 1 (verbose flags): Debug, Combat, Movement, Inventory, System, Umbral, Hostile</p>
+ * <p>Row 2 (utilities): Special Item Checks, Reload Profile, Config Editor</p>
  */
 public class DevMenu extends Menu {
 
@@ -37,40 +40,51 @@ public class DevMenu extends Menu {
         Player player = swordPlayer.player();
 
         SimpleItem verboseDebug = toggle(
-            "Debug.debug() output",
-            Debug.VERBOSE_ENABLED::get,
+            "Debug (general)",
+            () -> Config.Debug.LOGGING_VERBOSE_DEBUG,
             () -> Config.Debug.LOGGING_VERBOSE_DEBUG = !Config.Debug.LOGGING_VERBOSE_DEBUG
         );
 
         SimpleItem verboseCombat = toggle(
-            "Verbose combat logging",
+            "Combat",
             () -> Config.Debug.LOGGING_VERBOSE_COMBAT,
             () -> Config.Debug.LOGGING_VERBOSE_COMBAT = !Config.Debug.LOGGING_VERBOSE_COMBAT
         );
 
         SimpleItem verboseMovement = toggle(
-            "Verbose movement logging",
+            "Movement",
             () -> Config.Debug.LOGGING_VERBOSE_MOVEMENT,
             () -> Config.Debug.LOGGING_VERBOSE_MOVEMENT = !Config.Debug.LOGGING_VERBOSE_MOVEMENT
         );
 
-        SimpleItem verboseConfig = toggle(
-            "Verbose config logging",
-            () -> Config.Debug.LOGGING_VERBOSE_CONFIG,
-            () -> Config.Debug.LOGGING_VERBOSE_CONFIG = !Config.Debug.LOGGING_VERBOSE_CONFIG
+        SimpleItem verboseInventory = toggle(
+            "Inventory",
+            () -> Config.Debug.LOGGING_VERBOSE_INVENTORY,
+            () -> Config.Debug.LOGGING_VERBOSE_INVENTORY = !Config.Debug.LOGGING_VERBOSE_INVENTORY
+        );
+
+        SimpleItem verboseSystem = toggle(
+            "System (FSM / tasks)",
+            () -> Config.Debug.LOGGING_VERBOSE_SYSTEM,
+            () -> Config.Debug.LOGGING_VERBOSE_SYSTEM = !Config.Debug.LOGGING_VERBOSE_SYSTEM
+        );
+
+        SimpleItem verboseUmbral = toggle(
+            "Umbral",
+            () -> Config.Debug.LOGGING_VERBOSE_UMBRAL,
+            () -> Config.Debug.LOGGING_VERBOSE_UMBRAL = !Config.Debug.LOGGING_VERBOSE_UMBRAL
+        );
+
+        SimpleItem verboseHostile = toggle(
+            "Hostile",
+            () -> Config.Debug.LOGGING_VERBOSE_HOSTILE,
+            () -> Config.Debug.LOGGING_VERBOSE_HOSTILE = !Config.Debug.LOGGING_VERBOSE_HOSTILE
         );
 
         SimpleItem specialItemChecks = toggle(
             "Special item checks",
             () -> Debug.SPECIAL_ITEM_CHECKS_ENABLED,
             () -> Debug.SPECIAL_ITEM_CHECKS_ENABLED = !Debug.SPECIAL_ITEM_CHECKS_ENABLED
-        );
-
-        SimpleItem configEditor = new SimpleItem(
-            new ItemStackBuilder(Material.COMPARATOR)
-                .name(Component.text("Config Editor", NamedTextColor.GOLD, TextDecoration.BOLD))
-                .build(),
-            click -> new ConfigMenu(swordPlayer).open()
         );
 
         SimpleItem reloadProfile = new SimpleItem(
@@ -84,20 +98,30 @@ public class DevMenu extends Menu {
             }
         );
 
+        SimpleItem configEditor = new SimpleItem(
+            new ItemStackBuilder(Material.COMPARATOR)
+                .name(Component.text("Config Editor", NamedTextColor.GOLD, TextDecoration.BOLD))
+                .build(),
+            click -> new ConfigMenu(swordPlayer).open()
+        );
+
         Gui gui = Gui.normal()
             .setStructure(
                 "# # # # # # # # #",
-                "# A B C . G . F #",
-                "# D E . . . . . #",
+                "A B C D H E F . J",
+                ". . . . . . . . I",
                 "# # # < . > # # #")
             .addIngredient('#', BORDER)
             .addIngredient('A', verboseDebug)
             .addIngredient('B', verboseCombat)
             .addIngredient('C', verboseMovement)
-            .addIngredient('D', verboseConfig)
-            .addIngredient('E', specialItemChecks)
-            .addIngredient('G', reloadProfile)
-            .addIngredient('F', configEditor)
+            .addIngredient('D', verboseInventory)
+            .addIngredient('E', verboseSystem)
+            .addIngredient('F', verboseUmbral)
+            .addIngredient('G', verboseHostile)
+            .addIngredient('H', specialItemChecks)
+            .addIngredient('I', reloadProfile)
+            .addIngredient('J', configEditor)
             .addIngredient('<', generatePreviousButtonOrDefault())
             .addIngredient('>', generateForwardPreviousButtonOrDefault())
             .build();

--- a/src/main/java/btm/sword/system/inventory/menu/DevStatEditorMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/DevStatEditorMenu.java
@@ -65,9 +65,10 @@ public class DevStatEditorMenu extends Menu {
         // Layout: 2 rows of 9 — 12 aspects fit neatly
         Gui gui = Gui.normal()
             .setStructure(
-                "# # # B # # # # #",
+                "# # # # # # # # #",
                 "0 1 2 3 4 5 6 7 8",
-                "9 A B C . . . . #")
+                ". . . 9 A C . . .",
+                "# # # # B # # # #")
             .addIngredient('#', BORDER)
             .addIngredient('B', back)
             .addIngredient('0', items.get(0))   // SHARDS

--- a/src/main/java/btm/sword/system/inventory/menu/MainMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/MainMenu.java
@@ -18,6 +18,7 @@ import btm.sword.system.entity.impl.Dummy;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.inventory.InventoryMenuManager;
 import btm.sword.system.item.ItemStackBuilder;
+import btm.sword.system.item.special.NonMovableItem;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextDecoration;
 import xyz.xenondevs.invui.gui.Gui;
@@ -130,13 +131,26 @@ public class MainMenu extends Menu {
             click -> InventoryMenuManager.openMenu(MovesetMenu.class, swordPlayer)
         );
 
+        SimpleItem trashItem = new SimpleItem(
+            new ItemStackBuilder(Material.BARRIER)
+                .hideAll()
+                .name(Component.text("Item Trash", Config.SwordColor.TEXT_COOL, TextDecoration.BOLD))
+                .lore(List.of(Component.text("Click with an item to destroy it.", Config.SwordColor.TEXT_ITEM_BASE)))
+                .build(),
+            click -> {
+                ItemStack cursor = click.getPlayer().getItemOnCursor();
+                if (cursor.isEmpty() || NonMovableItem.isNonMovable(cursor)) return;
+                click.getPlayer().setItemOnCursor(new ItemStack(Material.AIR));
+            }
+        );
+
         Gui.Builder.Normal builder = Gui.normal()
             .setStructure(
                 "# # # . . . # # #",
                 "# . . . P . . . #",
                 ". . . . D Q . . .",
                 ". . . . . . . . .",
-                "# . . . H . M V #",
+                "# T . . H . M V #",
                 "# # # < . > # # #")
             .addIngredient('#', BORDER)
             .addIngredient('Q', queueForCTF)
@@ -144,6 +158,7 @@ public class MainMenu extends Menu {
             .addIngredient('P', HOW_TO_PLAY_ITEM)
             .addIngredient('D', spawnDummy)
             .addIngredient('M', combatReference)
+            .addIngredient('T', trashItem)
             .addIngredient('<', generatePreviousButtonOrDefault())
             .addIngredient('>', generateForwardPreviousButtonOrDefault());
 

--- a/src/main/java/btm/sword/system/item/special/SlotAnchoredItem.java
+++ b/src/main/java/btm/sword/system/item/special/SlotAnchoredItem.java
@@ -90,7 +90,6 @@ public class SlotAnchoredItem extends NonMovableItem {
      * @param player the player whose inventory to restore the item into
      */
     public void restore(Player player) {
-        // TODO: uncomment
-//        player.getInventory().setItem(targetSlot, itemStack);
+        player.getInventory().setItem(targetSlot, itemStack);
     }
 }

--- a/src/main/java/btm/sword/utility/Debug.java
+++ b/src/main/java/btm/sword/utility/Debug.java
@@ -1,11 +1,12 @@
 package btm.sword.utility;
 
 import java.util.List;
-import java.util.function.Supplier;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
 import btm.sword.Sword;
@@ -14,13 +15,28 @@ import btm.sword.utility.display.DrawUtil;
 import btm.sword.utility.math.Basis;
 import btm.sword.utility.math.VectorUtil;
 
+/**
+ * Centralized debug utility. Each category maps to a {@link Config.Debug} flag and a DevMenu toggle.
+ * <p>
+ * All methods log to the server console and, if online, send a chat message to the dev player
+ * ({@code BladeSworn}). Caller class and line number are captured automatically via
+ * {@link StackWalker} — no need to pass them manually.
+ * </p>
+ *
+ * <ul>
+ *   <li>{@link #debug}    – General/fallback debug  ({@code VERBOSE_DEBUG})</li>
+ *   <li>{@link #combat}   – Combat events            ({@code VERBOSE_COMBAT})</li>
+ *   <li>{@link #movement} – Movement / dash          ({@code VERBOSE_MOVEMENT})</li>
+ *   <li>{@link #inventory}– Inventory interactions   ({@code VERBOSE_INVENTORY})</li>
+ *   <li>{@link #system}   – State machine, scheduling({@code VERBOSE_SYSTEM})</li>
+ *   <li>{@link #umbral}   – UmbralBlade specific     ({@code VERBOSE_UMBRAL})</li>
+ *   <li>{@link #hostile}  – Hostile entity behaviour ({@code VERBOSE_HOSTILE})</li>
+ * </ul>
+ */
 public class Debug {
 
-    /**
-     * Master toggle for {@link #debug} output. Reads from {@link Config.Debug#LOGGING_VERBOSE_DEBUG}
-     * so the value persists across hot-reloads and is configurable from config.yaml.
-     */
-    public static final Supplier<Boolean> VERBOSE_ENABLED = () -> Config.Debug.LOGGING_VERBOSE_DEBUG;
+    private static final StackWalker WALKER =
+        StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
 
     /**
      * When {@code false}, {@link btm.sword.system.item.special.NonMovableItem#isNonMovable}
@@ -28,29 +44,69 @@ public class Debug {
      */
     public static boolean SPECIAL_ITEM_CHECKS_ENABLED = true;
 
-    @SuppressWarnings("all")
-    public static void debug(Class<?> clazz, int lineNum, String message) {
-        if (VERBOSE_ENABLED.get() && Config.Debug.LOGGING_VERBOSE_CONFIG) {
-            String toSend = "> " + clazz + " line" + " [" + lineNum + "] :: " + message;
-            Sword.print(toSend);
+    // =========================================================================
+    // Category methods
+    // =========================================================================
 
-            Player me = Bukkit.getPlayer("BladeSworn");
-
-            if (me != null && me.isValid()) {
-                me.sendMessage(toSend);
-            }
-        }
+    /** General debug output. Gated by {@link Config.Debug#LOGGING_VERBOSE_DEBUG}. */
+    public static void debug(String message) {
+        emit(Config.Debug.LOGGING_VERBOSE_DEBUG, "Debug", message);
     }
 
-    public static void combatDebug(Class<?> clazz, int lineNum, String message) {
-        if (!Config.Debug.LOGGING_VERBOSE_COMBAT) return;
-        debug(clazz, lineNum, "[Combat] " + message);
+    /** Combat-system debug. Gated by {@link Config.Debug#LOGGING_VERBOSE_COMBAT}. */
+    public static void combat(String message) {
+        emit(Config.Debug.LOGGING_VERBOSE_COMBAT, "Combat", message);
     }
 
+    /** Movement/dash debug. Gated by {@link Config.Debug#LOGGING_VERBOSE_MOVEMENT}. */
+    public static void movement(String message) {
+        emit(Config.Debug.LOGGING_VERBOSE_MOVEMENT, "Movement", message);
+    }
+
+    /** Inventory-interaction debug. Gated by {@link Config.Debug#LOGGING_VERBOSE_INVENTORY}. */
+    public static void inventory(String message) {
+        emit(Config.Debug.LOGGING_VERBOSE_INVENTORY, "Inventory", message);
+    }
+
+    /**
+     * System-level debug (state machine transitions, scheduler tasks, display lifecycle).
+     * Gated by {@link Config.Debug#LOGGING_VERBOSE_SYSTEM}.
+     */
+    public static void system(String message) {
+        emit(Config.Debug.LOGGING_VERBOSE_SYSTEM, "System", message);
+    }
+
+    /** UmbralBlade-specific debug. Gated by {@link Config.Debug#LOGGING_VERBOSE_UMBRAL}. */
+    public static void umbral(String message) {
+        emit(Config.Debug.LOGGING_VERBOSE_UMBRAL, "Umbral", message);
+    }
+
+    /** Hostile-entity debug. Gated by {@link Config.Debug#LOGGING_VERBOSE_HOSTILE}. */
+    public static void hostile(String message) {
+        emit(Config.Debug.LOGGING_VERBOSE_HOSTILE, "Hostile", message);
+    }
+
+    // =========================================================================
+    // Visual helpers
+    // =========================================================================
+
+    /**
+     * Renders a particle blob at the given location for visual debugging.
+     *
+     * @param debugLocation world location to display the blob
+     */
     public static void debugBlob(Location debugLocation) {
         Prefab.Particles.DEBUG_BLOB.display(debugLocation);
     }
 
+    /**
+     * Renders the three basis axes (right, up, forward) as particle lines originating from
+     * {@code location} in the given {@code direction}.
+     *
+     * @param location  origin of the basis
+     * @param direction direction to align the basis to
+     * @param length    length of each rendered axis line
+     */
     public static void debugBasis(Location location, Vector direction, double length) {
         Basis testBasis = VectorUtil.getBasis(location, direction);
         DrawUtil.line(List.of(Prefab.Particles.TEST_SWORD_BLUE),
@@ -59,5 +115,67 @@ public class Debug {
             location, testBasis.up(), length, 0.25);
         DrawUtil.line(List.of(Prefab.Particles.TEST_SWORD_BLUE),
             location, testBasis.forward(), length, 0.25);
+    }
+
+    /**
+     * Sends a formatted dump of an {@link InventoryClickEvent} to the clicking player.
+     * No-ops if {@link Config.Debug#LOGGING_VERBOSE_INVENTORY} is disabled.
+     *
+     * @param event the inventory click event to describe
+     */
+    public static void sendInventoryClickDebugMessage(InventoryClickEvent event) {
+        if (!Config.Debug.LOGGING_VERBOSE_INVENTORY) return;
+
+        StringBuilder b = new StringBuilder("> Inventory Click <\n");
+        b.append("Click: ").append(event.getClick())
+            .append(" | Action: ").append(event.getAction()).append('\n');
+        b.append("Slot: ").append(event.getSlot())
+            .append(" (raw ").append(event.getRawSlot())
+            .append(") | Hotbar: ").append(event.getHotbarButton()).append('\n');
+
+        b.append("ClickedInv: ");
+        if (event.getClickedInventory() == null) b.append("null");
+        else b.append(event.getClickedInventory().getType());
+        b.append(" | Top: ").append(event.getView().getTopInventory().getType())
+            .append(" | Bot: ").append(event.getView().getBottomInventory().getType()).append('\n');
+
+        b.append("Result: ").append(event.getResult())
+            .append(" | Cancelled: ").append(event.isCancelled()).append('\n');
+
+        ItemStack current = event.getCurrentItem();
+        ItemStack cursor = event.getCursor();
+        b.append("Current: ").append(current == null ? "null" : current.getType() + " x" + current.getAmount())
+            .append(" | Cursor: ").append(cursor.getType()).append(" x").append(cursor.getAmount()).append('\n');
+
+        b.append("Who: ").append(event.getWhoClicked().getName());
+
+        event.getWhoClicked().sendMessage(b.toString());
+    }
+
+    // =========================================================================
+    // Internal
+    // =========================================================================
+
+    /**
+     * Core emit: checks the flag, resolves the caller location via {@link StackWalker},
+     * logs to console, and forwards to the dev player if online.
+     *
+     * <p>Call depth (skip 3): {@code callerLocation} → {@code emit} → public method → actual caller.</p>
+     */
+    @SuppressWarnings("all")
+    private static void emit(boolean flag, String tag, String message) {
+        if (!flag) return;
+
+        String location = WALKER.walk(s -> s.skip(3).findFirst()
+            .map(f -> f.getDeclaringClass().getSimpleName() + ":" + f.getLineNumber())
+            .orElse("?:?"));
+
+        String line = "[" + tag + "][" + location + "] " + message;
+        Sword.print(line);
+
+        Player dev = Bukkit.getPlayer("BladeSworn");
+        if (dev != null && dev.isValid()) {
+            dev.sendMessage(line);
+        }
     }
 }

--- a/src/main/java/btm/sword/utility/Debug.java
+++ b/src/main/java/btm/sword/utility/Debug.java
@@ -1,6 +1,7 @@
 package btm.sword.utility;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -15,8 +16,11 @@ import btm.sword.utility.math.VectorUtil;
 
 public class Debug {
 
-    /** Master toggle for {@link #debug} output. Controlled via the in-game dev menu. */
-    public static boolean VERBOSE_ENABLED = false;
+    /**
+     * Master toggle for {@link #debug} output. Reads from {@link Config.Debug#LOGGING_VERBOSE_DEBUG}
+     * so the value persists across hot-reloads and is configurable from config.yaml.
+     */
+    public static final Supplier<Boolean> VERBOSE_ENABLED = () -> Config.Debug.LOGGING_VERBOSE_DEBUG;
 
     /**
      * When {@code false}, {@link btm.sword.system.item.special.NonMovableItem#isNonMovable}
@@ -26,7 +30,7 @@ public class Debug {
 
     @SuppressWarnings("all")
     public static void debug(Class<?> clazz, int lineNum, String message) {
-        if (VERBOSE_ENABLED && Config.Debug.LOGGING_VERBOSE_CONFIG) {
+        if (VERBOSE_ENABLED.get() && Config.Debug.LOGGING_VERBOSE_CONFIG) {
             String toSend = "> " + clazz + " line" + " [" + lineNum + "] :: " + message;
             Sword.print(toSend);
 

--- a/src/main/java/btm/sword/utility/display/DisplayUtil.java
+++ b/src/main/java/btm/sword/utility/display/DisplayUtil.java
@@ -90,7 +90,7 @@ public class DisplayUtil {
                 () -> iterations.getAndIncrement() > maxIterations || entity.isInvalid() || !display.isValid(),
                 () -> {
 
-                    Debug.debug(DisplayUtil.class, 90, "Display not valid. Current tick: " + iterations.get());
+                    Debug.system("display invalid, tick=" + iterations.get());
 
                     if (display.isValid() && removeOnArrival) display.remove();
                     if (callback != null) {
@@ -103,7 +103,7 @@ public class DisplayUtil {
                     currentDirectionToTarget.get().lengthSquared() < endDistance * endDistance,
                 () -> {
 
-                    Debug.debug(DisplayUtil.class, 101, "Got close enough Current tick: " + iterations.get());
+                    Debug.system("display arrived, tick=" + iterations.get());
 
                     if (display.isValid() && removeOnArrival) display.remove();
                     if (callback != null) {

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -325,13 +325,15 @@ world:
 
 
 debug:
-  
-  logging_verbose_combat: false
-  logging_verbose_movement: false
-  
-  logging_verbose_config: false
 
   logging_verbose_debug: false
+
+  logging_verbose_combat: false
+  logging_verbose_movement: false
+  logging_verbose_inventory: false
+  logging_verbose_system: false
+  logging_verbose_umbral: false
+  logging_verbose_hostile: false
 
   visualization_show_hitboxes: false
   visualization_show_raytraces: false

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -156,6 +156,7 @@ timing:
   intervals_combat_cleanup: 20
   
   attacks_combo_window_base: 3
+  right_interact_delay: 0
 
 
 display:
@@ -219,7 +220,7 @@ audio:
   punch_connect_vol: 1.5
   punch_connect_pitch: 1.0
   pre_attack_sound: ENTITY_DOLPHIN_JUMP
-  parry_attempt_sound: ENTITY_EVOKER_FANGS_ATTACK
+  parry_attempt_sound: ENTITY_ILLUSIONER_CAST_SPELL
 
 
 entity:
@@ -325,16 +326,12 @@ world:
 
 
 debug:
-
-  logging_verbose_debug: false
-
+  
   logging_verbose_combat: false
   logging_verbose_movement: false
-  logging_verbose_inventory: false
-  logging_verbose_system: false
-  logging_verbose_umbral: false
-  logging_verbose_hostile: false
-
+  
+  logging_verbose_config: false
+  
   visualization_show_hitboxes: false
   visualization_show_raytraces: false
 

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -330,7 +330,9 @@ debug:
   logging_verbose_movement: false
   
   logging_verbose_config: false
-  
+
+  logging_verbose_debug: false
+
   visualization_show_hitboxes: false
   visualization_show_raytraces: false
 


### PR DESCRIPTION
## Summary
- Block all Q/Ctrl+Q drops from inventory — players can no longer drop items via inventory
- Add `Config.Timing.RIGHT_INTERACT_DELAY` (default 0ms) to make the right-click interact delay configurable
- Null-check fix in `SwordEntityArbiter` onRegister delayed task
- Add `locFromFlatDir` helper on `SwordEntity`
- Remove `requiredSoulfire` from the grab action in `InputRegistrar`
- Debug log additions for inventory session tracking

Closes #70

## Test plan
- [ ] Verify inventory Q/Ctrl+Q drops are blocked for all item types
- [ ] Confirm right-click interact delay can be configured via config
- [ ] Test grab action without soulfire cost requirement
- [ ] Verify `SwordEntityArbiter` does not NPE on delayed registration
- [ ] Check debug logs show inventory session tracking correctly