### PR TITLE
[Feat] Make AttackType control vectors config-driven

### DIFF
--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -727,6 +727,21 @@ public class Config {
                 ConfigurationSection::getDouble
         ); }
 
+        /** Minimum sweep distance for heavy attack paths. */
+        public static double HEAVY_ATTACK_MIN_SWEEP_DISTANCE = 5.0;
+        static { register("combat.heavy_attack_min_sweep_distance",
+                HEAVY_ATTACK_MIN_SWEEP_DISTANCE, Double.class,
+                v -> HEAVY_ATTACK_MIN_SWEEP_DISTANCE = v,
+                ConfigurationSection::getDouble
+        ); }
+
+        /** Step distance for heavy attack secant particle path. */
+        public static double HEAVY_ATTACK_SECANT_STEP = 0.25;
+        static { register("combat.heavy_attack_secant_step",
+                HEAVY_ATTACK_SECANT_STEP, Double.class,
+                v -> HEAVY_ATTACK_SECANT_STEP = v,
+                ConfigurationSection::getDouble
+        ); }
 
         public static float SWEEP_ATTACK_X_SCALE = 0.5f;
         static { register(

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -194,6 +194,23 @@ public class Config {
     }
 
     /**
+     * Loader for {@link Vector} config values.
+     *
+     * <p>Expects the config path to point to a section with {@code x}, {@code y}, and {@code z}
+     * sub-keys. Missing sub-keys fall back to the corresponding component of {@code defaultValue}.
+     */
+    public static Vector loadVector(ConfigurationSection section, String path, Vector defaultValue) {
+        if (!section.contains(path)) return defaultValue.clone();
+        ConfigurationSection vec = section.getConfigurationSection(path);
+        if (vec == null) return defaultValue.clone();
+        return new Vector(
+            vec.getDouble("x", defaultValue.getX()),
+            vec.getDouble("y", defaultValue.getY()),
+            vec.getDouble("z", defaultValue.getZ())
+        );
+    }
+
+    /**
      * Loader for SoundType enum values.
      */
     public static SoundType loadSoundType(ConfigurationSection section, String path, SoundType defaultValue) {
@@ -3217,6 +3234,286 @@ public class Config {
             QUEST_STORAGE_ITEM, Material.class,
             v -> QUEST_STORAGE_ITEM = v,
             Config::loadMaterial); }
+    }
+
+    /**
+     * Bézier control-point vectors for each named {@link btm.sword.system.attack.style.AttackType}.
+     *
+     * <p>Each attack type exposes four {@link Vector} fields — {@code _START}, {@code _END},
+     * {@code _C1}, and {@code _C2} — corresponding to the four cubic Bézier control points.
+     * Values are loaded from the {@code attack_curves} YAML section as {@code {x, y, z}} maps
+     * and hot-reloaded by {@code /sword reload}.
+     *
+     * <p>{@link btm.sword.system.attack.style.AttackType} enum constants reference these fields
+     * via {@link btm.sword.utility.math.ControlVectors} suppliers so that live config changes
+     * take effect on the next attack without a restart.
+     */
+    public static class AttackCurves {
+        // UMBRAL_SLASH1
+        public static Vector UMBRAL_SLASH1_START = new Vector(-2, 0, 0);
+        static { register("attack_curves.umbral_slash1_start", UMBRAL_SLASH1_START, Vector.class,
+            v -> UMBRAL_SLASH1_START = v, Config::loadVector); }
+        public static Vector UMBRAL_SLASH1_END = new Vector(2, 0, -1);
+        static { register("attack_curves.umbral_slash1_end", UMBRAL_SLASH1_END, Vector.class,
+            v -> UMBRAL_SLASH1_END = v, Config::loadVector); }
+        public static Vector UMBRAL_SLASH1_C1 = new Vector(-1.5, 0, 2);
+        static { register("attack_curves.umbral_slash1_c1", UMBRAL_SLASH1_C1, Vector.class,
+            v -> UMBRAL_SLASH1_C1 = v, Config::loadVector); }
+        public static Vector UMBRAL_SLASH1_C2 = new Vector(1.5, 0, 3);
+        static { register("attack_curves.umbral_slash1_c2", UMBRAL_SLASH1_C2, Vector.class,
+            v -> UMBRAL_SLASH1_C2 = v, Config::loadVector); }
+
+        // UMBRAL_SLASH1_WINDUP
+        public static Vector UMBRAL_SLASH1_WINDUP_START = new Vector(-1.5, 0.17, 1);
+        static { register("attack_curves.umbral_slash1_windup_start", UMBRAL_SLASH1_WINDUP_START, Vector.class,
+            v -> UMBRAL_SLASH1_WINDUP_START = v, Config::loadVector); }
+        public static Vector UMBRAL_SLASH1_WINDUP_END = new Vector(-2.1, -0.33, -0.5);
+        static { register("attack_curves.umbral_slash1_windup_end", UMBRAL_SLASH1_WINDUP_END, Vector.class,
+            v -> UMBRAL_SLASH1_WINDUP_END = v, Config::loadVector); }
+        public static Vector UMBRAL_SLASH1_WINDUP_C1 = new Vector(-2, 0.17, 0.5);
+        static { register("attack_curves.umbral_slash1_windup_c1", UMBRAL_SLASH1_WINDUP_C1, Vector.class,
+            v -> UMBRAL_SLASH1_WINDUP_C1 = v, Config::loadVector); }
+        public static Vector UMBRAL_SLASH1_WINDUP_C2 = new Vector(-2, -0.08, 0);
+        static { register("attack_curves.umbral_slash1_windup_c2", UMBRAL_SLASH1_WINDUP_C2, Vector.class,
+            v -> UMBRAL_SLASH1_WINDUP_C2 = v, Config::loadVector); }
+
+        // WIDE_UMBRAL_SLASH1
+        public static Vector WIDE_UMBRAL_SLASH1_START = new Vector(-5.7615, 0, 2.171);
+        static { register("attack_curves.wide_umbral_slash1_start", WIDE_UMBRAL_SLASH1_START, Vector.class,
+            v -> WIDE_UMBRAL_SLASH1_START = v, Config::loadVector); }
+        public static Vector WIDE_UMBRAL_SLASH1_END = new Vector(5.845, 0, -0.334);
+        static { register("attack_curves.wide_umbral_slash1_end", WIDE_UMBRAL_SLASH1_END, Vector.class,
+            v -> WIDE_UMBRAL_SLASH1_END = v, Config::loadVector); }
+        public static Vector WIDE_UMBRAL_SLASH1_C1 = new Vector(-2.505, 0, 3.34);
+        static { register("attack_curves.wide_umbral_slash1_c1", WIDE_UMBRAL_SLASH1_C1, Vector.class,
+            v -> WIDE_UMBRAL_SLASH1_C1 = v, Config::loadVector); }
+        public static Vector WIDE_UMBRAL_SLASH1_C2 = new Vector(2.505, 0, 5.01);
+        static { register("attack_curves.wide_umbral_slash1_c2", WIDE_UMBRAL_SLASH1_C2, Vector.class,
+            v -> WIDE_UMBRAL_SLASH1_C2 = v, Config::loadVector); }
+
+        // WIDE_UMBRAL_SLASH1_WINDUP
+        public static Vector WIDE_UMBRAL_SLASH1_WINDUP_START = new Vector(-1.66, 0.17, -0.5);
+        static { register("attack_curves.wide_umbral_slash1_windup_start", WIDE_UMBRAL_SLASH1_WINDUP_START, Vector.class,
+            v -> WIDE_UMBRAL_SLASH1_WINDUP_START = v, Config::loadVector); }
+        public static Vector WIDE_UMBRAL_SLASH1_WINDUP_END = new Vector(-5, 0.27, 0.83);
+        static { register("attack_curves.wide_umbral_slash1_windup_end", WIDE_UMBRAL_SLASH1_WINDUP_END, Vector.class,
+            v -> WIDE_UMBRAL_SLASH1_WINDUP_END = v, Config::loadVector); }
+        public static Vector WIDE_UMBRAL_SLASH1_WINDUP_C1 = new Vector(-2.5, 1.03, 1.7);
+        static { register("attack_curves.wide_umbral_slash1_windup_c1", WIDE_UMBRAL_SLASH1_WINDUP_C1, Vector.class,
+            v -> WIDE_UMBRAL_SLASH1_WINDUP_C1 = v, Config::loadVector); }
+        public static Vector WIDE_UMBRAL_SLASH1_WINDUP_C2 = new Vector(-3.77, 0.51, 2.26);
+        static { register("attack_curves.wide_umbral_slash1_windup_c2", WIDE_UMBRAL_SLASH1_WINDUP_C2, Vector.class,
+            v -> WIDE_UMBRAL_SLASH1_WINDUP_C2 = v, Config::loadVector); }
+
+        // WIDE_UMBRAL_SLASH2
+        public static Vector WIDE_UMBRAL_SLASH2_START = new Vector(4.008, -1.002, -1.169);
+        static { register("attack_curves.wide_umbral_slash2_start", WIDE_UMBRAL_SLASH2_START, Vector.class,
+            v -> WIDE_UMBRAL_SLASH2_START = v, Config::loadVector); }
+        public static Vector WIDE_UMBRAL_SLASH2_END = new Vector(-3.841, 1.67, 4.008);
+        static { register("attack_curves.wide_umbral_slash2_end", WIDE_UMBRAL_SLASH2_END, Vector.class,
+            v -> WIDE_UMBRAL_SLASH2_END = v, Config::loadVector); }
+        public static Vector WIDE_UMBRAL_SLASH2_C1 = new Vector(1.67, 0, 2.839);
+        static { register("attack_curves.wide_umbral_slash2_c1", WIDE_UMBRAL_SLASH2_C1, Vector.class,
+            v -> WIDE_UMBRAL_SLASH2_C1 = v, Config::loadVector); }
+        public static Vector WIDE_UMBRAL_SLASH2_C2 = new Vector(-1.336, 0, 5.01);
+        static { register("attack_curves.wide_umbral_slash2_c2", WIDE_UMBRAL_SLASH2_C2, Vector.class,
+            v -> WIDE_UMBRAL_SLASH2_C2 = v, Config::loadVector); }
+
+        // WIDE_UMBRAL_SLASH2_WINDUP
+        public static Vector WIDE_UMBRAL_SLASH2_WINDUP_START = new Vector(5.344, -0.2171, -1.002);
+        static { register("attack_curves.wide_umbral_slash2_windup_start", WIDE_UMBRAL_SLASH2_WINDUP_START, Vector.class,
+            v -> WIDE_UMBRAL_SLASH2_WINDUP_START = v, Config::loadVector); }
+        public static Vector WIDE_UMBRAL_SLASH2_WINDUP_END = new Vector(4.509, -1.503, -2.338);
+        static { register("attack_curves.wide_umbral_slash2_windup_end", WIDE_UMBRAL_SLASH2_WINDUP_END, Vector.class,
+            v -> WIDE_UMBRAL_SLASH2_WINDUP_END = v, Config::loadVector); }
+        public static Vector WIDE_UMBRAL_SLASH2_WINDUP_C1 = new Vector(4.7261, 0, -0.501);
+        static { register("attack_curves.wide_umbral_slash2_windup_c1", WIDE_UMBRAL_SLASH2_WINDUP_C1, Vector.class,
+            v -> WIDE_UMBRAL_SLASH2_WINDUP_C1 = v, Config::loadVector); }
+        public static Vector WIDE_UMBRAL_SLASH2_WINDUP_C2 = new Vector(3.674, -0.4008, -1.5698);
+        static { register("attack_curves.wide_umbral_slash2_windup_c2", WIDE_UMBRAL_SLASH2_WINDUP_C2, Vector.class,
+            v -> WIDE_UMBRAL_SLASH2_WINDUP_C2 = v, Config::loadVector); }
+
+        // WIDE_UMBRAL_SLASH3
+        public static Vector WIDE_UMBRAL_SLASH3_START = new Vector(0, 5.177, -0.334);
+        static { register("attack_curves.wide_umbral_slash3_start", WIDE_UMBRAL_SLASH3_START, Vector.class,
+            v -> WIDE_UMBRAL_SLASH3_START = v, Config::loadVector); }
+        public static Vector WIDE_UMBRAL_SLASH3_END = new Vector(0, -3.674, 1.336);
+        static { register("attack_curves.wide_umbral_slash3_end", WIDE_UMBRAL_SLASH3_END, Vector.class,
+            v -> WIDE_UMBRAL_SLASH3_END = v, Config::loadVector); }
+        public static Vector WIDE_UMBRAL_SLASH3_C1 = new Vector(0, 1.7368, 1.67);
+        static { register("attack_curves.wide_umbral_slash3_c1", WIDE_UMBRAL_SLASH3_C1, Vector.class,
+            v -> WIDE_UMBRAL_SLASH3_C1 = v, Config::loadVector); }
+        public static Vector WIDE_UMBRAL_SLASH3_C2 = new Vector(0, -0.167, 2.9058);
+        static { register("attack_curves.wide_umbral_slash3_c2", WIDE_UMBRAL_SLASH3_C2, Vector.class,
+            v -> WIDE_UMBRAL_SLASH3_C2 = v, Config::loadVector); }
+
+        // WIDE_UMBRAL_SLASH3_WINDUP
+        public static Vector WIDE_UMBRAL_SLASH3_WINDUP_START = new Vector(-3.34, 2.0708, 3.34);
+        static { register("attack_curves.wide_umbral_slash3_windup_start", WIDE_UMBRAL_SLASH3_WINDUP_START, Vector.class,
+            v -> WIDE_UMBRAL_SLASH3_WINDUP_START = v, Config::loadVector); }
+        public static Vector WIDE_UMBRAL_SLASH3_WINDUP_END = new Vector(0.334, 4.0915, 0);
+        static { register("attack_curves.wide_umbral_slash3_windup_end", WIDE_UMBRAL_SLASH3_WINDUP_END, Vector.class,
+            v -> WIDE_UMBRAL_SLASH3_WINDUP_END = v, Config::loadVector); }
+        public static Vector WIDE_UMBRAL_SLASH3_WINDUP_C1 = new Vector(1.67, 0, 1.67);
+        static { register("attack_curves.wide_umbral_slash3_windup_c1", WIDE_UMBRAL_SLASH3_WINDUP_C1, Vector.class,
+            v -> WIDE_UMBRAL_SLASH3_WINDUP_C1 = v, Config::loadVector); }
+        public static Vector WIDE_UMBRAL_SLASH3_WINDUP_C2 = new Vector(-1.336, 0, 3.841);
+        static { register("attack_curves.wide_umbral_slash3_windup_c2", WIDE_UMBRAL_SLASH3_WINDUP_C2, Vector.class,
+            v -> WIDE_UMBRAL_SLASH3_WINDUP_C2 = v, Config::loadVector); }
+
+        // SLASH1
+        public static Vector SLASH1_START = new Vector(-2.06, -1.26, -0.5);
+        static { register("attack_curves.slash1_start", SLASH1_START, Vector.class,
+            v -> SLASH1_START = v, Config::loadVector); }
+        public static Vector SLASH1_END = new Vector(3.26, 0.79, -0.4);
+        static { register("attack_curves.slash1_end", SLASH1_END, Vector.class,
+            v -> SLASH1_END = v, Config::loadVector); }
+        public static Vector SLASH1_C1 = new Vector(-2.3, -0.16, 3);
+        static { register("attack_curves.slash1_c1", SLASH1_C1, Vector.class,
+            v -> SLASH1_C1 = v, Config::loadVector); }
+        public static Vector SLASH1_C2 = new Vector(1.9, 0.21, 5);
+        static { register("attack_curves.slash1_c2", SLASH1_C2, Vector.class,
+            v -> SLASH1_C2 = v, Config::loadVector); }
+
+        // SLASH2
+        public static Vector SLASH2_START = new Vector(2.6, -1.3, -1.2);
+        static { register("attack_curves.slash2_start", SLASH2_START, Vector.class,
+            v -> SLASH2_START = v, Config::loadVector); }
+        public static Vector SLASH2_END = new Vector(-3, 0.9, 1.3);
+        static { register("attack_curves.slash2_end", SLASH2_END, Vector.class,
+            v -> SLASH2_END = v, Config::loadVector); }
+        public static Vector SLASH2_C1 = new Vector(1.6, -0.7, 7);
+        static { register("attack_curves.slash2_c1", SLASH2_C1, Vector.class,
+            v -> SLASH2_C1 = v, Config::loadVector); }
+        public static Vector SLASH2_C2 = new Vector(-2.6, 1.05, 1.85);
+        static { register("attack_curves.slash2_c2", SLASH2_C2, Vector.class,
+            v -> SLASH2_C2 = v, Config::loadVector); }
+
+        // SLASH3
+        public static Vector SLASH3_START = new Vector(1.2, 2.8, -1.5);
+        static { register("attack_curves.slash3_start", SLASH3_START, Vector.class,
+            v -> SLASH3_START = v, Config::loadVector); }
+        public static Vector SLASH3_END = new Vector(-1.1, -2.2, -0.9);
+        static { register("attack_curves.slash3_end", SLASH3_END, Vector.class,
+            v -> SLASH3_END = v, Config::loadVector); }
+        public static Vector SLASH3_C1 = new Vector(1, 1.96, 4.3);
+        static { register("attack_curves.slash3_c1", SLASH3_C1, Vector.class,
+            v -> SLASH3_C1 = v, Config::loadVector); }
+        public static Vector SLASH3_C2 = new Vector(-1.1, -1.77, 5);
+        static { register("attack_curves.slash3_c2", SLASH3_C2, Vector.class,
+            v -> SLASH3_C2 = v, Config::loadVector); }
+
+        // UP_SMASH
+        public static Vector UP_SMASH_START = new Vector(0.66, -1.53, -0.5);
+        static { register("attack_curves.up_smash_start", UP_SMASH_START, Vector.class,
+            v -> UP_SMASH_START = v, Config::loadVector); }
+        public static Vector UP_SMASH_END = new Vector(-0.4, 0.67, -0.9);
+        static { register("attack_curves.up_smash_end", UP_SMASH_END, Vector.class,
+            v -> UP_SMASH_END = v, Config::loadVector); }
+        public static Vector UP_SMASH_C1 = new Vector(0.56, -0.89, 2.1);
+        static { register("attack_curves.up_smash_c1", UP_SMASH_C1, Vector.class,
+            v -> UP_SMASH_C1 = v, Config::loadVector); }
+        public static Vector UP_SMASH_C2 = new Vector(-0.4, 1.37, 1.65);
+        static { register("attack_curves.up_smash_c2", UP_SMASH_C2, Vector.class,
+            v -> UP_SMASH_C2 = v, Config::loadVector); }
+
+        // LUNGE1
+        public static Vector LUNGE1_START = new Vector(0.37, 0, 2);
+        static { register("attack_curves.lunge1_start", LUNGE1_START, Vector.class,
+            v -> LUNGE1_START = v, Config::loadVector); }
+        public static Vector LUNGE1_END = new Vector(0, 0, 20);
+        static { register("attack_curves.lunge1_end", LUNGE1_END, Vector.class,
+            v -> LUNGE1_END = v, Config::loadVector); }
+        public static Vector LUNGE1_C1 = new Vector(1.1, 0, 3.1);
+        static { register("attack_curves.lunge1_c1", LUNGE1_C1, Vector.class,
+            v -> LUNGE1_C1 = v, Config::loadVector); }
+        public static Vector LUNGE1_C2 = new Vector(0, 0, 2.46);
+        static { register("attack_curves.lunge1_c2", LUNGE1_C2, Vector.class,
+            v -> LUNGE1_C2 = v, Config::loadVector); }
+
+        // F_DASH_ATTACK
+        public static Vector F_DASH_ATTACK_START = new Vector(-1.95, -0.76, 0.9);
+        static { register("attack_curves.f_dash_attack_start", F_DASH_ATTACK_START, Vector.class,
+            v -> F_DASH_ATTACK_START = v, Config::loadVector); }
+        public static Vector F_DASH_ATTACK_END = new Vector(1.2, 1.1, 7.3);
+        static { register("attack_curves.f_dash_attack_end", F_DASH_ATTACK_END, Vector.class,
+            v -> F_DASH_ATTACK_END = v, Config::loadVector); }
+        public static Vector F_DASH_ATTACK_C1 = new Vector(-1.6, -0.57, 2.7);
+        static { register("attack_curves.f_dash_attack_c1", F_DASH_ATTACK_C1, Vector.class,
+            v -> F_DASH_ATTACK_C1 = v, Config::loadVector); }
+        public static Vector F_DASH_ATTACK_C2 = new Vector(-0.93, 0, 4.9);
+        static { register("attack_curves.f_dash_attack_c2", F_DASH_ATTACK_C2, Vector.class,
+            v -> F_DASH_ATTACK_C2 = v, Config::loadVector); }
+
+        // B_DASH_ATTACK
+        public static Vector B_DASH_ATTACK_START = new Vector(0.696, 2.2388, 1.74);
+        static { register("attack_curves.b_dash_attack_start", B_DASH_ATTACK_START, Vector.class,
+            v -> B_DASH_ATTACK_START = v, Config::loadVector); }
+        public static Vector B_DASH_ATTACK_END = new Vector(-0.8932, -3.2016, 0.116);
+        static { register("attack_curves.b_dash_attack_end", B_DASH_ATTACK_END, Vector.class,
+            v -> B_DASH_ATTACK_END = v, Config::loadVector); }
+        public static Vector B_DASH_ATTACK_C1 = new Vector(0.3132, 0.4176, 2.204);
+        static { register("attack_curves.b_dash_attack_c1", B_DASH_ATTACK_C1, Vector.class,
+            v -> B_DASH_ATTACK_C1 = v, Config::loadVector); }
+        public static Vector B_DASH_ATTACK_C2 = new Vector(-0.58, -1.74, 1.3572);
+        static { register("attack_curves.b_dash_attack_c2", B_DASH_ATTACK_C2, Vector.class,
+            v -> B_DASH_ATTACK_C2 = v, Config::loadVector); }
+
+        // R_STRAFE_ATTACK
+        public static Vector R_STRAFE_ATTACK_START = new Vector(-1.503, -0.4008, 0.668);
+        static { register("attack_curves.r_strafe_attack_start", R_STRAFE_ATTACK_START, Vector.class,
+            v -> R_STRAFE_ATTACK_START = v, Config::loadVector); }
+        public static Vector R_STRAFE_ATTACK_END = new Vector(4.676, 0.334, 1.169);
+        static { register("attack_curves.r_strafe_attack_end", R_STRAFE_ATTACK_END, Vector.class,
+            v -> R_STRAFE_ATTACK_END = v, Config::loadVector); }
+        public static Vector R_STRAFE_ATTACK_C1 = new Vector(0.167, 0, 1.4362);
+        static { register("attack_curves.r_strafe_attack_c1", R_STRAFE_ATTACK_C1, Vector.class,
+            v -> R_STRAFE_ATTACK_C1 = v, Config::loadVector); }
+        public static Vector R_STRAFE_ATTACK_C2 = new Vector(2.2211, 0, 1.7702);
+        static { register("attack_curves.r_strafe_attack_c2", R_STRAFE_ATTACK_C2, Vector.class,
+            v -> R_STRAFE_ATTACK_C2 = v, Config::loadVector); }
+
+        // L_STRAFE_ATTACK
+        public static Vector L_STRAFE_ATTACK_START = new Vector(1.503, -0.4008, 0.668);
+        static { register("attack_curves.l_strafe_attack_start", L_STRAFE_ATTACK_START, Vector.class,
+            v -> L_STRAFE_ATTACK_START = v, Config::loadVector); }
+        public static Vector L_STRAFE_ATTACK_END = new Vector(-4.676, 0.334, 1.169);
+        static { register("attack_curves.l_strafe_attack_end", L_STRAFE_ATTACK_END, Vector.class,
+            v -> L_STRAFE_ATTACK_END = v, Config::loadVector); }
+        public static Vector L_STRAFE_ATTACK_C1 = new Vector(-0.167, 0, 1.4362);
+        static { register("attack_curves.l_strafe_attack_c1", L_STRAFE_ATTACK_C1, Vector.class,
+            v -> L_STRAFE_ATTACK_C1 = v, Config::loadVector); }
+        public static Vector L_STRAFE_ATTACK_C2 = new Vector(-2.2211, 0, 1.7702);
+        static { register("attack_curves.l_strafe_attack_c2", L_STRAFE_ATTACK_C2, Vector.class,
+            v -> L_STRAFE_ATTACK_C2 = v, Config::loadVector); }
+
+        // D_AIR
+        public static Vector D_AIR_START = new Vector(-0.35, 2.53, 0.56);
+        static { register("attack_curves.d_air_start", D_AIR_START, Vector.class,
+            v -> D_AIR_START = v, Config::loadVector); }
+        public static Vector D_AIR_END = new Vector(0, -3.42, -0.581);
+        static { register("attack_curves.d_air_end", D_AIR_END, Vector.class,
+            v -> D_AIR_END = v, Config::loadVector); }
+        public static Vector D_AIR_C1 = new Vector(0.329, -0.165, 4.97);
+        static { register("attack_curves.d_air_c1", D_AIR_C1, Vector.class,
+            v -> D_AIR_C1 = v, Config::loadVector); }
+        public static Vector D_AIR_C2 = new Vector(-0.07, -6.15, 0.98);
+        static { register("attack_curves.d_air_c2", D_AIR_C2, Vector.class,
+            v -> D_AIR_C2 = v, Config::loadVector); }
+
+        // N_AIR
+        public static Vector N_AIR_START = new Vector(1.0961, 1.742, -1.13);
+        static { register("attack_curves.n_air_start", N_AIR_START, Vector.class,
+            v -> N_AIR_START = v, Config::loadVector); }
+        public static Vector N_AIR_END = new Vector(0, -1.987, -0.791);
+        static { register("attack_curves.n_air_end", N_AIR_END, Vector.class,
+            v -> N_AIR_END = v, Config::loadVector); }
+        public static Vector N_AIR_C1 = new Vector(-0.2825, 0.951, 9.153);
+        static { register("attack_curves.n_air_c1", N_AIR_C1, Vector.class,
+            v -> N_AIR_C1 = v, Config::loadVector); }
+        public static Vector N_AIR_C2 = new Vector(-0.7458, -5.151, -1.808);
+        static { register("attack_curves.n_air_c2", N_AIR_C2, Vector.class,
+            v -> N_AIR_C2 = v, Config::loadVector); }
     }
     //endregion
 }

--- a/src/main/java/btm/sword/config/ConfigManager.java
+++ b/src/main/java/btm/sword/config/ConfigManager.java
@@ -195,6 +195,12 @@ public final class ConfigManager {
         } else if (value instanceof TextColor tc) {
             // Adventure TextColor has no YAML serializer; store as hex string matching loadTextColor()
             config.set(entry.path, String.format("#%06X", tc.value()));
+        } else if (value instanceof org.bukkit.util.Vector v) {
+            // Vector has no flat YAML representation; store as {x,y,z} section matching loadVector()
+            org.bukkit.configuration.ConfigurationSection sec = config.createSection(entry.path);
+            sec.set("x", v.getX());
+            sec.set("y", v.getY());
+            sec.set("z", v.getZ());
         } else {
             config.set(entry.path, value);
         }

--- a/src/main/java/btm/sword/system/attack/style/AttackType.java
+++ b/src/main/java/btm/sword/system/attack/style/AttackType.java
@@ -15,151 +15,156 @@ import btm.sword.utility.Prefab;
 import btm.sword.utility.math.ControlVectors;
 import btm.sword.utility.math.VectorUtil;
 
-// TODO: consider - add base range multiplier as well
+/**
+ * Named attack curve presets backed by cubic Bézier control points.
+ *
+ * <p>Each entry's control-point vectors are read from {@link Config.AttackCurves} via
+ * {@link ControlVectors} suppliers, so live config changes (e.g., {@code /sword reload})
+ * take effect on the next attack without a server restart.
+ */
 public enum AttackType implements AttackProfile {
 //region Initializations
-    // TODO: #242 - Make control vectors config-driven; support Supplier<Vector> in ControlVectors
-    UMBRAL_SLASH1(ControlVectors.of(
-        new Vector(-2,0,0),
-        new Vector(2,0,-1),
-        new Vector(-1.5,0,2),
-        new Vector(1.5,0,3)),
+    UMBRAL_SLASH1(new ControlVectors(
+        () -> Config.AttackCurves.UMBRAL_SLASH1_START,
+        () -> Config.AttackCurves.UMBRAL_SLASH1_END,
+        () -> Config.AttackCurves.UMBRAL_SLASH1_C1,
+        () -> Config.AttackCurves.UMBRAL_SLASH1_C2),
         e -> Attack::getRightVector
     ),
-    UMBRAL_SLASH1_WINDUP(ControlVectors.of(
-        new Vector(-1.5,0.17,1),
-        new Vector(-2.1,-0.33,-0.5),
-        new Vector(-2,0.17,0.5),
-        new Vector(-2,-0.08,0))
+    UMBRAL_SLASH1_WINDUP(new ControlVectors(
+        () -> Config.AttackCurves.UMBRAL_SLASH1_WINDUP_START,
+        () -> Config.AttackCurves.UMBRAL_SLASH1_WINDUP_END,
+        () -> Config.AttackCurves.UMBRAL_SLASH1_WINDUP_C1,
+        () -> Config.AttackCurves.UMBRAL_SLASH1_WINDUP_C2)
     ),
 
-    WIDE_UMBRAL_SLASH1(ControlVectors.of(
-        new Vector(-5.7615,0,2.171),
-        new Vector(5.845,0,-0.334),
-        new Vector(-2.505,0,3.34),
-        new Vector(2.505,0,5.01)),
+    WIDE_UMBRAL_SLASH1(new ControlVectors(
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH1_START,
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH1_END,
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH1_C1,
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH1_C2),
         e -> Attack::getRightVector
     ),
-    WIDE_UMBRAL_SLASH1_WINDUP(ControlVectors.of(
-        new Vector(-1.66,0.17,-0.5),
-        new Vector(-5,0.27,0.83),
-        new Vector(-2.5,1.03,1.7),
-        new Vector(-3.77,0.51,2.26))
+    WIDE_UMBRAL_SLASH1_WINDUP(new ControlVectors(
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH1_WINDUP_START,
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH1_WINDUP_END,
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH1_WINDUP_C1,
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH1_WINDUP_C2)
     ),
 
-    WIDE_UMBRAL_SLASH2(ControlVectors.of(
-        new Vector(4.008,-1.002,-1.169),
-        new Vector(-3.841,1.67,4.008),
-        new Vector(1.67,0,2.839),
-        new Vector(-1.336,0,5.01)),
+    WIDE_UMBRAL_SLASH2(new ControlVectors(
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH2_START,
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH2_END,
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH2_C1,
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH2_C2),
         e -> attack -> attack.getRightVector().multiply(-1).add(attack.getForwardVector().multiply(0.3))
     ),
-    WIDE_UMBRAL_SLASH2_WINDUP(ControlVectors.of(
-        new Vector(5.344,-0.2171,-1.002),
-        new Vector(4.509,-1.503,-2.338),
-        new Vector(4.7261,0,-0.501),
-        new Vector(3.674,-0.4008,-1.5698))
+    WIDE_UMBRAL_SLASH2_WINDUP(new ControlVectors(
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH2_WINDUP_START,
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH2_WINDUP_END,
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH2_WINDUP_C1,
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH2_WINDUP_C2)
     ),
 
-    WIDE_UMBRAL_SLASH3(ControlVectors.of(
-        new Vector(0,5.177,-0.334),
-        new Vector(0,-3.674,1.336),
-        new Vector(0,1.7368,1.67),
-        new Vector(0,-0.167,2.9058)),
+    WIDE_UMBRAL_SLASH3(new ControlVectors(
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH3_START,
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH3_END,
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH3_C1,
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH3_C2),
         e -> attack -> attack.getForwardVector().add(Config.Direction.UP().multiply(-2))
     ),
-    WIDE_UMBRAL_SLASH3_WINDUP(ControlVectors.of(
-        new Vector(-3.34,2.0708,3.34),
-        new Vector(0.334,4.0915,0),
-        new Vector(1.67,0,1.67),
-        new Vector(-1.336,0,3.841))
+    WIDE_UMBRAL_SLASH3_WINDUP(new ControlVectors(
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH3_WINDUP_START,
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH3_WINDUP_END,
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH3_WINDUP_C1,
+        () -> Config.AttackCurves.WIDE_UMBRAL_SLASH3_WINDUP_C2)
     ),
 
-    SLASH1(ControlVectors.of(
-        new Vector(-2.06, -1.26, -0.5),
-        new Vector(3.26, 0.79, -0.4),
-        new Vector(-2.3, -0.16,3),
-        new Vector(1.9, 0.21, 5)),
+    SLASH1(new ControlVectors(
+        () -> Config.AttackCurves.SLASH1_START,
+        () -> Config.AttackCurves.SLASH1_END,
+        () -> Config.AttackCurves.SLASH1_C1,
+        () -> Config.AttackCurves.SLASH1_C2),
         e -> attack -> attack.getRightVector().multiply(-0.5).add(attack.getForwardVector().multiply(0.1))
     ),
-    SLASH2(ControlVectors.of(
-        new Vector(2.6,-1.3,-1.2),
-        new Vector(-3,0.9,1.3),
-        new Vector(1.6,-0.7,7),
-        new Vector(-2.6,1.05,1.85)),
+    SLASH2(new ControlVectors(
+        () -> Config.AttackCurves.SLASH2_START,
+        () -> Config.AttackCurves.SLASH2_END,
+        () -> Config.AttackCurves.SLASH2_C1,
+        () -> Config.AttackCurves.SLASH2_C2),
         e -> attack -> attack.getRightVector().multiply(0.5).add(attack.getForwardVector().multiply(0.1))
     ),
-    SLASH3(ControlVectors.of(
-        new Vector(1.2,2.8,-1.5),
-        new Vector(-1.1,-2.2,-0.9),
-        new Vector(1,1.96,4.3),
-        new Vector(-1.1,-1.77,5)),
+    SLASH3(new ControlVectors(
+        () -> Config.AttackCurves.SLASH3_START,
+        () -> Config.AttackCurves.SLASH3_END,
+        () -> Config.AttackCurves.SLASH3_C1,
+        () -> Config.AttackCurves.SLASH3_C2),
         e -> attack -> attack.getTo().add(attack.getForwardVector().multiply(0.5))
     ),
 
-    UP_SMASH(ControlVectors.of(
-        new Vector(0.66,-1.53,-0.5),
-        new Vector(-0.4,0.67,-0.9),
-        new Vector(0.56,-0.89,2.1),
-        new Vector(-0.4,1.37,1.65)),
+    UP_SMASH(new ControlVectors(
+        () -> Config.AttackCurves.UP_SMASH_START,
+        () -> Config.AttackCurves.UP_SMASH_END,
+        () -> Config.AttackCurves.UP_SMASH_C1,
+        () -> Config.AttackCurves.UP_SMASH_C2),
         e -> attack -> Config.Direction.UP().multiply(5)
     ),
 
-    LUNGE1(ControlVectors.of(
-        new Vector(0.37,0,2),
-        new Vector(0,0,20),
-        new Vector(1.1,0,3.1),
-        new Vector(0,0,2.46)),
+    LUNGE1(new ControlVectors(
+        () -> Config.AttackCurves.LUNGE1_START,
+        () -> Config.AttackCurves.LUNGE1_END,
+        () -> Config.AttackCurves.LUNGE1_C1,
+        () -> Config.AttackCurves.LUNGE1_C2),
         e -> attack -> new Vector()
     ),
 
-    F_DASH_ATTACK(ControlVectors.of(
-        new Vector(-1.95,-0.76,0.9),
-        new Vector(1.2,1.1,7.3),
-        new Vector(-1.6,-0.57,2.7),
-        new Vector(-0.93,0,4.9)),
+    F_DASH_ATTACK(new ControlVectors(
+        () -> Config.AttackCurves.F_DASH_ATTACK_START,
+        () -> Config.AttackCurves.F_DASH_ATTACK_END,
+        () -> Config.AttackCurves.F_DASH_ATTACK_C1,
+        () -> Config.AttackCurves.F_DASH_ATTACK_C2),
         e -> attack -> new Vector()
     ),
-    B_DASH_ATTACK(ControlVectors.of(
-        new Vector(0.696,2.2388,1.74),
-        new Vector(-0.8932,-3.2016,0.116),
-        new Vector(0.3132,0.4176,2.204),
-        new Vector(-0.58,-1.74,1.3572)),
+    B_DASH_ATTACK(new ControlVectors(
+        () -> Config.AttackCurves.B_DASH_ATTACK_START,
+        () -> Config.AttackCurves.B_DASH_ATTACK_END,
+        () -> Config.AttackCurves.B_DASH_ATTACK_C1,
+        () -> Config.AttackCurves.B_DASH_ATTACK_C2),
         e -> Attack::getForwardVector
     ),
-    R_STRAFE_ATTACK(ControlVectors.of(
-        new Vector(-1.503,-0.4008,0.668),
-        new Vector(4.676,0.334,1.169),
-        new Vector(0.167,0,1.4362),
-        new Vector(2.2211,0,1.7702)),
+    R_STRAFE_ATTACK(new ControlVectors(
+        () -> Config.AttackCurves.R_STRAFE_ATTACK_START,
+        () -> Config.AttackCurves.R_STRAFE_ATTACK_END,
+        () -> Config.AttackCurves.R_STRAFE_ATTACK_C1,
+        () -> Config.AttackCurves.R_STRAFE_ATTACK_C2),
         e -> Attack::getRightVector
     ),
-    L_STRAFE_ATTACK(ControlVectors.of(
-        new Vector(1.503,-0.4008,0.668),
-        new Vector(-4.676,0.334,1.169),
-        new Vector(-0.167,0,1.4362),
-        new Vector(-2.2211,0,1.7702)),
+    L_STRAFE_ATTACK(new ControlVectors(
+        () -> Config.AttackCurves.L_STRAFE_ATTACK_START,
+        () -> Config.AttackCurves.L_STRAFE_ATTACK_END,
+        () -> Config.AttackCurves.L_STRAFE_ATTACK_C1,
+        () -> Config.AttackCurves.L_STRAFE_ATTACK_C2),
         e -> attack -> attack.getRightVector().multiply(-1)
     ),
 
-    D_AIR(ControlVectors.of(
-        new Vector(-0.35, 2.53, 0.56),
-        new Vector(0, -3.42, -0.581),
-        new Vector(0.329, -0.165, 4.97),
-        new Vector(-0.07, -6.15, 0.98)
-    )),
-    N_AIR(ControlVectors.of(
-        new Vector(1.0961, 1.742, -1.13),
-        new Vector(0, -1.987, -0.791),
-        new Vector(-0.2825, 0.951, 9.153),
-        new Vector(-0.7458, -5.151, -1.808)
-    )),
+    D_AIR(new ControlVectors(
+        () -> Config.AttackCurves.D_AIR_START,
+        () -> Config.AttackCurves.D_AIR_END,
+        () -> Config.AttackCurves.D_AIR_C1,
+        () -> Config.AttackCurves.D_AIR_C2)
+    ),
+    N_AIR(new ControlVectors(
+        () -> Config.AttackCurves.N_AIR_START,
+        () -> Config.AttackCurves.N_AIR_END,
+        () -> Config.AttackCurves.N_AIR_C1,
+        () -> Config.AttackCurves.N_AIR_C2)
+    ),
 
-    DEFAULT(ControlVectors.of(
-        Config.Direction.UP(),
-        Config.Direction.DOWN(),
-        Config.Direction.OUT_UP(),
-        Config.Direction.OUT_DOWN()
+    DEFAULT(new ControlVectors(
+        Config.Direction::UP,
+        Config.Direction::DOWN,
+        Config.Direction::OUT_UP,
+        Config.Direction::OUT_DOWN
     )),
 
     BLADE_RETRIEVAL_CIRCULAR_SLASH(

--- a/src/main/java/btm/sword/system/entity/umbral/statemachine/state/AttackingHeavyState.java
+++ b/src/main/java/btm/sword/system/entity/umbral/statemachine/state/AttackingHeavyState.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
 
+import btm.sword.config.Config;
 import btm.sword.system.attack.Attack;
 import btm.sword.system.attack.GeneratedAttackProfile;
 import btm.sword.system.attack.UmbralBladeAttack;
@@ -78,12 +79,12 @@ public class AttackingHeavyState extends UmbralStateFacade {
         Basis attackFrame;
         double dist;
 
-        double minSweepDistance = 5.0;
+        double minSweepDistance = Config.Combat.HEAVY_ATTACK_MIN_SWEEP_DISTANCE;
         int direction;
 
         if (target == null || target.isInvalid()) {
             targetedLocation = blade.getThrower().getChestLocation().add(blade.getThrower().dir().multiply(range));
-            DrawUtil.secant(List.of(Prefab.Particles.TEST_SPARKLE), attackOrigin, targetedLocation, 0.25);
+            DrawUtil.secant(List.of(Prefab.Particles.TEST_SPARKLE), attackOrigin, targetedLocation, Config.Combat.HEAVY_ATTACK_SECANT_STEP);
         } else {
             DrawUtil.secant(List.of(Prefab.Particles.TEST_SPARKLE), blade.getDisplay().getLocation(), target.getChestLocation(), 0.5);
             targetedLocation = target.getChestLocation();

--- a/src/main/java/btm/sword/system/inventory/item/ConfigEntryItem.java
+++ b/src/main/java/btm/sword/system/inventory/item/ConfigEntryItem.java
@@ -8,6 +8,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
 import btm.sword.config.Config;
@@ -197,6 +198,21 @@ public class ConfigEntryItem extends AbstractItem {
                 .build());
         }
 
+        if (type == Vector.class) {
+            Vector val = Config.loadVector(config, path, defaultVector());
+            return new ItemWrapper(new ItemStackBuilder(Material.END_ROD)
+                .name(Component.text(path, NamedTextColor.WHITE))
+                .lore(List.of(
+                    Component.text("Type: ", NamedTextColor.GRAY).append(Component.text("Vector", NamedTextColor.WHITE)),
+                    Component.text("Value: ", NamedTextColor.GRAY).append(Component.text(vectorToString(val), NamedTextColor.YELLOW)),
+                    Component.text("Default: ", NamedTextColor.GRAY).append(Component.text(vectorToString(defaultVector()), NamedTextColor.DARK_GRAY)),
+                    Component.text("Click to edit  (format: ", NamedTextColor.DARK_GRAY)
+                        .append(Component.text("x y z", NamedTextColor.WHITE))
+                        .append(Component.text(")", NamedTextColor.DARK_GRAY))
+                ))
+                .build());
+        }
+
         // Read-only fallback for complex types
         String defStr = entry.defaultValue.toString();
         String defPreview = defStr.length() > 40 ? defStr.substring(0, 37) + "..." : defStr;
@@ -240,6 +256,11 @@ public class ConfigEntryItem extends AbstractItem {
 
         if (type == TextColor.class) {
             promptColorInput(player, mgr, config, true);
+            return;
+        }
+
+        if (type == Vector.class) {
+            promptVectorInput(player, mgr, config);
             return;
         }
 
@@ -400,11 +421,65 @@ public class ConfigEntryItem extends AbstractItem {
     }
 
     // -------------------------------------------------------------------------
+    //  Typed-input via chat — vectors
+    // -------------------------------------------------------------------------
+
+    @SuppressWarnings("unchecked")
+    private void promptVectorInput(Player player, ConfigManager mgr, FileConfiguration config) {
+        String path = entry.path;
+        Vector current = Config.loadVector(config, path, defaultVector());
+
+        Component prompt = Component.text("Enter ", NamedTextColor.YELLOW)
+            .append(Component.text("x y z", NamedTextColor.WHITE))
+            .append(Component.text(" for ", NamedTextColor.YELLOW))
+            .append(Component.text(path, NamedTextColor.WHITE))
+            .append(Component.text(" (current: ", NamedTextColor.YELLOW))
+            .append(Component.text(vectorToString(current), NamedTextColor.GREEN))
+            .append(Component.text("):", NamedTextColor.YELLOW));
+
+        ChatInputCapture.prompt(player, prompt, input -> {
+            if (input.equalsIgnoreCase("cancel")) {
+                swordPlayer.message(Component.text("Cancelled.", NamedTextColor.GRAY));
+                reopenMenu.run();
+                return;
+            }
+            try {
+                String[] parts = input.split("[,\\s]+");
+                if (parts.length != 3) {
+                    swordPlayer.message(Component.text("Expected format: ", NamedTextColor.RED)
+                        .append(Component.text("x y z", NamedTextColor.WHITE))
+                        .append(Component.text(" \u2014 got: ", NamedTextColor.RED))
+                        .append(Component.text(input, NamedTextColor.WHITE)));
+                    reopenMenu.run();
+                    return;
+                }
+                double x = Double.parseDouble(parts[0].trim());
+                double y = Double.parseDouble(parts[1].trim());
+                double z = Double.parseDouble(parts[2].trim());
+                Vector next = new Vector(x, y, z);
+                mgr.setValue((Config.ConfigEntry<Vector>) entry, next);
+                swordPlayer.message(Component.text("Set ", NamedTextColor.GREEN)
+                    .append(Component.text(path, NamedTextColor.WHITE))
+                    .append(Component.text(" = ", NamedTextColor.GREEN))
+                    .append(Component.text(vectorToString(next), NamedTextColor.YELLOW)));
+            } catch (NumberFormatException ex) {
+                swordPlayer.message(Component.text("Invalid number in: ", NamedTextColor.RED)
+                    .append(Component.text(input, NamedTextColor.WHITE)));
+            }
+            reopenMenu.run();
+        });
+    }
+
+    // -------------------------------------------------------------------------
     //  Helpers
     // -------------------------------------------------------------------------
 
     private static boolean isNumeric(Class<?> type) {
         return type == Integer.class || type == Long.class || type == Double.class || type == Float.class;
+    }
+
+    private static String vectorToString(Vector v) {
+        return String.format("%.4f %.4f %.4f", v.getX(), v.getY(), v.getZ());
     }
 
     private static String colorToString(Color c) {
@@ -441,6 +516,10 @@ public class ConfigEntryItem extends AbstractItem {
 
     private float defaultFloat() {
         return entry.defaultValue instanceof Float f ? f : 0.0f;
+    }
+
+    private Vector defaultVector() {
+        return entry.defaultValue instanceof Vector v ? v : new Vector();
     }
 
     private Color defaultBukkitColor() {

--- a/src/main/java/btm/sword/system/inventory/item/ConfigEntryItem.java
+++ b/src/main/java/btm/sword/system/inventory/item/ConfigEntryItem.java
@@ -200,7 +200,7 @@ public class ConfigEntryItem extends AbstractItem {
 
         if (type == Vector.class) {
             Vector val = Config.loadVector(config, path, defaultVector());
-            return new ItemWrapper(new ItemStackBuilder(Material.END_ROD)
+            return new ItemWrapper(new ItemStackBuilder(Material.SPECTRAL_ARROW)
                 .name(Component.text(path, NamedTextColor.WHITE))
                 .lore(List.of(
                     Component.text("Type: ", NamedTextColor.GRAY).append(Component.text("Vector", NamedTextColor.WHITE)),

--- a/src/main/java/btm/sword/system/inventory/menu/ConfigMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/ConfigMenu.java
@@ -42,7 +42,7 @@ public class ConfigMenu extends Menu {
     /** Material assigned to each config section button — keyed by first YAML path segment. */
     private static final Map<String, Material> SECTION_MATERIALS;
     static {
-        SECTION_MATERIALS = new LinkedHashMap<>();
+        SECTION_MATERIALS = new LinkedHashMap<>(); // TODO: Config these Materials! (And add the unregistered ones)
         SECTION_MATERIALS.put("umbralblade",       Material.HEAVY_CORE);
         SECTION_MATERIALS.put("hostile",       Material.REDSTONE);
         SECTION_MATERIALS.put("grab",     Material.RABBIT_FOOT);

--- a/src/main/java/btm/sword/system/inventory/menu/CreativeInventoryMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/CreativeInventoryMenu.java
@@ -86,6 +86,7 @@ public class CreativeInventoryMenu extends Menu {
                 "x x x x x x x x x",
                 "x x x x x x x x x",
                 "x x x x x x x x x",
+                "x x x x x x x x x",
                 "B # # < . > # # #")
             .addIngredient('#', BORDER)
             .addIngredient('x', Markers.CONTENT_LIST_SLOT_HORIZONTAL)

--- a/src/main/java/btm/sword/utility/math/ControlVectors.java
+++ b/src/main/java/btm/sword/utility/math/ControlVectors.java
@@ -1,20 +1,153 @@
 package btm.sword.utility.math;
 
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.bukkit.util.Vector;
 
-public record ControlVectors(Vector start, Vector end, Vector c1, Vector c2) {
+/**
+ * Holds the four cubic Bézier control points (start, end, c1, c2) for an attack sweep path.
+ *
+ * <p>Each point is stored as a {@link Supplier}{@code <Vector>} so the value can be resolved
+ * lazily at attack-execution time. This allows control-point values driven by
+ * {@link btm.sword.config.Config} entries to reflect live config changes without requiring
+ * a server restart.
+ *
+ * <p>Two construction paths are supported:
+ * <ul>
+ *   <li>Plain {@link Vector} constructor — vectors are captured eagerly and wrapped in a
+ *       supplier that always returns a clone of the captured value. Use this when the
+ *       geometry is computed at runtime (e.g., procedural world-space sweeps).</li>
+ *   <li>{@link Supplier}{@code <Vector>} constructor — suppliers are invoked each time a
+ *       point is read. Use this for config-driven attack types so that hot-reloaded
+ *       values are picked up automatically.</li>
+ * </ul>
+ *
+ * <p>The static {@link #of} factory methods mirror these two paths.
+ */
+public class ControlVectors {
 
-    public static ControlVectors of(Vector start, Vector end, Vector c1, Vector c2) {
-        return new ControlVectors(
-            start.clone(),
-            end.clone(),
-            c1.clone(),
-            c2.clone()
-        );
+    private final Supplier<Vector> start;
+    private final Supplier<Vector> end;
+    private final Supplier<Vector> c1;
+    private final Supplier<Vector> c2;
+
+    /**
+     * Creates a {@code ControlVectors} whose points are baked-in from the given vectors.
+     *
+     * <p>Each vector is cloned at construction time, so subsequent mutations to the
+     * originals have no effect.
+     *
+     * @param start the start control point
+     * @param end   the end control point
+     * @param c1    the first interior control point
+     * @param c2    the second interior control point
+     */
+    public ControlVectors(Vector start, Vector end, Vector c1, Vector c2) {
+        Vector s = start.clone();
+        Vector e = end.clone();
+        Vector c1c = c1.clone();
+        Vector c2c = c2.clone();
+        this.start = s::clone;
+        this.end = e::clone;
+        this.c1 = c1c::clone;
+        this.c2 = c2c::clone;
     }
 
+    /**
+     * Creates a {@code ControlVectors} whose points are resolved lazily from the given suppliers.
+     *
+     * <p>Each call to {@link #start()}, {@link #end()}, {@link #c1()}, or {@link #c2()} will
+     * invoke the corresponding supplier, making this suitable for config-backed entries that
+     * may change between attacks.
+     *
+     * @param start supplier for the start control point
+     * @param end   supplier for the end control point
+     * @param c1    supplier for the first interior control point
+     * @param c2    supplier for the second interior control point
+     */
+    public ControlVectors(Supplier<Vector> start, Supplier<Vector> end,
+                          Supplier<Vector> c1, Supplier<Vector> c2) {
+        this.start = start;
+        this.end = end;
+        this.c1 = c1;
+        this.c2 = c2;
+    }
+
+    /**
+     * Creates a baked-in {@code ControlVectors} from four plain vectors.
+     *
+     * @param start the start control point
+     * @param end   the end control point
+     * @param c1    the first interior control point
+     * @param c2    the second interior control point
+     * @return a new {@code ControlVectors} with eagerly captured values
+     */
+    public static ControlVectors of(Vector start, Vector end, Vector c1, Vector c2) {
+        return new ControlVectors(start, end, c1, c2);
+    }
+
+    /**
+     * Creates a lazily-resolved {@code ControlVectors} from four suppliers.
+     *
+     * @param start supplier for the start control point
+     * @param end   supplier for the end control point
+     * @param c1    supplier for the first interior control point
+     * @param c2    supplier for the second interior control point
+     * @return a new {@code ControlVectors} backed by the given suppliers
+     */
+    public static ControlVectors of(Supplier<Vector> start, Supplier<Vector> end,
+                                    Supplier<Vector> c1, Supplier<Vector> c2) {
+        return new ControlVectors(start, end, c1, c2);
+    }
+
+    /**
+     * Returns the start control point.
+     *
+     * @return the start vector (fresh value from the backing supplier)
+     */
+    public Vector start() {
+        return start.get();
+    }
+
+    /**
+     * Returns the end control point.
+     *
+     * @return the end vector (fresh value from the backing supplier)
+     */
+    public Vector end() {
+        return end.get();
+    }
+
+    /**
+     * Returns the first interior control point.
+     *
+     * @return the c1 vector (fresh value from the backing supplier)
+     */
+    public Vector c1() {
+        return c1.get();
+    }
+
+    /**
+     * Returns the second interior control point.
+     *
+     * @return the c2 vector (fresh value from the backing supplier)
+     */
+    public Vector c2() {
+        return c2.get();
+    }
+
+    /**
+     * Returns a new {@code ControlVectors} with each point transformed into the given basis
+     * and scaled by {@code multiplier}.
+     *
+     * <p>All four suppliers are resolved once during this call; the returned instance is
+     * baked-in (not supplier-backed) because the transformation has already been applied.
+     *
+     * @param basis      the target coordinate frame
+     * @param multiplier scale factor applied after basis transformation
+     * @return a new baked-in {@code ControlVectors} in the given basis
+     */
     public ControlVectors adjustToBasis(Basis basis, double multiplier) {
         Function<Vector, Vector> adjust = v -> VectorUtil.transformWithNewBasis(basis, v).multiply(multiplier);
         return of(
@@ -23,25 +156,5 @@ public record ControlVectors(Vector start, Vector end, Vector c1, Vector c2) {
             adjust.apply(c1()),
             adjust.apply(c2())
         );
-    }
-
-    @Override
-    public Vector start() {
-        return start.clone();
-    }
-
-    @Override
-    public Vector end() {
-        return end.clone();
-    }
-
-    @Override
-    public Vector c1() {
-        return c1.clone();
-    }
-
-    @Override
-    public Vector c2() {
-        return c2.clone();
     }
 }

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -383,3 +383,100 @@ umbral:
 materials:
   material_storage_item: BUNDLE
   currency_storage_item: NETHERITE_INGOT
+
+attack_curves:
+
+  umbral_slash1_start: {x: -2.0, y: 0.0, z: 0.0}
+  umbral_slash1_end: {x: 2.0, y: 0.0, z: -1.0}
+  umbral_slash1_c1: {x: -1.5, y: 0.0, z: 2.0}
+  umbral_slash1_c2: {x: 1.5, y: 0.0, z: 3.0}
+
+  umbral_slash1_windup_start: {x: -1.5, y: 0.17, z: 1.0}
+  umbral_slash1_windup_end: {x: -2.1, y: -0.33, z: -0.5}
+  umbral_slash1_windup_c1: {x: -2.0, y: 0.17, z: 0.5}
+  umbral_slash1_windup_c2: {x: -2.0, y: -0.08, z: 0.0}
+
+  wide_umbral_slash1_start: {x: -5.7615, y: 0.0, z: 2.171}
+  wide_umbral_slash1_end: {x: 5.845, y: 0.0, z: -0.334}
+  wide_umbral_slash1_c1: {x: -2.505, y: 0.0, z: 3.34}
+  wide_umbral_slash1_c2: {x: 2.505, y: 0.0, z: 5.01}
+
+  wide_umbral_slash1_windup_start: {x: -1.66, y: 0.17, z: -0.5}
+  wide_umbral_slash1_windup_end: {x: -5.0, y: 0.27, z: 0.83}
+  wide_umbral_slash1_windup_c1: {x: -2.5, y: 1.03, z: 1.7}
+  wide_umbral_slash1_windup_c2: {x: -3.77, y: 0.51, z: 2.26}
+
+  wide_umbral_slash2_start: {x: 4.008, y: -1.002, z: -1.169}
+  wide_umbral_slash2_end: {x: -3.841, y: 1.67, z: 4.008}
+  wide_umbral_slash2_c1: {x: 1.67, y: 0.0, z: 2.839}
+  wide_umbral_slash2_c2: {x: -1.336, y: 0.0, z: 5.01}
+
+  wide_umbral_slash2_windup_start: {x: 5.344, y: -0.2171, z: -1.002}
+  wide_umbral_slash2_windup_end: {x: 4.509, y: -1.503, z: -2.338}
+  wide_umbral_slash2_windup_c1: {x: 4.7261, y: 0.0, z: -0.501}
+  wide_umbral_slash2_windup_c2: {x: 3.674, y: -0.4008, z: -1.5698}
+
+  wide_umbral_slash3_start: {x: 0.0, y: 5.177, z: -0.334}
+  wide_umbral_slash3_end: {x: 0.0, y: -3.674, z: 1.336}
+  wide_umbral_slash3_c1: {x: 0.0, y: 1.7368, z: 1.67}
+  wide_umbral_slash3_c2: {x: 0.0, y: -0.167, z: 2.9058}
+
+  wide_umbral_slash3_windup_start: {x: -3.34, y: 2.0708, z: 3.34}
+  wide_umbral_slash3_windup_end: {x: 0.334, y: 4.0915, z: 0.0}
+  wide_umbral_slash3_windup_c1: {x: 1.67, y: 0.0, z: 1.67}
+  wide_umbral_slash3_windup_c2: {x: -1.336, y: 0.0, z: 3.841}
+
+  slash1_start: {x: -2.06, y: -1.26, z: -0.5}
+  slash1_end: {x: 3.26, y: 0.79, z: -0.4}
+  slash1_c1: {x: -2.3, y: -0.16, z: 3.0}
+  slash1_c2: {x: 1.9, y: 0.21, z: 5.0}
+
+  slash2_start: {x: 2.6, y: -1.3, z: -1.2}
+  slash2_end: {x: -3.0, y: 0.9, z: 1.3}
+  slash2_c1: {x: 1.6, y: -0.7, z: 7.0}
+  slash2_c2: {x: -2.6, y: 1.05, z: 1.85}
+
+  slash3_start: {x: 1.2, y: 2.8, z: -1.5}
+  slash3_end: {x: -1.1, y: -2.2, z: -0.9}
+  slash3_c1: {x: 1.0, y: 1.96, z: 4.3}
+  slash3_c2: {x: -1.1, y: -1.77, z: 5.0}
+
+  up_smash_start: {x: 0.66, y: -1.53, z: -0.5}
+  up_smash_end: {x: -0.4, y: 0.67, z: -0.9}
+  up_smash_c1: {x: 0.56, y: -0.89, z: 2.1}
+  up_smash_c2: {x: -0.4, y: 1.37, z: 1.65}
+
+  lunge1_start: {x: 0.37, y: 0.0, z: 2.0}
+  lunge1_end: {x: 0.0, y: 0.0, z: 20.0}
+  lunge1_c1: {x: 1.1, y: 0.0, z: 3.1}
+  lunge1_c2: {x: 0.0, y: 0.0, z: 2.46}
+
+  f_dash_attack_start: {x: -1.95, y: -0.76, z: 0.9}
+  f_dash_attack_end: {x: 1.2, y: 1.1, z: 7.3}
+  f_dash_attack_c1: {x: -1.6, y: -0.57, z: 2.7}
+  f_dash_attack_c2: {x: -0.93, y: 0.0, z: 4.9}
+
+  b_dash_attack_start: {x: 0.696, y: 2.2388, z: 1.74}
+  b_dash_attack_end: {x: -0.8932, y: -3.2016, z: 0.116}
+  b_dash_attack_c1: {x: 0.3132, y: 0.4176, z: 2.204}
+  b_dash_attack_c2: {x: -0.58, y: -1.74, z: 1.3572}
+
+  r_strafe_attack_start: {x: -1.503, y: -0.4008, z: 0.668}
+  r_strafe_attack_end: {x: 4.676, y: 0.334, z: 1.169}
+  r_strafe_attack_c1: {x: 0.167, y: 0.0, z: 1.4362}
+  r_strafe_attack_c2: {x: 2.2211, y: 0.0, z: 1.7702}
+
+  l_strafe_attack_start: {x: 1.503, y: -0.4008, z: 0.668}
+  l_strafe_attack_end: {x: -4.676, y: 0.334, z: 1.169}
+  l_strafe_attack_c1: {x: -0.167, y: 0.0, z: 1.4362}
+  l_strafe_attack_c2: {x: -2.2211, y: 0.0, z: 1.7702}
+
+  d_air_start: {x: -0.35, y: 2.53, z: 0.56}
+  d_air_end: {x: 0.0, y: -3.42, z: -0.581}
+  d_air_c1: {x: 0.329, y: -0.165, z: 4.97}
+  d_air_c2: {x: -0.07, y: -6.15, z: 0.98}
+
+  n_air_start: {x: 1.0961, y: 1.742, z: -1.13}
+  n_air_end: {x: 0.0, y: -1.987, z: -0.791}
+  n_air_c1: {x: -0.2825, y: 0.951, z: 9.153}
+  n_air_c2: {x: -0.7458, y: -5.151, z: -1.808}

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -74,7 +74,10 @@ combat:
   attacks_range_multipliers_basic_3: 1.4
   attacks_range_multipliers_neutral_air: 1.3
   attacks_range_multipliers_down_air: 1.2
-  
+
+  heavy_attack_min_sweep_distance: 5.0
+  heavy_attack_secant_step: 0.25
+
   sweep_attack_x_scale: 0.25
   sweep_attack_y_scale: 1
   sweep_attack_z_scale: 0.25
@@ -379,3 +382,4 @@ umbral:
   on_release: 3
 materials:
   material_storage_item: BUNDLE
+  currency_storage_item: NETHERITE_INGOT


### PR DESCRIPTION
## Summary

Refactored attack vector configuration to be entirely config-driven, eliminating hardcoded values and enabling hot-reload support. Added ConfigEntryItem UI support for Vector values, allowing admins to adjust attack vectors directly in-game via the config menu.

- Make AttackType vectors controlled by Supplier<Vector> backed by config entries
- Add ConfigEntryItem support for Vector types
- Extend ConfigManager to handle Vector deserialization
- Update config.yaml with attack vector defaults
- UI improvements: Vector item icon and ConfigMenu section materials

Closes #242

## Test plan

- Run the test server and verify attack vectors are applied correctly
- Test that `/sword reload` hot-reloads vector configs without requiring a restart
- Open the config menu and verify Vector entries display and save correctly
- Confirm attack behavior matches the configured vectors