### PR TITLE
Feat: Hostile weapon retrieval, display smoothing, and fake player packet tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,5 @@ runs/
 jdk-*/
 
 .sdkmanrc
+
+bb/

--- a/src/main/java/btm/sword/Sword.java
+++ b/src/main/java/btm/sword/Sword.java
@@ -22,6 +22,8 @@ import btm.sword.system.action.throwing.InteractiveItemArbiter;
 import btm.sword.system.action.throwing.ProjectileManager;
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.inventory.InventoryMenuManager;
+import btm.sword.system.join.MenuSlotGrid;
+import btm.sword.system.join.ServerJoinArbiter;
 import btm.sword.system.playerdata.PlayerDataManager;
 import btm.sword.system.scene.FakePlayerManager;
 import btm.sword.system.scene.animation.AnimationRegistry;
@@ -52,6 +54,7 @@ public final class Sword extends JavaPlugin {
 
         getServer().getPluginManager().registerEvents(new InputListener(), this);
         getServer().getPluginManager().registerEvents(new PlayerListener(), this);
+        getServer().getPluginManager().registerEvents(new ServerJoinArbiter(), this);
         getServer().getPluginManager().registerEvents(new EntityListener(), this);
         getServer().getPluginManager().registerEvents(new WorldListener(), this);
         getServer().getPluginManager().registerEvents(new SystemListener(), this);
@@ -77,6 +80,9 @@ public final class Sword extends JavaPlugin {
 
         PlayerDataManager.initialize();
 
+        // Place the staging grid platforms (worlds are loaded before onEnable on Paper)
+        MenuSlotGrid.placeAllBlocks();
+
         getLogger().info("~ Sword: Combat Evolved has been enabled ~");
     }
 
@@ -90,6 +96,9 @@ public final class Sword extends JavaPlugin {
 
         // Remove any lingering packet-based fake player NPCs
         FakePlayerManager.despawnAll();
+
+        // Release all staging grid slots
+        MenuSlotGrid.releaseAll();
 
         // TODO: #129 - Uncomment when persistent data is ready
         // PlayerDataManager.shutdown();

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -3893,4 +3893,63 @@ public class Config {
         }
     }
     //endregion
+
+    // ==============================================================================
+    //region Menu Grid Configuration
+    // ==============================================================================
+    /**
+     * Configuration for the server-join staging grid.
+     * <p>
+     * The grid is a matrix of off-screen platform slots. Each player occupies one slot
+     * from join until they enter gameplay. The grid is placed at the configured origin and
+     * grows along X (rows) and Z (columns) with the given spacing.
+     * {@link btm.sword.system.join.MenuSlotGrid} reads these values and manages occupancy.
+     * </p>
+     */
+    public static class MenuGrid {
+
+        /** World name for the staging grid. Falls back to the default world if not found. */
+        public static String WORLD = "world";
+
+        /** X coordinate of slot (0, 0) — grid grows in the positive-X direction. */
+        public static double ORIGIN_X = 0.0;
+
+        /** Y level of the grid platform surface (player stands at ORIGIN_Y). */
+        public static double ORIGIN_Y = 200.0;
+
+        /** Z coordinate of slot (0, 0) — grid grows in the positive-Z direction. */
+        public static double ORIGIN_Z = 0.0;
+
+        /** Number of rows (along X). */
+        public static int ROWS = 5;
+
+        /** Number of columns (along Z). */
+        public static int COLS = 10;
+
+        /** Distance in blocks between slot centres along X. */
+        public static double SPACING_X = 5.0;
+
+        /** Distance in blocks between slot centres along Z. */
+        public static double SPACING_Z = 5.0;
+
+        static {
+            register("menu_grid.world", WORLD, String.class,
+                v -> WORLD = v, ConfigurationSection::getString);
+            register("menu_grid.origin_x", ORIGIN_X, Double.class,
+                v -> ORIGIN_X = v, ConfigurationSection::getDouble);
+            register("menu_grid.origin_y", ORIGIN_Y, Double.class,
+                v -> ORIGIN_Y = v, ConfigurationSection::getDouble);
+            register("menu_grid.origin_z", ORIGIN_Z, Double.class,
+                v -> ORIGIN_Z = v, ConfigurationSection::getDouble);
+            register("menu_grid.rows", ROWS, Integer.class,
+                v -> ROWS = v, ConfigurationSection::getInt);
+            register("menu_grid.cols", COLS, Integer.class,
+                v -> COLS = v, ConfigurationSection::getInt);
+            register("menu_grid.spacing_x", SPACING_X, Double.class,
+                v -> SPACING_X = v, ConfigurationSection::getDouble);
+            register("menu_grid.spacing_z", SPACING_Z, Double.class,
+                v -> SPACING_Z = v, ConfigurationSection::getDouble);
+        }
+    }
+    //endregion
 }

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -3042,6 +3042,60 @@ public class Config {
             v -> MOB_THROW_ARC_HEIGHT = v,
             ConfigurationSection::getDouble
         ); }
+
+        /** DEU group tag for the Hostile display rig. Empty string disables the rig. */
+        public static String DISPLAY_GROUP = "witha";
+        static { register(
+            "hostile.display_group",
+            "witha", String.class,
+            v -> DISPLAY_GROUP = v,
+            ConfigurationSection::getString
+        ); }
+
+        /** Y offset applied to the display rig's ride position relative to the mob's passenger seat. */
+        public static double DISPLAY_RIDE_OFFSET_Y = 0.0;
+        static { register(
+            "hostile.display_ride_offset_y",
+            0.0, Double.class,
+            v -> DISPLAY_RIDE_OFFSET_Y = v,
+            ConfigurationSection::getDouble
+        ); }
+
+        /** Animation tag for the idle loop. Empty string skips registering this state. */
+        public static String DISPLAY_ANIM_IDLE = "idle";
+        static { register(
+            "hostile.display_anim_idle",
+            "idle", String.class,
+            v -> DISPLAY_ANIM_IDLE = v,
+            ConfigurationSection::getString
+        ); }
+
+        /** Animation tag for the walk loop. */
+        public static String DISPLAY_ANIM_WALK = "walk";
+        static { register(
+            "hostile.display_anim_walk",
+            "walk", String.class,
+            v -> DISPLAY_ANIM_WALK = v,
+            ConfigurationSection::getString
+        ); }
+
+        /** Animation tag for the falling loop. */
+        public static String DISPLAY_ANIM_FALL = "fall";
+        static { register(
+            "hostile.display_anim_fall",
+            "fall", String.class,
+            v -> DISPLAY_ANIM_FALL = v,
+            ConfigurationSection::getString
+        ); }
+
+        /** Animation tag for the melee attack (plays once, locked until complete). */
+        public static String DISPLAY_ANIM_MELEE = "melee";
+        static { register(
+            "hostile.display_anim_melee",
+            "melee", String.class,
+            v -> DISPLAY_ANIM_MELEE = v,
+            ConfigurationSection::getString
+        ); }
     }
     //endregion
 
@@ -4018,6 +4072,12 @@ public class Config {
         /** Distance in blocks between slot centres along Z. */
         public static double SPACING_Z = 5.0;
 
+        /**
+         * Milliseconds to hold the player in their dark-room staging slot before starting
+         * the join sequence. Allows the client to finish loading chunks and terrain.
+         */
+        public static int LOADING_WAIT_MS = 1500;
+
         static {
             register("menu_grid.world", WORLD, String.class,
                 v -> WORLD = v, ConfigurationSection::getString);
@@ -4035,6 +4095,8 @@ public class Config {
                 v -> SPACING_X = v, ConfigurationSection::getDouble);
             register("menu_grid.spacing_z", SPACING_Z, Double.class,
                 v -> SPACING_Z = v, ConfigurationSection::getDouble);
+            register("menu_grid.loading_wait_ms", LOADING_WAIT_MS, Integer.class,
+                v -> LOADING_WAIT_MS = v, ConfigurationSection::getInt);
         }
     }
     //endregion

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -3117,6 +3117,19 @@ public class Config {
             v -> DISPLAY_ANIM_MELEE = v,
             ConfigurationSection::getString
         ); }
+
+        /**
+         * Teleport-duration applied to every display entity in the rig (in ticks).
+         * Higher values give smoother movement at the cost of slightly delayed response.
+         * 3 is a good starting point; set to 0 to disable smoothing.
+         */
+        public static int DISPLAY_TELEPORT_DURATION = 3;
+        static { register(
+            "hostile.display_teleport_duration",
+            3, Integer.class,
+            v -> DISPLAY_TELEPORT_DURATION = v,
+            ConfigurationSection::getInt
+        ); }
     }
     //endregion
 

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -3043,6 +3043,27 @@ public class Config {
             ConfigurationSection::getDouble
         ); }
 
+        /**
+         * Probability (0.0–1.0) that the throw ability passes the {@code canUse} check when
+         * off cooldown. Lower values make throws rarer relative to melee.
+         */
+        public static double MOB_THROW_WEIGHT = 0.3;
+        static { register(
+            "hostile.mob_throw_weight",
+            0.3, Double.class,
+            v -> MOB_THROW_WEIGHT = v,
+            ConfigurationSection::getDouble
+        ); }
+
+        /** Pickup radius squared for weapon retrieval (loaded from raw distance and squared on assignment). */
+        public static double MOB_RETRIEVE_PICKUP_RANGE_SQUARED = 4.0;
+        static { register(
+            "hostile.mob_retrieve_pickup_range",
+            2.0, Double.class,
+            v -> MOB_RETRIEVE_PICKUP_RANGE_SQUARED = v * v,
+            ConfigurationSection::getDouble
+        ); }
+
         /** DEU group tag for the Hostile display rig. Empty string disables the rig. */
         public static String DISPLAY_GROUP = "witha";
         static { register(

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -3895,6 +3895,92 @@ public class Config {
     //endregion
 
     // ==============================================================================
+    //region Join Sequence Configuration
+    // ==============================================================================
+    /**
+     * Configuration for the server join routing pipeline.
+     * <p>
+     * Two world locations are used:
+     * </p>
+     * <ul>
+     *   <li><b>Spawnpoint</b> — where returning players (join sequence complete) are placed
+     *       before the main menu character scene opens.</li>
+     *   <li><b>Opening</b> — where first-time players are teleported for the intro cutscene.</li>
+     * </ul>
+     */
+    public static class JoinSequence {
+
+        /** World for both the spawnpoint and the opening animation location. */
+        public static String WORLD = "world";
+
+        /** X coordinate of the returning-player spawnpoint. */
+        public static double SPAWNPOINT_X = -132.0;
+
+        /** Y coordinate of the returning-player spawnpoint. */
+        public static double SPAWNPOINT_Y = 215.0;
+
+        /** Z coordinate of the returning-player spawnpoint. */
+        public static double SPAWNPOINT_Z = -783.0;
+
+        /** Yaw of the returning-player spawnpoint (degrees). */
+        public static float SPAWNPOINT_YAW = 0.0f;
+
+        /** X coordinate of the intro cutscene location. */
+        public static double OPENING_X = -186.0;
+
+        /** Y coordinate of the intro cutscene location. */
+        public static double OPENING_Y = 256.0;
+
+        /** Z coordinate of the intro cutscene location. */
+        public static double OPENING_Z = -1058.0;
+
+        /** Yaw of the opening cutscene location (degrees, controls NPC + camera facing). */
+        public static float OPENING_YAW = 0.0f;
+
+        /** Animation key used for the intro cutscene (must match an entry in animations.yml). */
+        public static String OPENING_ANIMATION_KEY = "slash_test_default";
+
+        /** Duration (ms) of the first animation phase before the lightning strike. */
+        public static int PHASE1_DURATION_MS = 5000;
+
+        /** Duration (ms) of the second animation phase after the lightning strike. */
+        public static int PHASE2_DURATION_MS = 2000;
+
+        /** Duration (ms) of the fake-player static camera phase. */
+        public static int PHASE3_DURATION_MS = 5000;
+
+        static {
+            register("join_sequence.world", WORLD, String.class,
+                v -> WORLD = v, ConfigurationSection::getString);
+            register("join_sequence.spawnpoint_x", SPAWNPOINT_X, Double.class,
+                v -> SPAWNPOINT_X = v, ConfigurationSection::getDouble);
+            register("join_sequence.spawnpoint_y", SPAWNPOINT_Y, Double.class,
+                v -> SPAWNPOINT_Y = v, ConfigurationSection::getDouble);
+            register("join_sequence.spawnpoint_z", SPAWNPOINT_Z, Double.class,
+                v -> SPAWNPOINT_Z = v, ConfigurationSection::getDouble);
+            register("join_sequence.spawnpoint_yaw", (double) SPAWNPOINT_YAW, Double.class,
+                v -> SPAWNPOINT_YAW = v.floatValue(), ConfigurationSection::getDouble);
+            register("join_sequence.opening_x", OPENING_X, Double.class,
+                v -> OPENING_X = v, ConfigurationSection::getDouble);
+            register("join_sequence.opening_y", OPENING_Y, Double.class,
+                v -> OPENING_Y = v, ConfigurationSection::getDouble);
+            register("join_sequence.opening_z", OPENING_Z, Double.class,
+                v -> OPENING_Z = v, ConfigurationSection::getDouble);
+            register("join_sequence.opening_yaw", (double) OPENING_YAW, Double.class,
+                v -> OPENING_YAW = v.floatValue(), ConfigurationSection::getDouble);
+            register("join_sequence.opening_animation_key", OPENING_ANIMATION_KEY, String.class,
+                v -> OPENING_ANIMATION_KEY = v, ConfigurationSection::getString);
+            register("join_sequence.phase1_duration_ms", PHASE1_DURATION_MS, Integer.class,
+                v -> PHASE1_DURATION_MS = v, ConfigurationSection::getInt);
+            register("join_sequence.phase2_duration_ms", PHASE2_DURATION_MS, Integer.class,
+                v -> PHASE2_DURATION_MS = v, ConfigurationSection::getInt);
+            register("join_sequence.phase3_duration_ms", PHASE3_DURATION_MS, Integer.class,
+                v -> PHASE3_DURATION_MS = v, ConfigurationSection::getInt);
+        }
+    }
+    //endregion
+
+    // ==============================================================================
     //region Menu Grid Configuration
     // ==============================================================================
     /**

--- a/src/main/java/btm/sword/listeners/PlayerListener.java
+++ b/src/main/java/btm/sword/listeners/PlayerListener.java
@@ -21,8 +21,6 @@ import org.bukkit.event.inventory.InventoryEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerGameModeChangeEvent;
-import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
@@ -59,41 +57,6 @@ import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
  * </p>
  */
 public class PlayerListener implements Listener {
-    /**
-     * Handles when a player joins the server.
-     * <p>
-     * Registers the player with the {@link SwordEntityArbiter} to create
-     * their {@link SwordPlayer} instance and sends a greeting message.
-     * </p>
-     *
-     * @param event the {@link PlayerJoinEvent} triggered when a player joins the server
-     */
-    @EventHandler
-    public void onPlayerJoin(PlayerJoinEvent event) {
-        Player p = event.getPlayer();
-//        SwordEntityArbiter.register(p);
-        p.sendMessage("Hello!");
-    }
-
-    /**
-     * Handles when a player leaves the server.
-     * <p>
-     * Ensures that any {@link SwordPlayer} instance is properly cleaned up,
-     * invoking {@link SwordPlayer#onLeave()} before removal from the {@link SwordEntityArbiter}.
-     * Logs the departure in the server console.
-     * </p>
-     *
-     * @param event the {@link PlayerQuitEvent} triggered when a player quits the server
-     */
-    @EventHandler
-    public void onPlayerLeave(PlayerQuitEvent event) {
-        if (SwordEntityArbiter.get(event.getPlayer()) instanceof SwordPlayer sp) {
-            sp.onLeave();
-            SwordEntityArbiter.remove(sp.self());
-            Sword.getInstance().getLogger().info(event.getPlayer().getName() + " has left the server ;(");
-        }
-    }
-
     /**
      * Handles player death events.
      * <p>

--- a/src/main/java/btm/sword/system/action/movement/Dash.java
+++ b/src/main/java/btm/sword/system/action/movement/Dash.java
@@ -19,6 +19,7 @@ import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.umbral.UmbralBlade;
+import btm.sword.system.entity.umbral.statemachine.state.LodgedState;
 import btm.sword.system.entity.umbral.statemachine.state.WaitingState;
 import btm.sword.utility.Debug;
 import btm.sword.utility.Prefab;
@@ -222,7 +223,7 @@ public class Dash {
 
         Debug.movement("heightDiff="+heightDiff);
 
-        boolean umbralHeightBoost = !holdingLink || targetedBlade.inState(WaitingState.class);
+        boolean umbralHeightBoost = !holdingLink || targetedBlade.inState(WaitingState.class) || targetedBlade.inState(LodgedState.class);
 
         if (umbralHeightBoost &&
             heightDiff <= Config.Movement.DASH_FLAT_HEIGHT_UPPER &&

--- a/src/main/java/btm/sword/system/control/ScheduleChain.java
+++ b/src/main/java/btm/sword/system/control/ScheduleChain.java
@@ -1,0 +1,89 @@
+package btm.sword.system.control;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.bukkit.Bukkit;
+
+import btm.sword.Sword;
+
+/**
+ * A cancellable, sequential chain of delayed tasks built on {@link SwordScheduler}.
+ *
+ * <p>Steps are enqueued via {@link #andThen} and execute in order, each step's delay
+ * measured from when the <em>previous</em> step ran (not from chain creation).
+ * Tasks started inside a step (e.g. looping animations) are independent and continue
+ * running across step boundaries — only the pending <em>next</em> step is cancelled
+ * when {@link #cancel()} is called.</p>
+ *
+ * <p>Obtain an instance via {@link SwordScheduler#after}:</p>
+ * <pre>{@code
+ * ScheduleChain chain = SwordScheduler.after(500, TimeUnit.MILLISECONDS, this::phaseOne)
+ *     .andThen(1000, TimeUnit.MILLISECONDS, this::phaseTwo)
+ *     .andThen(500,  TimeUnit.MILLISECONDS, this::phaseThree);
+ *
+ * // Later, if needed:
+ * chain.cancel();
+ * }</pre>
+ */
+public final class ScheduleChain {
+
+    private record Step(int delay, TimeUnit unit, Runnable runnable) {}
+
+    private final List<Step> steps = new ArrayList<>();
+    private volatile ScheduledFuture<?> pendingFuture;
+    private volatile boolean cancelled = false;
+
+    ScheduleChain() {}
+
+    /**
+     * Adds a step that runs after the previous step completes, delayed by the given duration.
+     *
+     * @param delay    how long to wait after the previous step runs
+     * @param unit     the time unit of the delay
+     * @param runnable the task to execute on the main thread
+     * @return this chain, for fluent chaining
+     */
+    public ScheduleChain andThen(int delay, TimeUnit unit, Runnable runnable) {
+        steps.add(new Step(delay, unit, runnable));
+        return this;
+    }
+
+    /**
+     * Cancels any pending (not-yet-started) step in this chain.
+     * Steps already executing and any independent looping tasks they started are unaffected.
+     */
+    public void cancel() {
+        cancelled = true;
+        ScheduledFuture<?> future = pendingFuture;
+        if (future != null) {
+            future.cancel(false);
+        }
+    }
+
+    /**
+     * Adds the first step and starts the chain. Called by {@link SwordScheduler#after}.
+     */
+    ScheduleChain start(int delay, TimeUnit unit, Runnable runnable) {
+        steps.add(new Step(delay, unit, runnable));
+        scheduleStep(0);
+        return this;
+    }
+
+    private void scheduleStep(int index) {
+        Step step = steps.get(index);
+        pendingFuture = Sword.getScheduler().schedule(() -> {
+            if (cancelled) return;
+            Bukkit.getScheduler().runTask(Sword.getInstance(), () -> {
+                if (cancelled) return;
+                step.runnable().run();
+                int next = index + 1;
+                if (next < steps.size()) {
+                    scheduleStep(next);
+                }
+            });
+        }, step.delay(), step.unit());
+    }
+}

--- a/src/main/java/btm/sword/system/control/SwordScheduler.java
+++ b/src/main/java/btm/sword/system/control/SwordScheduler.java
@@ -13,6 +13,26 @@ import btm.sword.Sword;
 public class SwordScheduler {
 
     /**
+     * Creates a new {@link ScheduleChain} whose first step runs after the given delay.
+     *
+     * <p>Chain additional steps with {@link ScheduleChain#andThen}. Each step's delay
+     * is measured from when the previous step ran, not from chain creation. Example:</p>
+     * <pre>{@code
+     * ScheduleChain chain = SwordScheduler.after(500, TimeUnit.MILLISECONDS, this::phaseOne)
+     *     .andThen(1000, TimeUnit.MILLISECONDS, this::phaseTwo)
+     *     .andThen(500,  TimeUnit.MILLISECONDS, this::phaseThree);
+     * }</pre>
+     *
+     * @param delay    how long to wait before the first step runs
+     * @param unit     the time unit of the delay
+     * @param runnable the first task to execute on the main thread
+     * @return a {@link ScheduleChain} that can be cancelled or extended with {@code andThen}
+     */
+    public static ScheduleChain after(int delay, TimeUnit unit, Runnable runnable) {
+        return new ScheduleChain().start(delay, unit, runnable);
+    }
+
+    /**
      * Runs the given {@link Runnable} synchronously (on the main server thread)
      * after the specified delay, measured using the internal asynchronous scheduler.
      * <p>

--- a/src/main/java/btm/sword/system/entity/SwordEntityArbiter.java
+++ b/src/main/java/btm/sword/system/entity/SwordEntityArbiter.java
@@ -135,7 +135,7 @@ public class SwordEntityArbiter {
         switch (entity.getType()) {
             case ZOMBIE, SKELETON, WITHER_SKELETON, ENDERMAN, WARDEN, RAVAGER, CAVE_SPIDER, PILLAGER, ZOMBIFIED_PIGLIN,
                  HOGLIN, HUSK, SHULKER, SILVERFISH, SLIME, SPIDER, ENDER_DRAGON, EVOKER, ELDER_GUARDIAN, ENDERMITE,
-                 BLAZE, MAGMA_CUBE, PHANTOM -> {
+                 BLAZE, MAGMA_CUBE, PHANTOM, WITCH, ILLUSIONER -> {
                 return new Hostile(entity, new CombatProfile());
             }
             case ARMOR_STAND -> {

--- a/src/main/java/btm/sword/system/entity/ai/HostileStateMachine.java
+++ b/src/main/java/btm/sword/system/entity/ai/HostileStateMachine.java
@@ -15,6 +15,7 @@ import btm.sword.system.entity.ai.state.IdleState;
 import btm.sword.system.entity.ai.state.OnGuardState;
 import btm.sword.system.entity.ai.state.PreAttackState;
 import btm.sword.system.entity.ai.state.RetreatState;
+import btm.sword.system.entity.ai.state.RetrieveWeaponState;
 import btm.sword.system.entity.ai.state.SurroundState;
 import btm.sword.system.entity.impl.Hostile;
 import btm.sword.utility.statemachine.State;
@@ -76,7 +77,22 @@ public class HostileStateMachine extends StateMachine<Hostile> {
             }
         ));
 
-        // 2. ANY → IdleState: current target switched to creative or spectator mid-combat
+        // 2. ANY → RetrieveWeaponState: mob's thrown weapon has landed and needs retrieval
+        addTransition(new Transition<>(
+            HostileAIFacade.class,
+            RetrieveWeaponState.class,
+            h -> {
+                if (h.getAiStateMachine().getState() instanceof RetrieveWeaponState) return false;
+                if (h.getAiStateMachine().getState() instanceof FleeState) return false;
+                if (h.isAttemptingThrow()) return false;
+                return h.getLodgedThrowItem() != null
+                    && h.getLodgedThrowItem().getDisplay() != null
+                    && h.getLodgedThrowItem().getDisplay().isValid();
+            },
+            h -> {}
+        ));
+
+        // 3. ANY → IdleState: current target switched to creative or spectator mid-combat
         addTransition(new Transition<>(
             HostileAIFacade.class,
             IdleState.class,
@@ -314,6 +330,37 @@ public class HostileStateMachine extends StateMachine<Hostile> {
                 return nearby.isEmpty();
             },
             h -> {}
+        ));
+
+        // 15. RetrieveWeaponState → ApproachState: weapon retrieved, target still in aggro range
+        addTransition(new Transition<>(
+            RetrieveWeaponState.class,
+            ApproachState.class,
+            h -> {
+                if (h.getLodgedThrowItem() != null) return false;
+                if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return false;
+                return h.self().getLocation()
+                    .distanceSquared(h.getCurrentTarget().self().getLocation()) <= Config.Hostile.AGGRO_RANGE_SQUARED;
+            },
+            h -> {}
+        ));
+
+        // 16. RetrieveWeaponState → IdleState: weapon retrieved (or expired), target gone or out of range
+        addTransition(new Transition<>(
+            RetrieveWeaponState.class,
+            IdleState.class,
+            h -> {
+                if (h.getLodgedThrowItem() != null) return false;
+                if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return true;
+                return h.self().getLocation()
+                    .distanceSquared(h.getCurrentTarget().self().getLocation()) > Config.Hostile.AGGRO_RANGE_SQUARED;
+            },
+            h -> {
+                h.setCurrentTarget(null);
+                if (h.getAggroTarget() != null && !h.getAggroTarget().self().isValid()) {
+                    h.setAggroTarget(null);
+                }
+            }
         ));
     }
 }

--- a/src/main/java/btm/sword/system/entity/ai/README.md
+++ b/src/main/java/btm/sword/system/entity/ai/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This package implements a finite state machine (FSM) driven AI for `Hostile` entities. It governs every phase of enemy behaviour — idle patrol, player detection, approach, group coordination, attack wind-up, attack execution, three post-attack branches, and low-health flight — through nine concrete states wired together with nineteen transitions.
+This package implements a finite state machine (FSM) driven AI for `Hostile` entities. It governs every phase of enemy behaviour — idle patrol, player detection, approach, group coordination, attack wind-up, attack execution, three post-attack branches, weapon retrieval, and low-health flight — through ten concrete states wired together with twenty-three transitions.
 
 The design mirrors the `UmbralBlade` FSM found in `system/entity/umbral/statemachine/`. `HostileAIFacade` plays the same role as `UmbralStateFacade`: a common abstract base that enables wildcard transitions (transitions whose `from` type matches any concrete state in the machine). The generic `StateMachine<T>` / `State<T>` / `Transition<T>` infrastructure in `utility/statemachine/` is shared between both machines without modification.
 
@@ -64,6 +64,17 @@ The design mirrors the `UmbralBlade` FSM found in `system/entity/umbral/statemac
                                      in aggro range]+----> IDLE
 
   ANY STATE --[target switches to creative/spectator]--> IDLE
+
+  ANY STATE --[lodgedThrowItem != null && !attemptingThrow]--> +-----------------+
+                                                               | RETRIEVE_WEAPON |
+                                                               +-----------------+
+                                                                        |
+                                                [lodgedThrowItem null]  |
+                                                         +--------------+--------------+
+                                                         |                             |
+                                                  [target in range]           [target gone/out of range]
+                                                         v                             v
+                                                    APPROACH                         IDLE
 ```
 
 Transitions `SURROUND → APPROACH` (ally count drops) and the `RETREAT` sub-graph (orphaned but retained)
@@ -95,6 +106,9 @@ are omitted from the ASCII art for readability; see the transition table below.
 | 18 | `RetreatState` | `ApproachState` | `retreatTimer <= 0` AND target still in aggro range | None |
 | 19 | `RetreatState` | `IdleState` | `retreatTimer <= 0` AND target left aggro range or invalid | Clear `currentTarget`; clear `aggroTarget` only if target dead/invalid |
 | 20 | `FleeState` | `IdleState` | No `Player` entity within aggro radius | None |
+| 21 | ANY (`HostileAIFacade`) | `RetrieveWeaponState` | Not already in `RetrieveWeaponState`/`FleeState`, not `isAttemptingThrow()`, AND `lodgedThrowItem` is non-null with valid display | None |
+| 22 | `RetrieveWeaponState` | `ApproachState` | `lodgedThrowItem == null` AND target still in aggro range | None |
+| 23 | `RetrieveWeaponState` | `IdleState` | `lodgedThrowItem == null` AND target lost or left aggro range | Clear `currentTarget`; clear `aggroTarget` only if target dead/invalid |
 
 ---
 
@@ -165,6 +179,18 @@ After landing an attack the mob backs off before re-engaging. On entry the mob's
 
 > **Note:** `RetreatState` is no longer reachable from `AttackState` — all post-attack branches now lead to `OnGuardState`, `AttackReadyState`, or `AttackState` (combo). `RetreatState` and its transitions are retained for potential future use.
 
+### `RetrieveWeaponState`
+
+Triggered any time a mob's thrown weapon grounds in the world (the `ThrownItem.onGroundCallback` sets `Hostile.lodgedThrowItem`). On entry, `RetrieveWeaponGoal` (MOVE, priority 1) pathfinds toward the item display at 120% speed; `LookAtTargetGoal` (LOOK, priority 2) is added if a `currentTarget` is set so the mob still faces its opponent while closing in.
+
+Each tick checks `distanceSquared(display) <= MOB_RETRIEVE_PICKUP_RANGE_SQUARED`. When the mob closes to within pickup range:
+1. The `ThrownItem` display is removed from `InteractiveItemArbiter` (without disposal) and marked `retrieved = true`.
+2. The item stack is restored to the mob's main hand via `setItemStackInHand(weapon, true)`.
+3. A `GRAB_CLOUD` particle effect is played at the display location.
+4. The display entity is disposed and `lodgedThrowItem` is cleared.
+
+Clearing `lodgedThrowItem` triggers transition #22 (→ `ApproachState`) if the target is still in aggro range, or transition #23 (→ `IdleState`) if the target has left. If the display expires before the mob arrives (timed out or disposed externally), `lodgedThrowItem` is cleared in `onTick` and the same exit transitions fire.
+
 ### `FleeState`
 
 The mob's health has dropped below `FLEE_HEALTH_FRACTION` of its maximum. `currentTarget` is cleared on transition entry. `Mob.setAware(true)` is called so the mob can move freely. Every 20 ticks the nearest `Player` within aggro range is located and a flee direction is computed as the vector pointing away from that player; the mob pathfinds 16 blocks along that vector at 150% speed. The direction is recalculated on a cadence rather than every tick to reduce the cost of `World.getNearbyPlayers()`. Transition #20 checks for the complete absence of players in aggro range and returns to `IdleState`.
@@ -188,7 +214,7 @@ The mob's health has dropped below `FLEE_HEALTH_FRACTION` of its maximum. `curre
 | Class | Category | Description |
 |-------|----------|-------------|
 | `MobSlashAbility` | `MELEE` | Randomly selects `SLASH1`/`SLASH2`/`SLASH3` and runs a `MobSweepAttack` with `defaultMobHit` |
-| `MobThrowAbility` | `RANGED` | Launches the mob's off-hand item as a `DroppedItem` with a parabolic arc toward the target |
+| `MobThrowAbility` | `RANGED` | Launches the mob's main-hand item toward the target. `canUse()` gates selection by both cooldown and a `MOB_THROW_WEIGHT` probability roll (default 0.3). If the hand is empty, performs a dirt-scoop animation (look down → break particles → give dirt) before throwing. When the item lands, sets `Hostile.lodgedThrowItem` to trigger retrieval via `RetrieveWeaponState`. |
 
 **Selection flow in `PreAttackState.onEnter`:**
 1. `selectAbility()` filters `possibleAbilities` by `canUse()` and picks one at random; stores it in `pendingAbility`.

--- a/src/main/java/btm/sword/system/entity/ai/ability/MobThrowAbility.java
+++ b/src/main/java/btm/sword/system/entity/ai/ability/MobThrowAbility.java
@@ -1,7 +1,10 @@
 package btm.sword.system.entity.ai.ability;
 
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
+import org.bukkit.Material;
+import org.bukkit.Particle;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
@@ -15,9 +18,16 @@ import btm.sword.system.entity.impl.Hostile;
 /**
  * A ranged throwing ability for hostile mobs.
  *
- * <p>Launches the mob's off-hand item as a projectile with a parabolic arc toward the
+ * <p>Launches the mob's main-hand item as a projectile with a parabolic arc toward the
  * current target. The arc height and cooldown are controlled via {@link Config.Hostile}.
- * Ability category: {@link AbilityCategory#RANGED}.
+ *
+ * <p>If the mob has nothing in its main hand, it performs a dirt-scoop animation:
+ * looks down, punches the ground, picks up a dirt block, and throws it instead.
+ *
+ * <p>When the thrown item lands, the mob's {@code lodgedThrowItem} is set so the
+ * {@link btm.sword.system.entity.ai.state.RetrieveWeaponState} can drive retrieval.
+ *
+ * <p>Ability category: {@link AbilityCategory#RANGED}.
  */
 public class MobThrowAbility implements MobAbility {
 
@@ -31,10 +41,19 @@ public class MobThrowAbility implements MobAbility {
         return AbilityCategory.RANGED;
     }
 
+    /**
+     * Returns {@code true} if the ability is off cooldown and passes the
+     * {@link Config.Hostile#MOB_THROW_WEIGHT} probability roll, making throws rarer
+     * than melee when both abilities are available.
+     *
+     * @param h the hostile mob
+     * @return {@code true} if the throw can be selected this pre-attack phase
+     */
     @Override
     public boolean canUse(Hostile h) {
         Integer cooldown = h.getAbilityCooldowns().get(name());
-        return cooldown == null || cooldown <= 0;
+        if (cooldown != null && cooldown > 0) return false;
+        return ThreadLocalRandom.current().nextDouble() < Config.Hostile.MOB_THROW_WEIGHT;
     }
 
     @Override
@@ -48,27 +67,26 @@ public class MobThrowAbility implements MobAbility {
 
         MobGoalArbiter.GOALS.addGoal(h.mob(), 1, new LookAtTargetGoal(h.mob(), h));
 
-        // Bug 1 fix: use the explicit item so ThrowAction uses it instead of inferring from hand
-        ItemStack projectile = h.getItemStackInHand(true);
-        if (projectile == null || projectile.isEmpty()) return;
-
         Vector toTarget = h.getCurrentTarget().self().getLocation()
             .subtract(h.self().getLocation())
             .toVector();
 
         double distance = toTarget.length();
         if (distance < 0.001) return;
-
         toTarget.normalize();
-//        // Add vertical arc so the projectile curves up and lands on the target
-//        toTarget.setY(toTarget.getY() + Config.Hostile.MOB_THROW_ARC_HEIGHT * distance / 8.0);
 
-        // Bug 1 fix: pass the explicit off-hand item so ThrowAction uses it instead of main-hand
+        ItemStack projectile = h.getItemStackInHand(true);
+        if (projectile == null || projectile.isEmpty()) {
+            executeDirtThrow(h, toTarget);
+            return;
+        }
+
         ThrowAction.throwReady(h, projectile);
 
-        // Bug 2 fix: apply the arc direction to the ThrownItem before it is released
         if (h.getThrownItem() != null) {
             h.getThrownItem().setLaunchDirection(toTarget);
+            // #224: when the weapon lands, flag it for retrieval
+            h.getThrownItem().setOnGroundCallback(() -> h.setLodgedThrowItem(h.getThrownItem()));
         }
 
         SwordScheduler.runBukkitTaskLater(
@@ -76,6 +94,54 @@ public class MobThrowAbility implements MobAbility {
             400,
             TimeUnit.MILLISECONDS
         );
+    }
+
+    /**
+     * Fallback throw sequence for when the mob has no item in its main hand.
+     *
+     * <p>The mob looks down, punches the ground (block-break particles), then after a short
+     * delay stands up, takes a dirt block, and throws it at the current target.
+     *
+     * @param h        the hostile mob performing the sequence
+     * @param toTarget pre-normalized direction vector toward the current target
+     */
+    private void executeDirtThrow(Hostile h, Vector toTarget) {
+        // Prevent re-entry during the animation window
+        h.setAttemptingThrow(true);
+
+        float yaw = h.mob().getLocation().getYaw();
+        h.mob().setRotation(yaw, 70f);
+
+        h.self().getWorld().spawnParticle(
+            Particle.BLOCK,
+            h.self().getLocation().add(0, 0.2, 0),
+            30, 0.3, 0.1, 0.3, 0,
+            Material.DIRT.createBlockData()
+        );
+
+        SwordScheduler.runBukkitTaskLater(() -> {
+            if (!h.self().isValid() || h.getCurrentTarget() == null
+                    || !h.getCurrentTarget().self().isValid()) {
+                h.setAttemptingThrow(false);
+                return;
+            }
+
+            h.mob().setRotation(yaw, 0f);
+            ItemStack dirt = new ItemStack(Material.DIRT);
+            h.setItemStackInHand(dirt, true);
+
+            ThrowAction.throwReady(h, dirt);
+
+            if (h.getThrownItem() != null) {
+                h.getThrownItem().setLaunchDirection(toTarget);
+            }
+
+            SwordScheduler.runBukkitTaskLater(
+                () -> ThrowAction.throwItem(h),
+                400,
+                TimeUnit.MILLISECONDS
+            );
+        }, 300, TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/src/main/java/btm/sword/system/entity/ai/goal/RetrieveWeaponGoal.java
+++ b/src/main/java/btm/sword/system/entity/ai/goal/RetrieveWeaponGoal.java
@@ -1,0 +1,96 @@
+package btm.sword.system.entity.ai.goal;
+
+import java.util.EnumSet;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Mob;
+import org.jetbrains.annotations.NotNull;
+
+import com.destroystokyo.paper.entity.ai.Goal;
+import com.destroystokyo.paper.entity.ai.GoalKey;
+import com.destroystokyo.paper.entity.ai.GoalType;
+
+import btm.sword.Sword;
+import btm.sword.system.action.throwing.types.ThrownItem;
+import btm.sword.system.entity.impl.Hostile;
+
+/**
+ * Pathfinds toward the {@link Hostile}'s lodged thrown item at 120% movement speed.
+ *
+ * <p>Registered by {@code RetrieveWeaponState.onEnter} and removed by {@code RetrieveWeaponState.onExit}.
+ * {@link #shouldStayActive()} deactivates when the lodged item is cleared or its display becomes invalid.
+ */
+public class RetrieveWeaponGoal implements Goal<@NotNull Mob> {
+
+    /** Unique key for this goal; used for lookup and removal. */
+    public static final GoalKey<@NotNull Mob> KEY =
+        GoalKey.of(Mob.class, new NamespacedKey(Sword.getInstance(), "retrieve_weapon"));
+
+    private static final double RETRIEVE_SPEED = 1.2;
+
+    private final Mob mob;
+    private final Hostile hostile;
+
+    /**
+     * Constructs a {@code RetrieveWeaponGoal} for the given mob and its Sword wrapper.
+     *
+     * @param mob     the Bukkit {@link Mob} to pathfind
+     * @param hostile the {@link Hostile} wrapper owning the lodged item reference
+     */
+    public RetrieveWeaponGoal(Mob mob, Hostile hostile) {
+        this.mob = mob;
+        this.hostile = hostile;
+    }
+
+    /** Activates immediately on registration. */
+    @Override
+    public boolean shouldActivate() {
+        return true;
+    }
+
+    /**
+     * Returns {@code false} when the lodged item is cleared or its display has been removed,
+     * acting as a secondary exit signal alongside the FSM transition.
+     *
+     * @return {@code true} while a valid lodged item exists
+     */
+    @Override
+    public boolean shouldStayActive() {
+        ThrownItem item = hostile.getLodgedThrowItem();
+        return item != null && item.getDisplay() != null && item.getDisplay().isValid();
+    }
+
+    /** Starts pathfinding toward the lodged item on goal activation. */
+    @Override
+    public void start() {
+        pathfindToItem();
+    }
+
+    /** Stops pathfinding when the goal deactivates. */
+    @Override
+    public void stop() {
+        mob.getPathfinder().stopPathfinding();
+    }
+
+    /** Re-issues the pathfind command each tick to track the item's current location. */
+    @Override
+    public void tick() {
+        pathfindToItem();
+    }
+
+    @Override
+    public @NotNull GoalKey<@NotNull Mob> getKey() {
+        return KEY;
+    }
+
+    @Override
+    public @NotNull EnumSet<GoalType> getTypes() {
+        return EnumSet.of(GoalType.MOVE);
+    }
+
+    private void pathfindToItem() {
+        ThrownItem item = hostile.getLodgedThrowItem();
+        if (item == null || item.getDisplay() == null || !item.getDisplay().isValid()) return;
+        mob.getPathfinder().moveTo(item.getDisplay().getLocation(), RETRIEVE_SPEED);
+    }
+}

--- a/src/main/java/btm/sword/system/entity/ai/state/AttackState.java
+++ b/src/main/java/btm/sword/system/entity/ai/state/AttackState.java
@@ -9,7 +9,9 @@ import com.destroystokyo.paper.entity.ai.GoalType;
 import btm.sword.system.entity.ai.HostileAIFacade;
 import btm.sword.system.entity.ai.MobGoalArbiter;
 import btm.sword.system.entity.ai.goal.LookAtTargetGoal;
+import btm.sword.system.entity.display.DisplayRig;
 import btm.sword.system.entity.impl.Hostile;
+import net.donnypz.displayentityutils.utils.DisplayEntities.machine.MachineState;
 
 /**
  * Attack AI state for Hostile entities.
@@ -54,6 +56,11 @@ public class AttackState extends HostileAIFacade {
 
         h.setAttackDone(true);
         h.setAttackPostRoll(ThreadLocalRandom.current().nextInt(3));
+
+        DisplayRig rig = h.getDisplayRig();
+        if (rig != null) {
+            rig.setState(MachineState.StateType.MELEE);
+        }
     }
 
     @Override

--- a/src/main/java/btm/sword/system/entity/ai/state/RetrieveWeaponState.java
+++ b/src/main/java/btm/sword/system/entity/ai/state/RetrieveWeaponState.java
@@ -1,0 +1,87 @@
+package btm.sword.system.entity.ai.state;
+
+import org.bukkit.entity.ItemDisplay;
+
+import com.destroystokyo.paper.entity.ai.GoalType;
+
+import btm.sword.config.Config;
+import btm.sword.system.action.throwing.InteractiveItemArbiter;
+import btm.sword.system.action.throwing.types.ThrownItem;
+import btm.sword.system.entity.ai.HostileAIFacade;
+import btm.sword.system.entity.ai.MobGoalArbiter;
+import btm.sword.system.entity.ai.goal.LookAtTargetGoal;
+import btm.sword.system.entity.ai.goal.RetrieveWeaponGoal;
+import btm.sword.system.entity.impl.Hostile;
+import btm.sword.utility.Prefab;
+
+/**
+ * Weapon-retrieval AI state for Hostile entities.
+ *
+ * <p>Entered when a mob's thrown weapon lands and becomes lodged in the world.
+ * Adds a {@link RetrieveWeaponGoal} to pathfind toward the item's display entity.
+ * Each tick checks whether the mob is within pickup range
+ * ({@link Config.Hostile#MOB_RETRIEVE_PICKUP_RANGE_SQUARED}); on proximity,
+ * retrieves the item back into the mob's main hand.
+ *
+ * <p>Exits via FSM transition once {@code lodgedThrowItem} is cleared (either by pickup
+ * or by the display expiring before the mob arrives).
+ */
+public class RetrieveWeaponState extends HostileAIFacade {
+
+    @Override
+    public String name() {
+        return "RETRIEVE_WEAPON";
+    }
+
+    @Override
+    public void onEnter(Hostile h) {
+        MobGoalArbiter.GOALS.addGoal(h.mob(), 1, new RetrieveWeaponGoal(h.mob(), h));
+        if (h.getCurrentTarget() != null) {
+            MobGoalArbiter.GOALS.addGoal(h.mob(), 2, new LookAtTargetGoal(h.mob(), h));
+        }
+    }
+
+    @Override
+    public void onTick(Hostile h) {
+        ThrownItem lodged = h.getLodgedThrowItem();
+        if (lodged == null) return;
+
+        ItemDisplay display = lodged.getDisplay();
+        if (display == null || !display.isValid()) {
+            h.setLodgedThrowItem(null);
+            return;
+        }
+
+        double distSq = h.self().getLocation().distanceSquared(display.getLocation());
+        if (distSq <= Config.Hostile.MOB_RETRIEVE_PICKUP_RANGE_SQUARED) {
+            retrieveItem(h, lodged);
+        }
+    }
+
+    @Override
+    public void onExit(Hostile h) {
+        MobGoalArbiter.GOALS.removeAllGoals(h.mob(), GoalType.MOVE);
+        MobGoalArbiter.GOALS.removeAllGoals(h.mob(), GoalType.LOOK);
+    }
+
+    /**
+     * Removes the lodged item from the interactive arbiter, returns it to the mob's main hand,
+     * plays a pickup particle effect, and clears the lodged reference.
+     *
+     * @param h      the hostile mob retrieving the weapon
+     * @param lodged the grounded {@link ThrownItem} to reclaim
+     */
+    private void retrieveItem(Hostile h, ThrownItem lodged) {
+        ItemDisplay display = lodged.getDisplay();
+        InteractiveItemArbiter.remove(display, false);
+        lodged.setRetrieved(true);
+
+        if (lodged.getItemStack() != null && !lodged.getItemStack().isEmpty()) {
+            h.setItemStackInHand(lodged.getItemStack(), true);
+            Prefab.Particles.GRAB_CLOUD.display(display.getLocation());
+        }
+
+        lodged.dispose();
+        h.setLodgedThrowItem(null);
+    }
+}

--- a/src/main/java/btm/sword/system/entity/display/DisplayRig.java
+++ b/src/main/java/btm/sword/system/entity/display/DisplayRig.java
@@ -1,0 +1,118 @@
+package btm.sword.system.entity.display;
+
+import java.util.List;
+
+import org.bukkit.entity.Mob;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.Nullable;
+
+import btm.sword.Sword;
+import btm.sword.config.Config;
+import net.donnypz.displayentityutils.events.GroupSpawnedEvent;
+import net.donnypz.displayentityutils.managers.DisplayGroupManager;
+import net.donnypz.displayentityutils.managers.LoadMethod;
+import net.donnypz.displayentityutils.utils.DisplayEntities.DisplayAnimator;
+import net.donnypz.displayentityutils.utils.DisplayEntities.DisplayEntityGroup;
+import net.donnypz.displayentityutils.utils.DisplayEntities.SpawnedDisplayEntityGroup;
+import net.donnypz.displayentityutils.utils.DisplayEntities.machine.DisplayStateMachine;
+import net.donnypz.displayentityutils.utils.DisplayEntities.machine.MachineState;
+import net.donnypz.displayentityutils.utils.FollowType;
+import net.donnypz.displayentityutils.utils.controller.GroupFollowProperties;
+
+/**
+ * Visual display rig attached to a {@link Mob}.
+ * <p>
+ * Wraps a {@link SpawnedDisplayEntityGroup} and a {@link DisplayStateMachine}.
+ * The machine automatically transitions between IDLE, WALK, and FALLING states based
+ * on the mob's movement. The MELEE state is triggered manually by the AI FSM
+ * (see {@link btm.sword.system.entity.ai.state.AttackState}).
+ * </p>
+ *
+ * <p>To spawn a rig for a mob, call {@link #spawn(Mob, String)} with the mob and
+ * the DEU group tag. Call {@link #despawn()} when the mob dies to clean up entities.</p>
+ */
+public class DisplayRig {
+
+    private final SpawnedDisplayEntityGroup group;
+    private final DisplayStateMachine stateMachine;
+
+    private DisplayRig(SpawnedDisplayEntityGroup group, DisplayStateMachine stateMachine) {
+        this.group = group;
+        this.stateMachine = stateMachine;
+    }
+
+    /**
+     * Spawns a display rig for the given mob using the named DEU group tag.
+     * Returns {@code null} if the group cannot be found in DEU's local storage.
+     *
+     * @param mob      the mob to attach the rig to
+     * @param groupTag the DEU group tag to spawn
+     * @return the new rig, or {@code null} on failure
+     */
+    public static @Nullable DisplayRig spawn(Mob mob, String groupTag) {
+        DisplayEntityGroup def = DisplayGroupManager.getGroup(LoadMethod.LOCAL, groupTag);
+        if (def == null) {
+            Sword.getInstance().getLogger().warning(
+                "[DisplayRig] Group not found: " + groupTag + " — skipping display rig."
+            );
+            return null;
+        }
+
+        SpawnedDisplayEntityGroup group = def.spawn(mob.getLocation(), GroupSpawnedEvent.SpawnReason.CUSTOM);
+        group.rideEntity(mob);
+        group.setRideOffset(new Vector(0, Config.Hostile.DISPLAY_RIDE_OFFSET_Y, 0));
+
+        GroupFollowProperties yawFollow = GroupFollowProperties.builder(FollowType.YAW)
+            .setId("hostile_yaw")
+            .build();
+        group.followEntityDirection(mob, yawFollow);
+
+        DisplayStateMachine stateMachine = new DisplayStateMachine(mob.getUniqueId() + "_rig");
+        addState(stateMachine, MachineState.StateType.IDLE, Config.Hostile.DISPLAY_ANIM_IDLE, false);
+        addState(stateMachine, MachineState.StateType.WALK, Config.Hostile.DISPLAY_ANIM_WALK, false);
+        addState(stateMachine, MachineState.StateType.FALLING, Config.Hostile.DISPLAY_ANIM_FALL, false);
+        addState(stateMachine, MachineState.StateType.MELEE, Config.Hostile.DISPLAY_ANIM_MELEE, true);
+        stateMachine.addGroup(group);
+
+        return new DisplayRig(group, stateMachine);
+    }
+
+    /**
+     * Manually overrides the current animation state.
+     * States registered with {@code transitionLock = true} (e.g. MELEE) hold until
+     * the animation completes, then the machine resumes automatic transitions.
+     *
+     * @param type the state to transition to
+     */
+    public void setState(MachineState.StateType type) {
+        stateMachine.setState(type, group);
+    }
+
+    /**
+     * Removes the spawned group from the world and unregisters the state machine.
+     * Must be called when the mob dies or is removed.
+     */
+    public void despawn() {
+        stateMachine.removeGroup(group);
+        group.unregister(true, true);
+    }
+
+    /**
+     * Registers a {@link MachineState} in the machine if {@code animTag} is non-empty.
+     * Looping states use {@link DisplayAnimator.AnimationType#LOOP};
+     * locked states use {@link DisplayAnimator.AnimationType#LINEAR} so DEU knows when
+     * the animation ends and can release the transition lock.
+     */
+    private static void addState(
+            DisplayStateMachine machine,
+            MachineState.StateType type,
+            String animTag,
+            boolean transitionLock) {
+        if (animTag == null || animTag.isEmpty()) return;
+        DisplayAnimator.AnimationType animType = transitionLock
+            ? DisplayAnimator.AnimationType.LINEAR
+            : DisplayAnimator.AnimationType.LOOP;
+        MachineState state = new MachineState(machine, type, List.of(animTag), LoadMethod.LOCAL, animType, transitionLock);
+        machine.addState(state);
+    }
+}

--- a/src/main/java/btm/sword/system/entity/display/DisplayRig.java
+++ b/src/main/java/btm/sword/system/entity/display/DisplayRig.java
@@ -2,6 +2,7 @@ package btm.sword.system.entity.display;
 
 import java.util.List;
 
+import org.bukkit.entity.Display;
 import org.bukkit.entity.Mob;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.Nullable;
@@ -60,10 +61,18 @@ public class DisplayRig {
 
         SpawnedDisplayEntityGroup group = def.spawn(mob.getLocation(), GroupSpawnedEvent.SpawnReason.CUSTOM);
         group.rideEntity(mob);
-        group.setRideOffset(new Vector(0, Config.Hostile.DISPLAY_RIDE_OFFSET_Y, 0));
+        // Offset the rig downward by the mob's height so the rig sits at ground level,
+        // with DISPLAY_RIDE_OFFSET_Y as a fine-tuning knob on top of that.
+        group.setRideOffset(new Vector(0, -mob.getHeight() + Config.Hostile.DISPLAY_RIDE_OFFSET_Y, 0));
+
+        // Apply teleport duration to every display part for smooth client-side movement.
+        for (Display display : group.getPartEntities(Display.class)) {
+            display.setTeleportDuration(Config.Hostile.DISPLAY_TELEPORT_DURATION);
+        }
 
         GroupFollowProperties yawFollow = GroupFollowProperties.builder(FollowType.YAW)
             .setId("hostile_yaw")
+            .setTeleportationDuration(Config.Hostile.DISPLAY_TELEPORT_DURATION)
             .build();
         group.followEntityDirection(mob, yawFollow);
 

--- a/src/main/java/btm/sword/system/entity/impl/Hostile.java
+++ b/src/main/java/btm/sword/system/entity/impl/Hostile.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -21,7 +22,10 @@ import org.bukkit.util.Vector;
 import com.destroystokyo.paper.entity.Pathfinder;
 import com.destroystokyo.paper.entity.ai.GoalType;
 
+import btm.sword.config.Config;
 import btm.sword.system.action.throwing.types.DroppedItem;
+import btm.sword.system.action.throwing.types.ThrownItem;
+import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.entity.ai.HostileStateMachine;
 import btm.sword.system.entity.ai.MobGoalArbiter;
 import btm.sword.system.entity.ai.WanderProfile;
@@ -33,6 +37,7 @@ import btm.sword.system.entity.aspect.AspectType;
 import btm.sword.system.entity.aspect.Resource;
 import btm.sword.system.entity.base.CombatProfile;
 import btm.sword.system.entity.base.SwordEntity;
+import btm.sword.system.entity.display.DisplayRig;
 import btm.sword.system.item.weapon.WeaponType;
 import btm.sword.utility.Debug;
 import lombok.Getter;
@@ -60,6 +65,13 @@ public class Hostile extends Combatant {
     /** The ability selected at the start of PreAttackState; executed on AttackState entry. */
     private MobAbility pendingAbility;
 
+    /**
+     * The thrown item that has landed in the world and is waiting to be retrieved.
+     * Set by {@link btm.sword.system.entity.ai.ability.MobThrowAbility} when the item grounds;
+     * cleared by {@link btm.sword.system.entity.ai.state.RetrieveWeaponState} on pickup or expiry.
+     */
+    private ThrownItem lodgedThrowItem;
+
     /** Per-ability cooldown counters (ticks remaining). Decremented each tick; removed at 0. */
     private final Map<String, Integer> abilityCooldowns;
 
@@ -68,6 +80,9 @@ public class Hostile extends Combatant {
 
     // AI state machine
     private HostileStateMachine aiStateMachine;
+
+    /** Visual display rig; {@code null} when the group tag is unset or the group is not found. */
+    @Getter private DisplayRig displayRig;
     private WanderProfile wanderProfile = WanderProfile.ROAMER;
     private SwordEntity currentTarget;
     private SwordEntity nearestScannedTarget;
@@ -158,10 +173,21 @@ public class Hostile extends Combatant {
         ((Resource) aspects.getAspect(AspectType.SHARDS)).stopRegenTask(); // prevent regen of shards
         MobGoalArbiter.GOALS.removeAllGoals(mob); // clear all vanilla goals before starting custom AI
         aiStateMachine = new HostileStateMachine(this, new IdleState());
+        // Defer display rig spawn by one tick — spawning display entities synchronously during
+        // EntityAddToWorldEvent causes a Paper chunk-system error because the host chunk is
+        // still mid-update when this event fires.
+        SwordScheduler.runBukkitTaskLater(
+            () -> { if (mob.isValid()) displayRig = DisplayRig.spawn(mob, Config.Hostile.DISPLAY_GROUP); },
+            50, TimeUnit.MILLISECONDS
+        );
     }
 
     @Override
     public void onDeath() {
+        if (displayRig != null) {
+            displayRig.despawn();
+            displayRig = null;
+        }
         aiStateMachine = null;
         super.onDeath();
     }

--- a/src/main/java/btm/sword/system/entity/impl/Hostile.java
+++ b/src/main/java/btm/sword/system/entity/impl/Hostile.java
@@ -12,6 +12,7 @@ import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Mob;
 import org.bukkit.entity.Player;
@@ -147,9 +148,19 @@ public class Hostile extends Combatant {
 
         EntityEquipment equipment = associatedEntity.getEquipment();
         if (equipment != null) {
-            equipment.setItemInMainHand(itemInRightHand);
-            equipment.setItemInOffHand(itemInLeftHand);
-            equipment.setChestplate(new ItemStack(Material.NETHERITE_CHESTPLATE));
+            if (associatedEntity.getType() == EntityType.PILLAGER) {
+                // Zombie is driven by the display rig — strip all vanilla gear so nothing shows.
+                equipment.setItemInMainHand(ItemStack.of(Material.AIR));
+                equipment.setItemInOffHand(ItemStack.of(Material.AIR));
+                equipment.setHelmet(ItemStack.of(Material.AIR));
+                equipment.setChestplate(ItemStack.of(Material.AIR));
+                equipment.setLeggings(ItemStack.of(Material.AIR));
+                equipment.setBoots(ItemStack.of(Material.AIR));
+            } else {
+                equipment.setItemInMainHand(itemInRightHand);
+                equipment.setItemInOffHand(itemInLeftHand);
+                equipment.setChestplate(new ItemStack(Material.NETHERITE_CHESTPLATE));
+            }
         }
     }
 
@@ -176,10 +187,20 @@ public class Hostile extends Combatant {
         // Defer display rig spawn by one tick — spawning display entities synchronously during
         // EntityAddToWorldEvent causes a Paper chunk-system error because the host chunk is
         // still mid-update when this event fires.
-        SwordScheduler.runBukkitTaskLater(
-            () -> { if (mob.isValid()) displayRig = DisplayRig.spawn(mob, Config.Hostile.DISPLAY_GROUP); },
-            50, TimeUnit.MILLISECONDS
-        );
+        if (mob.getType() == EntityType.ZOMBIE) {
+            // Defer display rig spawn by one tick — spawning display entities synchronously during
+            // EntityAddToWorldEvent causes a Paper chunk-system error because the host chunk is
+            // still mid-update when this event fires.
+            SwordScheduler.runBukkitTaskLater(
+                () -> {
+                    if (mob.isValid()) {
+                        mob.setInvisible(true);
+                        displayRig = DisplayRig.spawn(mob, Config.Hostile.DISPLAY_GROUP);
+                    }
+                },
+                50, TimeUnit.MILLISECONDS
+            );
+        }
     }
 
     @Override

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -46,7 +46,6 @@ import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.aspect.AspectType;
 import btm.sword.system.entity.base.SwordEntity;
-import btm.sword.system.entity.umbral.input.BladeRequest;
 import btm.sword.system.input.ActivationContext;
 import btm.sword.system.input.InputAction;
 import btm.sword.system.input.InputActionExecutor;
@@ -648,9 +647,7 @@ public class SwordPlayer extends Combatant {
 
         player.setInvisible(true);
 
-        if (getUmbralBlade() != null) {
-            getUmbralBlade().request(BladeRequest.DEACTIVATE);
-        }
+        deactivateUmbralBlade();
 
         inSceneOverlay = true;
     }
@@ -683,6 +680,7 @@ public class SwordPlayer extends Combatant {
         }
 
         player.setInvisible(false);
+        activateUmbralBlade();
     }
 
     /**

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -725,6 +725,8 @@ public class SwordPlayer extends Combatant {
         // Place menu button one row above the hotbar (slot 17) to free up the hotbar
         player.getInventory().setItem(17, menuButton.getItemStack());
         player.getInventory().setItem(0, new ItemStack(Material.WOODEN_AXE));
+        player.getInventory().setItem(1, new ItemStack(Material.FIREWORK_ROCKET));
+        player.getInventory().setItem(38, new ItemStack(Material.ELYTRA));
 
         setAllAnchoredItemUpkeep(false);
         Debug.SPECIAL_ITEM_CHECKS_ENABLED = false;

--- a/src/main/java/btm/sword/system/entity/umbral/UmbralBlade.java
+++ b/src/main/java/btm/sword/system/entity/umbral/UmbralBlade.java
@@ -209,15 +209,32 @@ public class UmbralBlade extends ThrownItem {
     }
 
     // TODO: #240 - Make a method for calculating correct orientation of blade for edge to align with plane of swing on attack
-    // TODO: #240 - Make transitions smooth and slow with arcs and such and interpolation
     public void setDisplayTransformation(Class<? extends State<UmbralBlade>> state) {
         if (display == null) return;
 
+        int duration = getInterpolationDurationForState(state);
         SwordScheduler.runBukkitTaskLater(() -> {
-            DisplayUtil.setInterpolationValues(display, 0, 2); // TODO: #240 - Make duration dynamic if needed
+            DisplayUtil.setInterpolationValues(display, 0, duration);
             display.setTransformation(getStateDisplayTransformation(state));
             }, 50, TimeUnit.MILLISECONDS
         );
+    }
+
+    /**
+     * Returns the interpolation duration in ticks to use when transitioning the blade display
+     * into the given state. Fast action states use short durations; idle/equipped states use longer
+     * durations for smoother visual transitions.
+     *
+     * @param state the target state class
+     * @return interpolation duration in ticks
+     */
+    private int getInterpolationDurationForState(Class<? extends State<UmbralBlade>> state) {
+        if (state == LungingState.class || state == GrabImpaleState.class) return 2;
+        if (state == AttackingQuickState.class || state == AttackingHeavyState.class) return 2;
+        if (state == RecallingState.class) return 3;
+        if (state == SheathedState.class || state == WieldState.class) return 5;
+        if (state == StandbyState.class || state == WaitingState.class) return 8;
+        return 4;
     }
 
     public Transformation getStateDisplayTransformation(Class<? extends State<UmbralBlade>> state) {
@@ -301,8 +318,6 @@ public class UmbralBlade extends ThrownItem {
             idleMovementTask.cancel();
         }
     }
-
-    // TODO: #240 - Make item Display changes look less jerky
 
     @Override
     public void groundedCheck() {

--- a/src/main/java/btm/sword/system/input/InputRegistrar.java
+++ b/src/main/java/btm/sword/system/input/InputRegistrar.java
@@ -114,7 +114,12 @@ public class InputRegistrar {
             new InputExecutionTree.ActionContextPair(
                 () -> InputAction.builder()
                     .name("Block")
-                    .action(c -> BlockAction.startBlock((SwordPlayer) c))
+                    .action(c -> {
+                        // TODO: Revert after testing
+//                        PacketDisplayEntityGroup group = PacketDisplayEntityGroup.getGroup() // TODO:
+
+                        BlockAction.startBlock((SwordPlayer) c);
+                    })
                     .cooldown(executor -> 0)
                     .canCast(c -> true)
                     .displayDisabled(false)
@@ -528,6 +533,7 @@ public class InputRegistrar {
             .timeoutTicks(7)
             .cancellable(true)
             .display(true)
+            .visibleIf(ActivationContext.onlyIn(ActivationContext.NORMAL))
             .build();
 
         new InputExecutionTree.InputNodeBuilder(root, List.of(key, key, InputType.LEFT))

--- a/src/main/java/btm/sword/system/inventory/menu/AnimationBrowserMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/AnimationBrowserMenu.java
@@ -27,6 +27,7 @@ import btm.sword.system.inventory.item.PreviousItem;
 import btm.sword.system.item.ItemStackBuilder;
 import btm.sword.system.scene.CameraSystem;
 import btm.sword.system.scene.DEUAnimationController;
+import btm.sword.system.scene.WorldAnimationController;
 import btm.sword.system.scene.animation.AnimationDef;
 import btm.sword.system.scene.animation.AnimationRegistry;
 import net.kyori.adventure.text.Component;
@@ -90,7 +91,7 @@ public class AnimationBrowserMenu extends Menu {
                     } else if (type == ClickType.SHIFT_RIGHT) {
                         new DEUAnimationController(def, true, AnimationRegistry.isLooping(def.key())).start(swordPlayer);
                     } else if (type == ClickType.LEFT || type == ClickType.SHIFT_LEFT) {
-                        new DEUAnimationController(def, false, AnimationRegistry.isLooping(def.key())).start(swordPlayer);
+                        new WorldAnimationController(def, AnimationRegistry.isLooping(def.key())).start(swordPlayer);
                     }
                 }
             ));
@@ -302,7 +303,7 @@ public class AnimationBrowserMenu extends Menu {
                         ? Component.text("ON", NamedTextColor.GREEN, TextDecoration.BOLD)
                         : Component.text("OFF", NamedTextColor.RED)),
                 Component.empty(),
-                Component.text("Left-click        » play (no camera)", NamedTextColor.DARK_GRAY),
+                Component.text("Left-click        » play in world", NamedTextColor.DARK_GRAY),
                 Component.text("Right-click       » toggle loop", NamedTextColor.DARK_GRAY),
                 Component.text("Shift+Right-click » play + camera", NamedTextColor.DARK_GRAY)
             ))

--- a/src/main/java/btm/sword/system/inventory/menu/DevMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/DevMenu.java
@@ -156,6 +156,22 @@ public class DevMenu extends Menu {
             click -> new DEUBDEMenu(swordPlayer).open()
         );
 
+        SimpleItem packetTests = new SimpleItem(
+            new ItemStackBuilder(Material.COMMAND_BLOCK)
+                .name(Component.text("Packet Tests", NamedTextColor.LIGHT_PURPLE, TextDecoration.BOLD))
+                .lore(List.of(Component.text("Fake player packet test harness", NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> new PacketTestMenu(swordPlayer).open()
+        );
+
+        SimpleItem joinCutscene = new SimpleItem(
+            new ItemStackBuilder(Material.LIGHTNING_ROD)
+                .name(Component.text("Initial Join Cutscene", NamedTextColor.LIGHT_PURPLE, TextDecoration.BOLD))
+                .lore(List.of(Component.text("Play the first-time join sequence", NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> btm.sword.system.join.InitialJoinCutscene.play(swordPlayer)
+        );
+
         SimpleItem itemLibrary = new SimpleItem(
             new ItemStackBuilder(Material.BOOKSHELF)
                 .name(Component.text("Item Library", NamedTextColor.GOLD, TextDecoration.BOLD))
@@ -167,18 +183,20 @@ public class DevMenu extends Menu {
         Gui gui = Gui.normal()
             .setStructure(
                 "# # # # # # # # #",
-                "# J N S F L . C #",
-                "# . . . . . . E #",
+                "# J N S F . L C #",
+                "# P X . . . . E #",
                 "# R I . T . M W #",
                 "# # # < . > # # #")
             .addIngredient('#', BORDER)
             .addIngredient('T', toggles)
+            .addIngredient('P', packetTests)
             .addIngredient('R', reloadInventoryButtons)
             .addIngredient('J', configEditor)
             .addIngredient('N', deuTools)
             .addIngredient('S', staticScene)
             .addIngredient('F', fakePlayerScene)
             .addIngredient('L', itemLibrary)
+            .addIngredient('X', joinCutscene)
             .addIngredient('C', creativeInventory)
             .addIngredient('W', woodenAxe)
             .addIngredient('E', witherSkeletonEgg)

--- a/src/main/java/btm/sword/system/inventory/menu/PacketTestMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/PacketTestMenu.java
@@ -1,0 +1,169 @@
+package btm.sword.system.inventory.menu;
+
+import java.util.List;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.item.ItemStackBuilder;
+import btm.sword.system.scene.FakePlayerPacketTester;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import xyz.xenondevs.invui.gui.Gui;
+import xyz.xenondevs.invui.item.impl.SimpleItem;
+import xyz.xenondevs.invui.window.Window;
+
+/**
+ * Developer sub-menu with one looping test button per {@link FakePlayerPacketTester} packet type.
+ *
+ * <p>Clicking an individual test button starts a repeating loop (every 2 seconds) that
+ * sends that packet to a fake player NPC spawned 2 blocks in front of the viewer.
+ * If a loop is already running for that test, clicking it again stops it.
+ * The "Stop" button cancels any active loop and despawns the NPC immediately.</p>
+ *
+ * <p>The "Run All" button runs all six packets once in sequence and despawns the NPC
+ * when finished — useful for a quick sanity check.</p>
+ *
+ * <p>All results and stack traces are logged to the server console.</p>
+ */
+public class PacketTestMenu extends Menu {
+
+    /**
+     * Creates a new PacketTestMenu for the given player.
+     *
+     * @param player the player opening this menu
+     */
+    public PacketTestMenu(SwordPlayer player) {
+        super(player);
+    }
+
+    @Override
+    public void open() {
+        Player player = swordPlayer.player();
+        boolean looping = FakePlayerPacketTester.hasActiveLoop(swordPlayer);
+
+        SimpleItem moveRelative = loopButton(
+            Material.SLIME_BLOCK,
+            "REL_ENTITY_MOVE",
+            "Move NPC +0.5 on X axis (relative)",
+            () -> FakePlayerPacketTester.loopMoveRelative(swordPlayer)
+        );
+        SimpleItem teleport = loopButton(
+            Material.ENDER_PEARL,
+            "ENTITY_TELEPORT",
+            "Snap NPC +1 block upward (absolute)",
+            () -> FakePlayerPacketTester.loopTeleport(swordPlayer)
+        );
+        SimpleItem rotate = loopButton(
+            Material.COMPASS,
+            "ENTITY_LOOK",
+            "Rotate NPC to 90\u00b0 yaw, 20\u00b0 pitch",
+            () -> FakePlayerPacketTester.loopRotate(swordPlayer)
+        );
+        SimpleItem animate = loopButton(
+            Material.STICK,
+            "ANIMATION",
+            "Trigger main-hand swing every 2s",
+            () -> FakePlayerPacketTester.loopAnimate(swordPlayer)
+        );
+        SimpleItem velocity = loopButton(
+            Material.FEATHER,
+            "ENTITY_VELOCITY",
+            "Send upward velocity impulse every 2s",
+            () -> FakePlayerPacketTester.loopVelocity(swordPlayer)
+        );
+        SimpleItem flags = loopButton(
+            Material.SHIELD,
+            "ENTITY_DATA (flags)",
+            "Re-apply blocking pose every 2s",
+            () -> FakePlayerPacketTester.loopEntityFlags(swordPlayer)
+        );
+
+        SimpleItem stop = new SimpleItem(
+            new ItemStackBuilder(looping ? Material.BARRIER : Material.GRAY_DYE)
+                .name(looping
+                    ? Component.text("Stop Loop", NamedTextColor.RED, TextDecoration.BOLD)
+                    : Component.text("Stop Loop", NamedTextColor.DARK_GRAY))
+                .lore(List.of(Component.text(
+                    looping ? "Click to cancel the active loop" : "No loop is running",
+                    NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> {
+                FakePlayerPacketTester.stopLoop(swordPlayer);
+                swordPlayer.message(Component.text("[PacketTester] Loop stopped.", NamedTextColor.YELLOW));
+                open(); // refresh to update stop button state
+            }
+        );
+
+        SimpleItem runAll = new SimpleItem(
+            new ItemStackBuilder(Material.REDSTONE_TORCH)
+                .name(Component.text("Run All (once)", NamedTextColor.YELLOW, TextDecoration.BOLD))
+                .lore(List.of(Component.text("Send all 6 packets once, then despawn NPC", NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> {
+                boolean allPassed = FakePlayerPacketTester.runAll(swordPlayer);
+                swordPlayer.message(allPassed
+                    ? Component.text("[PacketTester] All 6 passed. See console.", NamedTextColor.GREEN)
+                    : Component.text("[PacketTester] Some tests failed. See console.", NamedTextColor.RED));
+            }
+        );
+
+        Gui gui = Gui.normal()
+            .setStructure(
+                "# # # # # # # # #",
+                "# M T R A V F . #",
+                "# # S X < # # # #")
+            .addIngredient('#', BORDER)
+            .addIngredient('M', moveRelative)
+            .addIngredient('T', teleport)
+            .addIngredient('R', rotate)
+            .addIngredient('A', animate)
+            .addIngredient('V', velocity)
+            .addIngredient('F', flags)
+            .addIngredient('S', stop)
+            .addIngredient('X', runAll)
+            .addIngredient('<', generatePreviousButtonOrDefault())
+            .build();
+
+        Window window = Window.single()
+            .setViewer(player)
+            .setTitle("Packet Tests")
+            .setGui(gui)
+            .build();
+
+        window.open();
+    }
+
+    /**
+     * Builds a loop toggle button. Clicking it starts the loop if none is active,
+     * or stops the current loop (regardless of which test is running) if one is active.
+     *
+     * @param icon    the item material used as the button icon
+     * @param label   short packet/test name shown in the item name and result message
+     * @param desc    one-line description of what the test does, shown in the lore
+     * @param startFn the action to run to start this test's loop
+     * @return a ready-to-use {@link SimpleItem}
+     */
+    private SimpleItem loopButton(Material icon, String label, String desc, Runnable startFn) {
+        return new SimpleItem(
+            new ItemStackBuilder(icon)
+                .name(Component.text(label, NamedTextColor.YELLOW, TextDecoration.BOLD))
+                .lore(List.of(Component.text(desc, NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> {
+                if (FakePlayerPacketTester.hasActiveLoop(swordPlayer)) {
+                    FakePlayerPacketTester.stopLoop(swordPlayer);
+                    swordPlayer.message(Component.text(
+                        "[PacketTester] Loop stopped.", NamedTextColor.YELLOW));
+                } else {
+                    startFn.run();
+                    swordPlayer.message(Component.text(
+                        "[PacketTester] Loop started: " + label, NamedTextColor.GREEN));
+                }
+                open(); // refresh stop button state
+            }
+        );
+    }
+}

--- a/src/main/java/btm/sword/system/item/material/MaterialType.java
+++ b/src/main/java/btm/sword/system/item/material/MaterialType.java
@@ -28,7 +28,7 @@ public enum MaterialType {
     METAL_SCRAP(
         "metal_scrap",
         "Metal Scrap",
-        Material.ANCIENT_DEBRIS,
+        Material.NETHERITE_SCRAP,
         List.of(
             Component.text("A fragment of ancient alloy.", Config.SwordColor.TEXT_ITEM_BASE)
                 .decoration(TextDecoration.ITALIC, false),

--- a/src/main/java/btm/sword/system/join/InitialJoinCutscene.java
+++ b/src/main/java/btm/sword/system/join/InitialJoinCutscene.java
@@ -6,7 +6,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
-import org.bukkit.util.Vector;
 
 import btm.sword.config.Config;
 import btm.sword.system.control.SwordScheduler;
@@ -55,7 +54,7 @@ public final class InitialJoinCutscene {
             return;
         }
 
-        player.teleport(openingLoc.clone().add(new Vector(0.5, 0, 0.5)));
+        player.teleport(openingLoc);
 
         AnimationDef def = resolveAnimation(sp);
 
@@ -86,6 +85,7 @@ public final class InitialJoinCutscene {
             if (!player.isOnline()) return;
             CameraSystem.stopController(sp);
             complete(sp);
+            player.teleport(openingLoc);
         });
     }
 
@@ -143,7 +143,7 @@ public final class InitialJoinCutscene {
     static Location openingLocation() {
         World world = Bukkit.getWorld(Config.JoinSequence.WORLD);
         if (world == null && !Bukkit.getWorlds().isEmpty()) {
-            world = Bukkit.getWorlds().get(0);
+            world = Bukkit.getWorlds().getFirst();
         }
         if (world == null) return null;
         return new Location(

--- a/src/main/java/btm/sword/system/join/InitialJoinCutscene.java
+++ b/src/main/java/btm/sword/system/join/InitialJoinCutscene.java
@@ -1,0 +1,158 @@
+package btm.sword.system.join;
+
+import java.util.concurrent.TimeUnit;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
+
+import btm.sword.config.Config;
+import btm.sword.system.control.SwordScheduler;
+import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.playerdata.PlayerData;
+import btm.sword.system.playerdata.PlayerDataManager;
+import btm.sword.system.scene.CameraSystem;
+import btm.sword.system.scene.DEUAnimationController;
+import btm.sword.system.scene.SceneManager;
+import btm.sword.system.scene.animation.AnimationDef;
+import btm.sword.system.scene.animation.AnimationRegistry;
+
+/**
+ * Orchestrates the first-time player intro cutscene.
+ *
+ * <p>Sequence:</p>
+ * <p><b>Phase 1</b> — Player teleports to the opening location; the opening animation plays
+ * (looping, camera attached) for {@link Config.JoinSequence#PHASE1_DURATION_MS} ms.</p>
+ * <p><b>Phase 2</b> — A lightning-effect strikes the opening location; the animation plays
+ * again for {@link Config.JoinSequence#PHASE2_DURATION_MS} ms.</p>
+ * <p><b>Phase 3</b> — The animation stops; a fake player NPC (real skin and equipment) spawns
+ * at the opening location and the static camera locks onto it for
+ * {@link Config.JoinSequence#PHASE3_DURATION_MS} ms.</p>
+ * <p><b>Complete</b> — The scene exits, the NPC despawns, the player lands at the opening
+ * location, and {@link PlayerData#setJoinSequenceCompleted} is called.</p>
+ *
+ * <p>All durations and coordinates are hot-reloadable via {@code join_sequence} config keys.</p>
+ */
+public final class InitialJoinCutscene {
+
+    private InitialJoinCutscene() {}
+
+    /**
+     * Starts the intro cutscene for the given player.
+     *
+     * <p>The player is immediately teleported from their staging slot to the opening location.
+     * All subsequent steps are scheduled on the main thread.</p>
+     *
+     * @param sp the player entering the game for the first time
+     */
+    public static void play(SwordPlayer sp) {
+        Player player = sp.player();
+        Location openingLoc = openingLocation();
+        if (openingLoc == null) {
+            complete(sp);
+            return;
+        }
+
+        player.teleport(openingLoc.clone().add(new Vector(0.5, 0, 0.5)));
+
+        AnimationDef def = resolveAnimation(sp);
+
+        // Phase 1: play opening animation
+        startAnimation(sp, def);
+
+        SwordScheduler.after(Config.JoinSequence.PHASE1_DURATION_MS, TimeUnit.MILLISECONDS, () -> {
+            if (!player.isOnline()) return;
+            CameraSystem.stopController(sp);
+
+            // Phase 2: lightning strike + second animation pass
+            World world = openingLoc.getWorld();
+            if (world != null) {
+                world.strikeLightningEffect(openingLoc);
+            }
+            startAnimation(sp, def);
+
+        }).andThen(Config.JoinSequence.PHASE2_DURATION_MS, TimeUnit.MILLISECONDS, () -> {
+            if (!player.isOnline()) return;
+            CameraSystem.stopController(sp);
+
+            // Phase 3: fake player NPC + static camera
+            // Player is at openingLoc — NPC spawns there; on scene exit
+            // MenuSceneController.onStop teleports the player back to openingLoc.
+            SceneManager.enterStaticMenuScene(sp, openingLoc);
+
+        }).andThen(Config.JoinSequence.PHASE3_DURATION_MS, TimeUnit.MILLISECONDS, () -> {
+            if (!player.isOnline()) return;
+            CameraSystem.stopController(sp);
+            complete(sp);
+        });
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    /**
+     * Marks the join sequence as completed for this player.
+     *
+     * @param sp the player to mark complete
+     */
+    private static void complete(SwordPlayer sp) {
+        PlayerData data = PlayerDataManager.getPlayerData(sp.player().getUniqueId());
+        if (data != null) {
+            data.setJoinSequenceCompleted(true);
+        }
+    }
+
+    /**
+     * Starts the opening animation on the player with camera attached and looping enabled
+     * so it plays continuously until explicitly stopped. No-op if {@code def} is null.
+     *
+     * @param sp  the player
+     * @param def the animation definition, or null to skip
+     */
+    private static void startAnimation(SwordPlayer sp, AnimationDef def) {
+        if (def == null) return;
+        new DEUAnimationController(def, true, true).start(sp);
+    }
+
+    /**
+     * Resolves the opening animation definition from the registry.
+     * Sends the player a warning message if the configured key is not registered.
+     *
+     * @param sp the player (used for warning delivery only)
+     * @return the animation def, or null if not found
+     */
+    private static AnimationDef resolveAnimation(SwordPlayer sp) {
+        String key = Config.JoinSequence.OPENING_ANIMATION_KEY;
+        AnimationDef def = AnimationRegistry.get(key).orElse(null);
+        if (def == null) {
+            sp.player().sendMessage("[JoinCutscene] Opening animation not found: " + key);
+        }
+        return def;
+    }
+
+    /**
+     * Builds the opening-sequence {@link Location} from config.
+     * Falls back to the first loaded world if the configured world name is not found.
+     * Returns null if no world is available.
+     *
+     * @return the opening location, or null
+     */
+    static Location openingLocation() {
+        World world = Bukkit.getWorld(Config.JoinSequence.WORLD);
+        if (world == null && !Bukkit.getWorlds().isEmpty()) {
+            world = Bukkit.getWorlds().get(0);
+        }
+        if (world == null) return null;
+        return new Location(
+            world,
+            Config.JoinSequence.OPENING_X,
+            Config.JoinSequence.OPENING_Y,
+            Config.JoinSequence.OPENING_Z,
+            Config.JoinSequence.OPENING_YAW,
+            0.0f
+        );
+    }
+}

--- a/src/main/java/btm/sword/system/join/MenuSlotGrid.java
+++ b/src/main/java/btm/sword/system/join/MenuSlotGrid.java
@@ -1,0 +1,165 @@
+package btm.sword.system.join;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+
+import btm.sword.config.Config;
+
+/**
+ * Manages a matrix of off-screen "staging slots" used during the server join sequence.
+ * <p>
+ * Each slot is a fixed position in a configured world. When a player joins, they are
+ * teleported to the best available slot and held there (invisible, zero velocity) while
+ * the menu scene loads. The slot is released when the player leaves or enters gameplay.
+ * </p>
+ *
+ * <h2>Grid layout</h2>
+ * The grid grows from {@link Config.MenuGrid#ORIGIN_X}/{@link Config.MenuGrid#ORIGIN_Z}
+ * along positive X (rows) and positive Z (columns) with configurable spacing.
+ * A single black-concrete block is placed one unit below each slot centre as a platform.
+ *
+ * <h2>Slot selection</h2>
+ * Slots closest to the grid centre are preferred (Manhattan distance), so the occupied
+ * region stays compact rather than filling from a corner.
+ */
+public final class MenuSlotGrid {
+
+    /** UUID → {row, col} for all currently occupied slots. */
+    private static final Map<UUID, int[]> OCCUPIED = new HashMap<>();
+
+    private MenuSlotGrid() {}
+
+    // =========================================================================
+    // Public API
+    // =========================================================================
+
+    /**
+     * Claims the most-central free slot for the given player.
+     * <p>
+     * Idempotent: if the player already has a slot, that slot's location is returned without
+     * acquiring a new one.
+     * </p>
+     *
+     * @param playerUuid the player who will occupy the slot
+     * @return the world location of the claimed slot centre, or empty if the grid is full
+     *         or the world cannot be resolved
+     */
+    public static Optional<Location> acquireSlot(UUID playerUuid) {
+        int[] existing = OCCUPIED.get(playerUuid);
+        if (existing != null) {
+            return Optional.ofNullable(slotCenter(existing));
+        }
+
+        int rows = Config.MenuGrid.ROWS;
+        int cols = Config.MenuGrid.COLS;
+        double centerRow = (rows - 1) / 2.0;
+        double centerCol = (cols - 1) / 2.0;
+
+        return IntStream.range(0, rows)
+            .boxed()
+            .flatMap(i -> IntStream.range(0, cols).mapToObj(j -> new int[]{i, j}))
+            .filter(rc -> !isOccupied(rc[0], rc[1]))
+            .min(Comparator.comparingDouble(rc ->
+                Math.abs(rc[0] - centerRow) + Math.abs(rc[1] - centerCol)))
+            .map(rc -> {
+                OCCUPIED.put(playerUuid, rc);
+                return slotCenter(rc);
+            });
+    }
+
+    /**
+     * Returns the location of the slot currently held by this player, or empty if they
+     * have no slot.
+     *
+     * @param playerUuid the player to look up
+     * @return the slot's world location, or empty if no slot is held
+     */
+    public static Optional<Location> getSlot(UUID playerUuid) {
+        int[] rc = OCCUPIED.get(playerUuid);
+        if (rc == null) return Optional.empty();
+        return Optional.ofNullable(slotCenter(rc));
+    }
+
+    /**
+     * Releases the slot held by the given player. No-op if the player has no slot.
+     *
+     * @param playerUuid the player whose slot to free
+     */
+    public static void releaseSlot(UUID playerUuid) {
+        OCCUPIED.remove(playerUuid);
+    }
+
+    /**
+     * Releases all occupied slots. Call on plugin disable.
+     */
+    public static void releaseAll() {
+        OCCUPIED.clear();
+    }
+
+    /**
+     * Places a single black-concrete platform block one unit below each slot centre in the
+     * configured world. No-op if the world cannot be resolved.
+     * <p>
+     * Safe to call on plugin enable — worlds are loaded before {@code onEnable()} on Paper.
+     * </p>
+     */
+    public static void placeAllBlocks() {
+        World world = resolveWorld();
+        if (world == null) return;
+
+        int rows = Config.MenuGrid.ROWS;
+        int cols = Config.MenuGrid.COLS;
+        for (int i = 0; i < rows; i++) {
+            for (int j = 0; j < cols; j++) {
+                Location floor = slotCenter(new int[]{i, j});
+                if (floor == null) return;
+                floor.clone().add(0, -1, 0).getBlock().setType(Material.BLACK_CONCRETE);
+            }
+        }
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private static boolean isOccupied(int row, int col) {
+        for (int[] rc : OCCUPIED.values()) {
+            if (rc[0] == row && rc[1] == col) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Computes the world-space centre of a grid slot.
+     *
+     * @param rc {row, col} indices
+     * @return the location, or {@code null} if the world cannot be resolved
+     */
+    static Location slotCenter(int[] rc) {
+        World world = resolveWorld();
+        if (world == null) return null;
+        return new Location(
+            world,
+            Config.MenuGrid.ORIGIN_X + rc[0] * Config.MenuGrid.SPACING_X,
+            Config.MenuGrid.ORIGIN_Y,
+            Config.MenuGrid.ORIGIN_Z + rc[1] * Config.MenuGrid.SPACING_Z
+        );
+    }
+
+    private static World resolveWorld() {
+        World world = Bukkit.getWorld(Config.MenuGrid.WORLD);
+        if (world == null && !Bukkit.getWorlds().isEmpty()) {
+            world = Bukkit.getWorlds().get(0);
+        }
+        return world;
+    }
+}

--- a/src/main/java/btm/sword/system/join/MenuSlotGrid.java
+++ b/src/main/java/btm/sword/system/join/MenuSlotGrid.java
@@ -9,7 +9,6 @@ import java.util.stream.IntStream;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.World;
 
 import btm.sword.config.Config;
@@ -113,18 +112,21 @@ public final class MenuSlotGrid {
      * </p>
      */
     public static void placeAllBlocks() {
-        World world = resolveWorld();
-        if (world == null) return;
+        // TODO: will it be better to build them on world load?
+        //  I've already built some manually
 
-        int rows = Config.MenuGrid.ROWS;
-        int cols = Config.MenuGrid.COLS;
-        for (int i = 0; i < rows; i++) {
-            for (int j = 0; j < cols; j++) {
-                Location floor = slotCenter(new int[]{i, j});
-                if (floor == null) return;
-                floor.clone().add(0, -1, 0).getBlock().setType(Material.BLACK_CONCRETE);
-            }
-        }
+//        World world = resolveWorld();
+//        if (world == null) return;
+//
+//        int rows = Config.MenuGrid.ROWS;
+//        int cols = Config.MenuGrid.COLS;
+//        for (int i = 0; i < rows; i++) {
+//            for (int j = 0; j < cols; j++) {
+//                Location floor = slotCenter(new int[]{i, j});
+//                if (floor == null) return;
+//                floor.clone().add(0, -1, 0).getBlock().setType(Material.BLACK_CONCRETE);
+//            }
+//        }
     }
 
     // =========================================================================
@@ -158,7 +160,7 @@ public final class MenuSlotGrid {
     private static World resolveWorld() {
         World world = Bukkit.getWorld(Config.MenuGrid.WORLD);
         if (world == null && !Bukkit.getWorlds().isEmpty()) {
-            world = Bukkit.getWorlds().get(0);
+            world = Bukkit.getWorlds().getFirst();
         }
         return world;
     }

--- a/src/main/java/btm/sword/system/join/ServerJoinArbiter.java
+++ b/src/main/java/btm/sword/system/join/ServerJoinArbiter.java
@@ -32,11 +32,12 @@ import btm.sword.system.scene.SceneManager;
  * <ol>
  *   <li><b>Register</b> — player is registered with {@link SwordEntityArbiter} and
  *       {@link PlayerDataManager}.</li>
- *   <li><b>Stage</b> (deferred 100 ms) — claim a {@link MenuSlotGrid} slot, teleport the
- *       player there, set them invisible and zero their velocity. This hides the player
- *       body in an off-screen staging area while the scene loads.</li>
- *   <li><b>Route</b> (deferred 100 ms after staging) — check the player's
- *       {@link PlayerData#isJoinSequenceCompleted()} flag and send them to either:
+ *   <li><b>Stage</b> (deferred 1 tick) — claim a {@link MenuSlotGrid} dark-room slot,
+ *       teleport the player there, set them invisible and zero their velocity. The player
+ *       waits here while the client loads chunks and terrain.</li>
+ *   <li><b>Route</b> (deferred {@link Config.MenuGrid#LOADING_WAIT_MS} after staging) —
+ *       check the player's {@link PlayerData#isJoinSequenceCompleted()} flag and send them
+ *       to either:
  *       <ul>
  *         <li>the initial join sequence (first-time players), or</li>
  *         <li>the main menu / character selection scene (returning players).</li>
@@ -50,11 +51,8 @@ import btm.sword.system.scene.SceneManager;
  */
 public final class ServerJoinArbiter implements Listener {
 
-    /** Time (ms) after join before staging the player on a grid slot. */
-    private static final int STAGE_DELAY_MS = 100;
-
-    /** Additional time (ms) after staging before routing to a scene or cutscene. */
-    private static final int ROUTE_DELAY_MS = 100;
+    /** Time (ms) after join before staging the player in their dark-room slot. */
+    private static final int STAGE_DELAY_MS = 50;
 
     /**
      * Registers the player with core systems, then defers the staging + routing sequence.
@@ -98,8 +96,9 @@ public final class ServerJoinArbiter implements Listener {
     // =========================================================================
 
     /**
-     * Teleports the player to their assigned grid slot, makes them invisible, and
-     * zeroes their velocity; then schedules the routing step.
+     * Teleports the player into their assigned dark-room staging slot, makes them invisible,
+     * and zeroes their velocity. Then waits {@link Config.MenuGrid#LOADING_WAIT_MS} for the
+     * client to finish loading before routing to the join sequence.
      */
     private static void stagePlayer(Player player, UUID uuid) {
         Optional<Location> slot = MenuSlotGrid.acquireSlot(uuid);
@@ -115,7 +114,7 @@ public final class ServerJoinArbiter implements Listener {
             if (!player.isOnline()) return;
             SwordPlayer sp = (SwordPlayer) SwordEntityArbiter.getOrAdd(player);
             routePlayer(sp);
-        }, ROUTE_DELAY_MS, TimeUnit.MILLISECONDS);
+        }, Config.MenuGrid.LOADING_WAIT_MS, TimeUnit.MILLISECONDS);
     }
 
     /**

--- a/src/main/java/btm/sword/system/join/ServerJoinArbiter.java
+++ b/src/main/java/btm/sword/system/join/ServerJoinArbiter.java
@@ -4,8 +4,10 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -14,6 +16,7 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.util.Vector;
 
+import btm.sword.config.Config;
 import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.impl.SwordPlayer;
@@ -118,30 +121,51 @@ public final class ServerJoinArbiter implements Listener {
     /**
      * Routes the player based on their join-sequence completion flag.
      * <ul>
-     *   <li>{@code joinSequenceCompleted == false} → initial join sequence</li>
-     *   <li>{@code joinSequenceCompleted == true}  → main menu character scene</li>
+     *   <li>{@code joinSequenceCompleted == false} → {@link InitialJoinCutscene}</li>
+     *   <li>{@code joinSequenceCompleted == true}  → spawnpoint → main menu scene</li>
      * </ul>
      */
     private static void routePlayer(SwordPlayer sp) {
         PlayerData data = PlayerDataManager.getPlayerData(sp.player().getUniqueId());
         if (data == null || !data.isJoinSequenceCompleted()) {
-            enterInitialJoinSequence(sp);
+            InitialJoinCutscene.play(sp);
+        } else {
+            enterMainMenuScene(sp);
+        }
+    }
+
+    /**
+     * Teleports a returning player to the configured spawnpoint and opens the main menu
+     * character scene at that position.
+     *
+     * @param sp the returning player
+     */
+    private static void enterMainMenuScene(SwordPlayer sp) {
+        Location spawnpoint = spawnpointLocation();
+        if (spawnpoint != null) {
+            SceneManager.enterStaticMenuScene(sp, spawnpoint);
         } else {
             SceneManager.enterStaticMenuScene(sp);
         }
     }
 
     /**
-     * Entry point for first-time (or incomplete) join sequences.
-     * <p>
-     * Currently falls through to the main menu scene as a placeholder. Replace with
-     * the initial cutscene controller once it is built (see issue #253).
-     * </p>
-     *
-     * @param sp the player to route
+     * Builds the returning-player spawnpoint {@link Location} from config.
+     * Returns {@code null} if the configured world cannot be resolved.
      */
-    private static void enterInitialJoinSequence(SwordPlayer sp) {
-        // TODO: #253 - Replace with initial join cutscene once it is implemented
-        SceneManager.enterStaticMenuScene(sp);
+    private static Location spawnpointLocation() {
+        World world = Bukkit.getWorld(Config.JoinSequence.WORLD);
+        if (world == null && !Bukkit.getWorlds().isEmpty()) {
+            world = Bukkit.getWorlds().get(0);
+        }
+        if (world == null) return null;
+        return new Location(
+            world,
+            Config.JoinSequence.SPAWNPOINT_X,
+            Config.JoinSequence.SPAWNPOINT_Y,
+            Config.JoinSequence.SPAWNPOINT_Z,
+            Config.JoinSequence.SPAWNPOINT_YAW,
+            0.0f
+        );
     }
 }

--- a/src/main/java/btm/sword/system/join/ServerJoinArbiter.java
+++ b/src/main/java/btm/sword/system/join/ServerJoinArbiter.java
@@ -1,0 +1,147 @@
+package btm.sword.system.join;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.util.Vector;
+
+import btm.sword.system.control.SwordScheduler;
+import btm.sword.system.entity.SwordEntityArbiter;
+import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.playerdata.PlayerData;
+import btm.sword.system.playerdata.PlayerDataManager;
+import btm.sword.system.scene.CameraSystem;
+import btm.sword.system.scene.SceneManager;
+
+/**
+ * Manages the full server-join lifecycle for each player.
+ *
+ * <h2>Join pipeline</h2>
+ * <ol>
+ *   <li><b>Register</b> — player is registered with {@link SwordEntityArbiter} and
+ *       {@link PlayerDataManager}.</li>
+ *   <li><b>Stage</b> (deferred 100 ms) — claim a {@link MenuSlotGrid} slot, teleport the
+ *       player there, set them invisible and zero their velocity. This hides the player
+ *       body in an off-screen staging area while the scene loads.</li>
+ *   <li><b>Route</b> (deferred 100 ms after staging) — check the player's
+ *       {@link PlayerData#isJoinSequenceCompleted()} flag and send them to either:
+ *       <ul>
+ *         <li>the initial join sequence (first-time players), or</li>
+ *         <li>the main menu / character selection scene (returning players).</li>
+ *       </ul>
+ *   </li>
+ * </ol>
+ *
+ * <h2>Quit pipeline</h2>
+ * On disconnect the player's grid slot is released, any active camera controller is
+ * stopped, and the {@link SwordPlayer} is cleaned up and removed from the arbiter.
+ */
+public final class ServerJoinArbiter implements Listener {
+
+    /** Time (ms) after join before staging the player on a grid slot. */
+    private static final int STAGE_DELAY_MS = 100;
+
+    /** Additional time (ms) after staging before routing to a scene or cutscene. */
+    private static final int ROUTE_DELAY_MS = 100;
+
+    /**
+     * Registers the player with core systems, then defers the staging + routing sequence.
+     *
+     * @param event the join event
+     */
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        UUID uuid = player.getUniqueId();
+
+        SwordEntityArbiter.register(player);
+        PlayerDataManager.register(player);
+
+        SwordScheduler.runBukkitTaskLater(() -> {
+            if (!player.isOnline()) return;
+            stagePlayer(player, uuid);
+        }, STAGE_DELAY_MS, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Releases the player's grid slot, stops any active camera controller, and cleans up
+     * the {@link SwordPlayer} instance.
+     *
+     * @param event the quit event
+     */
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        Player player = event.getPlayer();
+        MenuSlotGrid.releaseSlot(player.getUniqueId());
+
+        if (SwordEntityArbiter.get(player) instanceof SwordPlayer sp) {
+            CameraSystem.stopController(sp);
+            sp.onLeave();
+            SwordEntityArbiter.remove(player);
+        }
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    /**
+     * Teleports the player to their assigned grid slot, makes them invisible, and
+     * zeroes their velocity; then schedules the routing step.
+     */
+    private static void stagePlayer(Player player, UUID uuid) {
+        Optional<Location> slot = MenuSlotGrid.acquireSlot(uuid);
+        if (slot.isPresent()) {
+            player.teleport(slot.get());
+        }
+
+        player.setGameMode(GameMode.SURVIVAL);
+        player.setInvisible(true);
+        player.setVelocity(new Vector(0, 0, 0));
+
+        SwordScheduler.runBukkitTaskLater(() -> {
+            if (!player.isOnline()) return;
+            SwordPlayer sp = (SwordPlayer) SwordEntityArbiter.getOrAdd(player);
+            routePlayer(sp);
+        }, ROUTE_DELAY_MS, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Routes the player based on their join-sequence completion flag.
+     * <ul>
+     *   <li>{@code joinSequenceCompleted == false} → initial join sequence</li>
+     *   <li>{@code joinSequenceCompleted == true}  → main menu character scene</li>
+     * </ul>
+     */
+    private static void routePlayer(SwordPlayer sp) {
+        PlayerData data = PlayerDataManager.getPlayerData(sp.player().getUniqueId());
+        if (data == null || !data.isJoinSequenceCompleted()) {
+            enterInitialJoinSequence(sp);
+        } else {
+            SceneManager.enterStaticMenuScene(sp);
+        }
+    }
+
+    /**
+     * Entry point for first-time (or incomplete) join sequences.
+     * <p>
+     * Currently falls through to the main menu scene as a placeholder. Replace with
+     * the initial cutscene controller once it is built (see issue #253).
+     * </p>
+     *
+     * @param sp the player to route
+     */
+    private static void enterInitialJoinSequence(SwordPlayer sp) {
+        // TODO: #253 - Replace with initial join cutscene once it is implemented
+        SceneManager.enterStaticMenuScene(sp);
+    }
+}

--- a/src/main/java/btm/sword/system/playerdata/PlayerData.java
+++ b/src/main/java/btm/sword/system/playerdata/PlayerData.java
@@ -5,12 +5,22 @@ import java.util.UUID;
 
 import btm.sword.system.entity.base.CombatProfile;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 public class PlayerData {
     private final UUID uuid;
     private final Date dateOfFirstLogin;
     private final CombatProfile combatProfile;
+
+    /**
+     * Whether this player has completed the initial join sequence (intro cutscene + first setup).
+     * When {@code false}, the server-join pipeline routes them to the intro cutscene instead of
+     * the main menu character scene.
+     */
+    @Getter
+    @Setter
+    private boolean joinSequenceCompleted = false;
 
     public PlayerData(UUID uuid) {
         this.uuid = uuid;

--- a/src/main/java/btm/sword/system/scene/FakeAnimation.java
+++ b/src/main/java/btm/sword/system/scene/FakeAnimation.java
@@ -1,0 +1,32 @@
+package btm.sword.system.scene;
+
+/**
+ * Animation IDs for {@link FakePlayerManager#animateFake}.
+ * Maps to the raw protocol animation byte in {@code ClientboundAnimatePacket}.
+ */
+public enum FakeAnimation {
+
+    /** Swing the entity's main hand. */
+    SWING_MAIN_HAND(0),
+
+    /** Play the hurt/take-damage flinch. */
+    TAKE_DAMAGE(1),
+
+    /** Swing the entity's offhand. */
+    SWING_OFF_HAND(3);
+
+    private final int id;
+
+    FakeAnimation(int id) {
+        this.id = id;
+    }
+
+    /**
+     * Returns the raw protocol animation ID sent in the ANIMATION packet.
+     *
+     * @return protocol animation byte value
+     */
+    public int getId() {
+        return id;
+    }
+}

--- a/src/main/java/btm/sword/system/scene/FakePlayerManager.java
+++ b/src/main/java/btm/sword/system/scene/FakePlayerManager.java
@@ -10,8 +10,10 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
@@ -153,6 +155,358 @@ public final class FakePlayerManager {
         ProtocolManager manager = ProtocolLibrary.getProtocolManager();
         Player player = viewer.player();
         sendEquipment(manager, player, data.entityId(), player.getEquipment());
+    }
+
+    /**
+     * Returns whether an active fake player NPC exists for the given viewer.
+     *
+     * @param viewer the player to check
+     * @return {@code true} if a fake player is currently spawned for this viewer
+     */
+    public static boolean isActive(SwordPlayer viewer) {
+        return ACTIVE.containsKey(viewer.player().getUniqueId());
+    }
+
+    /**
+     * Moves the fake player NPC by the given relative delta.
+     * Maximum supported delta per axis is approximately ±8 blocks
+     * (short fixed-point limit at 4096 units/block).
+     * For larger displacements use {@link #teleportFake} instead.
+     *
+     * @param viewer    the player whose NPC to move
+     * @param dx        X delta in blocks
+     * @param dy        Y delta in blocks
+     * @param dz        Z delta in blocks
+     * @param onGround  whether the entity is touching the ground
+     * @return {@code true} if the packet was sent without error
+     */
+    public static boolean moveRelative(SwordPlayer viewer, double dx, double dy, double dz, boolean onGround) {
+        FakePlayerData data = ACTIVE.get(viewer.player().getUniqueId());
+        if (data == null) return false;
+        if (Math.abs(dx) > 7.9 || Math.abs(dy) > 7.9 || Math.abs(dz) > 7.9) {
+            Sword.getInstance().getLogger().warning(
+                "[FakePlayerManager] moveRelative delta exceeds ±8 block limit; use teleportFake for large displacements");
+        }
+        try {
+            sendMoveRelative(ProtocolLibrary.getProtocolManager(), data.player(), data.entityId(), dx, dy, dz, onGround);
+            return true;
+        } catch (Exception e) {
+            Sword.getInstance().getLogger().log(Level.SEVERE,
+                "[FakePlayerManager] Failed to send REL_ENTITY_MOVE for " + viewer.player().getName(), e);
+            return false;
+        }
+    }
+
+    /**
+     * Teleports the fake player NPC to an absolute world position.
+     * Unlike {@link #moveRelative}, there is no distance limit;
+     * the client snaps immediately with no lerp interpolation.
+     *
+     * @param viewer   the player whose NPC to teleport
+     * @param location the destination (yaw/pitch are applied)
+     * @return {@code true} if the packet was sent without error
+     */
+    public static boolean teleportFake(SwordPlayer viewer, Location location) {
+        FakePlayerData data = ACTIVE.get(viewer.player().getUniqueId());
+        if (data == null) return false;
+        try {
+            sendTeleport(ProtocolLibrary.getProtocolManager(), data.player(), data.entityId(), location);
+            return true;
+        } catch (Exception e) {
+            Sword.getInstance().getLogger().log(Level.SEVERE,
+                "[FakePlayerManager] Failed to send ENTITY_TELEPORT for " + viewer.player().getName(), e);
+            return false;
+        }
+    }
+
+    /**
+     * Rotates the fake player NPC to face the given yaw/pitch.
+     * Sends both {@code ENTITY_LOOK} (body rotation) and {@code ENTITY_HEAD_ROTATION}
+     * (head yaw) so the head and body stay aligned.
+     *
+     * @param viewer   the player whose NPC to rotate
+     * @param yaw      yaw angle in degrees (0 = south, 90 = west, 180/−180 = north, −90 = east)
+     * @param pitch    pitch angle in degrees (−90 = looking straight up, 90 = straight down)
+     * @param onGround whether the entity is touching the ground
+     * @return {@code true} if both packets were sent without error
+     */
+    public static boolean rotateFake(SwordPlayer viewer, float yaw, float pitch, boolean onGround) {
+        FakePlayerData data = ACTIVE.get(viewer.player().getUniqueId());
+        if (data == null) return false;
+        try {
+            sendRotate(ProtocolLibrary.getProtocolManager(), data.player(), data.entityId(), yaw, pitch, onGround);
+            return true;
+        } catch (Exception e) {
+            Sword.getInstance().getLogger().log(Level.SEVERE,
+                "[FakePlayerManager] Failed to send ENTITY_LOOK/ENTITY_HEAD_ROTATION for " + viewer.player().getName(), e);
+            return false;
+        }
+    }
+
+    /**
+     * Plays a one-shot animation on the fake player NPC via {@code ClientboundAnimatePacket}.
+     *
+     * @param viewer    the player whose NPC to animate
+     * @param animation the animation to play
+     * @return {@code true} if the packet was sent without error
+     */
+    public static boolean animateFake(SwordPlayer viewer, FakeAnimation animation) {
+        FakePlayerData data = ACTIVE.get(viewer.player().getUniqueId());
+        if (data == null) return false;
+        try {
+            sendAnimation(ProtocolLibrary.getProtocolManager(), data.player(), data.entityId(), animation.getId());
+            return true;
+        } catch (Exception e) {
+            Sword.getInstance().getLogger().log(Level.SEVERE,
+                "[FakePlayerManager] Failed to send ANIMATION (" + animation.name() + ") for " + viewer.player().getName(), e);
+            return false;
+        }
+    }
+
+    /**
+     * Sends a velocity impulse to the fake player NPC.
+     * The client receives this as a visual impulse only; the server does not simulate
+     * ongoing physics. Follow up with position packets (e.g. {@link #moveRelative})
+     * to drive the actual trajectory each tick.
+     *
+     * <p>Units: 1/8000 of a block per tick. A value of {@code 1.0} represents 8000 units
+     * (the maximum short range). Typical jump velocity is approximately {@code 0.42}.</p>
+     *
+     * @param viewer the player whose NPC to impulse
+     * @param vx     X velocity in blocks/tick
+     * @param vy     Y velocity in blocks/tick (positive = up)
+     * @param vz     Z velocity in blocks/tick
+     * @return {@code true} if the packet was sent without error
+     */
+    public static boolean velocityFake(SwordPlayer viewer, double vx, double vy, double vz) {
+        FakePlayerData data = ACTIVE.get(viewer.player().getUniqueId());
+        if (data == null) return false;
+        try {
+            sendVelocity(ProtocolLibrary.getProtocolManager(), data.player(), data.entityId(), vx, vy, vz);
+            return true;
+        } catch (Exception e) {
+            Sword.getInstance().getLogger().log(Level.SEVERE,
+                "[FakePlayerManager] Failed to send ENTITY_VELOCITY for " + viewer.player().getName(), e);
+            return false;
+        }
+    }
+
+    // =========================================================================
+    // ProtocolLib helpers — movement, rotation, animation, velocity
+    // (private; throw on failure so public wrappers own the catch/log)
+    // =========================================================================
+
+    private static void sendMoveRelative(ProtocolManager manager, Player player, int entityId,
+            double dx, double dy, double dz, boolean onGround) throws Exception {
+        PacketContainer packet = manager.createPacket(PacketType.Play.Server.REL_ENTITY_MOVE);
+        packet.getIntegers().write(0, entityId);
+        packet.getShorts().write(0, (short) Math.round(dx * 4096));
+        packet.getShorts().write(1, (short) Math.round(dy * 4096));
+        packet.getShorts().write(2, (short) Math.round(dz * 4096));
+        packet.getBooleans().write(0, onGround);
+        manager.sendServerPacket(player, packet);
+    }
+
+    /**
+     * Builds {@code ClientboundTeleportEntityPacket} via NMS reflection.
+     * <p>
+     * In Paper 1.21.8, {@code ClientboundTeleportEntityPacket} stores position/rotation
+     * inside a {@code PositionMoveRotation} record, so ProtocolLib's {@code getIntegers()}
+     * and {@code getDoubles()} modifiers return empty — the same class-layout issue seen
+     * with player-info and entity-data packets. We bypass the ProtocolLib modifier entirely.
+     * </p>
+     * <p>
+     * NMS path: {@code ClientboundTeleportEntityPacket(int id, PositionMoveRotation change,
+     * Set<Relative> relatives, boolean onGround)}.
+     * An empty {@code relatives} set means all coordinates are absolute (not relative deltas).
+     * </p>
+     */
+    private static void sendTeleport(ProtocolManager manager, Player player, int entityId,
+            Location location) throws Exception {
+        // Vec3(x, y, z) — position
+        Class<?> vec3Class = Class.forName("net.minecraft.world.phys.Vec3");
+        Constructor<?> vec3Ctor = vec3Class.getDeclaredConstructor(double.class, double.class, double.class);
+        Object position = vec3Ctor.newInstance(location.getX(), location.getY(), location.getZ());
+        Object zeroDelta = vec3Ctor.newInstance(0.0, 0.0, 0.0);
+
+        // PositionMoveRotation(Vec3 position, Vec3 delta, float yRot, float xRot)
+        // yRot = yaw, xRot = pitch (NMS naming convention)
+        Class<?> pmrClass = Class.forName("net.minecraft.world.entity.PositionMoveRotation");
+        Constructor<?> pmrCtor = pmrClass.getDeclaredConstructor(vec3Class, vec3Class, float.class, float.class);
+        pmrCtor.setAccessible(true);
+        Object pmr = pmrCtor.newInstance(position, zeroDelta, location.getYaw(), location.getPitch());
+
+        // ClientboundTeleportEntityPacket(int id, PositionMoveRotation change, Set<Relative> relatives, boolean onGround)
+        // Empty relatives set = all axes are absolute
+        Class<?> packetClass = Class.forName(
+            "net.minecraft.network.protocol.game.ClientboundTeleportEntityPacket");
+        Constructor<?> packetCtor = packetClass.getDeclaredConstructor(int.class, pmrClass, Set.class, boolean.class);
+        packetCtor.setAccessible(true);
+        Object nmsPacket = packetCtor.newInstance(entityId, pmr, Set.of(), false);
+
+        manager.sendServerPacket(player, PacketContainer.fromPacket(nmsPacket));
+    }
+
+    private static void sendRotate(ProtocolManager manager, Player player, int entityId,
+            float yaw, float pitch, boolean onGround) throws Exception {
+        // Body rotation
+        PacketContainer lookPacket = manager.createPacket(PacketType.Play.Server.ENTITY_LOOK);
+        lookPacket.getIntegers().write(0, entityId);
+        lookPacket.getBytes().write(0, angleToByte(yaw));
+        lookPacket.getBytes().write(1, angleToByte(pitch));
+        lookPacket.getBooleans().write(0, onGround);
+        manager.sendServerPacket(player, lookPacket);
+        // Head yaw — must match body yaw or the head twists independently of the body
+        PacketContainer headPacket = manager.createPacket(PacketType.Play.Server.ENTITY_HEAD_ROTATION);
+        headPacket.getIntegers().write(0, entityId);
+        headPacket.getBytes().write(0, angleToByte(yaw));
+        manager.sendServerPacket(player, headPacket);
+    }
+
+    private static void sendAnimation(ProtocolManager manager, Player player, int entityId,
+            int animationId) throws Exception {
+        PacketContainer packet = manager.createPacket(PacketType.Play.Server.ANIMATION);
+        packet.getIntegers().write(0, entityId);
+        packet.getIntegers().write(1, animationId);
+        manager.sendServerPacket(player, packet);
+    }
+
+    /**
+     * Builds {@code ClientboundSetEntityMotionPacket} via NMS reflection.
+     * <p>
+     * In Paper 1.21.8, {@code ClientboundSetEntityMotionPacket} stores velocity components
+     * as fields derived from a {@code Vec3}, so ProtocolLib's {@code getIntegers()} and
+     * {@code getShorts()} modifiers return empty. We bypass ProtocolLib's modifier entirely.
+     * </p>
+     * <p>
+     * NMS path: {@code ClientboundSetEntityMotionPacket(int id, Vec3 velocity)}.
+     * The constructor clamps each axis to ±3.9 blocks/tick and converts to the wire
+     * format (multiply by 8000, cast to int).
+     * </p>
+     */
+    private static void sendVelocity(ProtocolManager manager, Player player, int entityId,
+            double vx, double vy, double vz) throws Exception {
+        // Vec3(x, y, z) — velocity in blocks/tick
+        Class<?> vec3Class = Class.forName("net.minecraft.world.phys.Vec3");
+        Constructor<?> vec3Ctor = vec3Class.getDeclaredConstructor(double.class, double.class, double.class);
+        Object velocityVec = vec3Ctor.newInstance(vx, vy, vz);
+
+        // ClientboundSetEntityMotionPacket(int id, Vec3 velocity)
+        Class<?> packetClass = Class.forName(
+            "net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket");
+        Constructor<?> packetCtor = packetClass.getDeclaredConstructor(int.class, vec3Class);
+        packetCtor.setAccessible(true);
+        Object nmsPacket = packetCtor.newInstance(entityId, velocityVec);
+
+        manager.sendServerPacket(player, PacketContainer.fromPacket(nmsPacket));
+    }
+
+    /**
+     * Sets the {@code LIVING_ENTITY_FLAGS} metadata byte (index 8) on the fake player,
+     * controlling item-use pose, active hand selection, and riptide spin state.
+     *
+     * <p><b>Shield requirement for blocking:</b> setting {@code handActive = true} only renders
+     * the blocking animation if the active hand's equipped item is a shield. Equip one first via
+     * {@link #setEquipmentSlot(SwordPlayer, EnumWrappers.ItemSlot, ItemStack)} before calling
+     * this method.</p>
+     *
+     * <p>Flag semantics:</p>
+     * <ul>
+     *   <li><b>handActive</b> ({@code 0x01}) — marks the entity as actively using an item.
+     *       When the held item is a shield this produces the blocking stance; with other items
+     *       it raises the selected hand into the use-item pose.</li>
+     *   <li><b>offhand</b> ({@code 0x02}) — selects which hand the active flag applies to.
+     *       {@code false} = main hand, {@code true} = offhand. Only meaningful when
+     *       {@code handActive} is {@code true}.</li>
+     *   <li><b>riptide</b> ({@code 0x04}) — plays the trident riptide arm-raise and spin pose.
+     *       Independent of the other two flags; can be set alone without {@code handActive}.</li>
+     * </ul>
+     *
+     * <p>Pass all {@code false} to clear any active pose and return the NPC to idle stance.</p>
+     *
+     * <p>Implemented via {@code ClientboundSetEntityDataPacket} with a single
+     * {@code SynchedEntityData$DataValue} at index 8, using the NMS {@code BYTE} serializer —
+     * the same reflection strategy used by {@link #spawnFakePlayer} for skin parts.</p>
+     *
+     * @param viewer     the player whose NPC to update
+     * @param handActive {@code true} to enter item-use / blocking stance
+     * @param offhand    {@code true} to apply the active flag to the offhand instead of the main hand
+     * @param riptide    {@code true} to play the riptide trident raise/spin pose
+     * @return {@code true} if the metadata packet was sent without error
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static boolean setEntityFlags(SwordPlayer viewer, boolean handActive, boolean offhand, boolean riptide) {
+        FakePlayerData data = ACTIVE.get(viewer.player().getUniqueId());
+        if (data == null) return false;
+        byte flags = (byte) ((handActive ? 0x01 : 0) | (offhand ? 0x02 : 0) | (riptide ? 0x04 : 0));
+        try {
+            sendEntityFlags(data.player(), data.entityId(), flags);
+            return true;
+        } catch (Exception e) {
+            Sword.getInstance().getLogger().log(Level.SEVERE,
+                "[FakePlayerManager] Failed to send ENTITY_DATA (living entity flags) for "
+                    + viewer.player().getName(), e);
+            return false;
+        }
+    }
+
+    /**
+     * Sends a single-slot {@code ENTITY_EQUIPMENT} packet to update one equipment slot on the
+     * fake player NPC. Use this to equip items (e.g. a shield before calling
+     * {@link #setEntityFlags}) without replacing the full equipment set.
+     *
+     * <p>Does nothing if no NPC is active for the viewer.</p>
+     *
+     * @param viewer the player whose NPC to update
+     * @param slot   the equipment slot to update (MAINHAND, OFFHAND, HEAD, CHEST, LEGS, FEET)
+     * @param item   the item to place in the slot; {@code null} is treated as air
+     * @return {@code true} if the packet was sent without error
+     */
+    public static boolean setEquipmentSlot(SwordPlayer viewer, EnumWrappers.ItemSlot slot, ItemStack item) {
+        FakePlayerData data = ACTIVE.get(viewer.player().getUniqueId());
+        if (data == null) return false;
+        try {
+            ProtocolManager manager = ProtocolLibrary.getProtocolManager();
+            PacketContainer packet = manager.createPacket(PacketType.Play.Server.ENTITY_EQUIPMENT);
+            packet.getIntegers().write(0, data.entityId());
+            packet.getSlotStackPairLists().write(0,
+                Collections.singletonList(new Pair<>(slot, orAir(item))));
+            manager.sendServerPacket(data.player(), packet);
+            return true;
+        } catch (Exception e) {
+            Sword.getInstance().getLogger().log(Level.SEVERE,
+                "[FakePlayerManager] Failed to send ENTITY_EQUIPMENT (single slot) for "
+                    + viewer.player().getName(), e);
+            return false;
+        }
+    }
+
+    /**
+     * Builds and sends {@code ClientboundSetEntityDataPacket} with the {@code LIVING_ENTITY_FLAGS}
+     * byte at metadata index 8. Throws on any reflection or send failure so the public wrapper
+     * can log with a full stack trace.
+     */
+    private static void sendEntityFlags(Player player, int entityId, byte flags) throws Exception {
+        Class<?> serializersClass = Class.forName("net.minecraft.network.syncher.EntityDataSerializers");
+        Class<?> serializerClass = Class.forName("net.minecraft.network.syncher.EntityDataSerializer");
+        Field byteField = serializersClass.getDeclaredField("BYTE");
+        byteField.setAccessible(true);
+        Object byteSerializer = byteField.get(null);
+
+        // SynchedEntityData$DataValue(index, serializer, value)
+        Class<?> dataValueClass = Class.forName("net.minecraft.network.syncher.SynchedEntityData$DataValue");
+        Constructor<?> dataValueCtor = dataValueClass.getDeclaredConstructor(int.class, serializerClass, Object.class);
+        dataValueCtor.setAccessible(true);
+        Object dataValue = dataValueCtor.newInstance(8, byteSerializer, flags);
+
+        Class<?> packetClass = Class.forName(
+            "net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket");
+        Constructor<?> packetCtor = packetClass.getDeclaredConstructor(int.class, List.class);
+        packetCtor.setAccessible(true);
+        Object nmsPacket = packetCtor.newInstance(entityId, List.of(dataValue));
+
+        ProtocolLibrary.getProtocolManager()
+            .sendServerPacket(player, PacketContainer.fromPacket(nmsPacket));
     }
 
     /**

--- a/src/main/java/btm/sword/system/scene/FakePlayerPacketTester.java
+++ b/src/main/java/btm/sword/system/scene/FakePlayerPacketTester.java
@@ -1,0 +1,278 @@
+package btm.sword.system.scene;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+import com.comphenix.protocol.wrappers.EnumWrappers;
+
+import btm.sword.Sword;
+import btm.sword.system.entity.impl.SwordPlayer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+/**
+ * In-game packet test harness for {@link FakePlayerManager}.
+ *
+ * <h2>Looping tests</h2>
+ * <p>Each {@code loop*} method starts a repeating task (every 2 seconds) that sends its
+ * specific packet to the active fake player NPC. The NPC is spawned once on the first
+ * iteration and kept alive between iterations. If a packet call returns {@code false},
+ * the loop cancels itself and messages the viewer.</p>
+ *
+ * <p>Only one loop can be active per player at a time. Starting a new loop cancels the
+ * previous one. Call {@link #stopLoop} to stop manually and despawn the NPC.</p>
+ *
+ * <h2>Run All</h2>
+ * <p>{@link #runAll} is a single-shot batch: spawns, sends each packet once, despawns.
+ * Use it to quickly check all six types without looping.</p>
+ *
+ * <h2>Console output</h2>
+ * <p>All results (PASS / FAIL) are logged. Failures include a full stack trace via
+ * {@link Logger#log(Level, String, Throwable)}.</p>
+ */
+public final class FakePlayerPacketTester {
+
+    private FakePlayerPacketTester() {}
+
+    /** Repeating tasks keyed by the viewer's UUID. At most one active per player. */
+    private static final Map<UUID, BukkitTask> ACTIVE_LOOPS = new HashMap<>();
+
+    /** Repeat interval for looping tests, in server ticks (20 ticks = 1 second). */
+    private static final long LOOP_INTERVAL_TICKS = 40L;
+
+    // =========================================================================
+    // Public loop API
+    // =========================================================================
+
+    /**
+     * Starts a looping test for {@code REL_ENTITY_MOVE}: moves the NPC +0.5 blocks on the
+     * X axis every {@value #LOOP_INTERVAL_TICKS} ticks. Cancels any previously active loop.
+     *
+     * @param viewer the player to run the test against
+     */
+    public static void loopMoveRelative(SwordPlayer viewer) {
+        startLoop(viewer, "REL_ENTITY_MOVE",
+            () -> FakePlayerManager.moveRelative(viewer, 0.5, 0.0, 0.0, true));
+    }
+
+    /**
+     * Starts a looping test for {@code ENTITY_TELEPORT}: snaps the NPC +1 block upward
+     * from its spawn position every {@value #LOOP_INTERVAL_TICKS} ticks.
+     *
+     * @param viewer the player to run the test against
+     */
+    public static void loopTeleport(SwordPlayer viewer) {
+        Location spawn = spawnAhead(viewer);
+        Location target = spawn.clone().add(0, 1, 0);
+        startLoop(viewer, "ENTITY_TELEPORT",
+            () -> FakePlayerManager.teleportFake(viewer, target));
+    }
+
+    /**
+     * Starts a looping test for {@code ENTITY_LOOK} + {@code ENTITY_HEAD_ROTATION}: rotates
+     * the NPC to 90° yaw, 20° pitch every {@value #LOOP_INTERVAL_TICKS} ticks.
+     *
+     * @param viewer the player to run the test against
+     */
+    public static void loopRotate(SwordPlayer viewer) {
+        startLoop(viewer, "ENTITY_LOOK + ENTITY_HEAD_ROTATION",
+            () -> FakePlayerManager.rotateFake(viewer, 90.0f, 20.0f, true));
+    }
+
+    /**
+     * Starts a looping test for {@code ANIMATION}: triggers a main-hand swing on the NPC
+     * every {@value #LOOP_INTERVAL_TICKS} ticks.
+     *
+     * @param viewer the player to run the test against
+     */
+    public static void loopAnimate(SwordPlayer viewer) {
+        startLoop(viewer, "ANIMATION (SWING_MAIN_HAND)",
+            () -> FakePlayerManager.animateFake(viewer, FakeAnimation.SWING_MAIN_HAND));
+    }
+
+    /**
+     * Starts a looping test for {@code ENTITY_VELOCITY}: sends an upward impulse (~jump
+     * strength) every {@value #LOOP_INTERVAL_TICKS} ticks.
+     *
+     * @param viewer the player to run the test against
+     */
+    public static void loopVelocity(SwordPlayer viewer) {
+        startLoop(viewer, "ENTITY_VELOCITY",
+            () -> FakePlayerManager.velocityFake(viewer, 0.0, 0.42, 0.0));
+    }
+
+    /**
+     * Starts a looping test for {@code ENTITY_DATA} living-entity flags: equips a shield in the
+     * NPC's main hand, then sets the hand-active bit (blocking pose), every
+     * {@value #LOOP_INTERVAL_TICKS} ticks.
+     *
+     * <p>The shield equipment packet is sent on each iteration because the NPC may be
+     * re-spawned mid-loop with no equipment. Sending it every cycle is harmless.</p>
+     *
+     * @param viewer the player to run the test against
+     */
+    public static void loopEntityFlags(SwordPlayer viewer) {
+        startLoop(viewer, "ENTITY_DATA (living entity flags — blocking)", () -> {
+            FakePlayerManager.setEquipmentSlot(
+                viewer, EnumWrappers.ItemSlot.MAINHAND, new ItemStack(Material.SHIELD));
+            return FakePlayerManager.setEntityFlags(viewer, true, false, false);
+        });
+    }
+
+    /**
+     * Cancels the active loop for the given viewer and despawns the NPC.
+     * Does nothing if no loop is running.
+     *
+     * @param viewer the player whose loop to stop
+     */
+    public static void stopLoop(SwordPlayer viewer) {
+        BukkitTask task = ACTIVE_LOOPS.remove(viewer.player().getUniqueId());
+        if (task != null) {
+            task.cancel();
+            FakePlayerManager.despawnFakePlayer(viewer);
+        }
+    }
+
+    /**
+     * Returns whether a loop is currently active for the given viewer.
+     *
+     * @param viewer the player to check
+     * @return {@code true} if a loop task is running
+     */
+    public static boolean hasActiveLoop(SwordPlayer viewer) {
+        return ACTIVE_LOOPS.containsKey(viewer.player().getUniqueId());
+    }
+
+    // =========================================================================
+    // Run All (single-shot)
+    // =========================================================================
+
+    /**
+     * Single-shot batch test: spawns a fresh NPC, sends each of the six packet types once,
+     * then despawns. Results and stack traces are logged to the server console.
+     *
+     * @param viewer the player to run tests against
+     * @return {@code true} if every packet was sent without error
+     */
+    public static boolean runAll(SwordPlayer viewer) {
+        Logger log = log();
+        log.info("[PacketTester] === Running all fake player packet tests ===");
+        FakePlayerManager.spawnFakePlayer(viewer, spawnAhead(viewer));
+
+        int passed = 0;
+        if (run(log, "REL_ENTITY_MOVE",
+            () -> assertSent(FakePlayerManager.moveRelative(viewer, 0.5, 0.0, 0.0, true)))) passed++;
+        if (run(log, "ENTITY_TELEPORT",
+            () -> assertSent(FakePlayerManager.teleportFake(viewer, spawnAhead(viewer).add(0, 1, 0))))) passed++;
+        if (run(log, "ENTITY_LOOK + ENTITY_HEAD_ROTATION",
+            () -> assertSent(FakePlayerManager.rotateFake(viewer, 90.0f, 20.0f, true)))) passed++;
+        if (run(log, "ANIMATION (SWING_MAIN_HAND)",
+            () -> assertSent(FakePlayerManager.animateFake(viewer, FakeAnimation.SWING_MAIN_HAND)))) passed++;
+        if (run(log, "ENTITY_VELOCITY",
+            () -> assertSent(FakePlayerManager.velocityFake(viewer, 0.0, 0.42, 0.0)))) passed++;
+        if (run(log, "ENTITY_DATA (living entity flags — blocking)", () -> {
+            assertSent(FakePlayerManager.setEquipmentSlot(
+                viewer, EnumWrappers.ItemSlot.MAINHAND, new ItemStack(Material.SHIELD)));
+            assertSent(FakePlayerManager.setEntityFlags(viewer, true, false, false));
+        })) passed++;
+
+        FakePlayerManager.despawnFakePlayer(viewer);
+        log.info("[PacketTester] === Results: " + passed + "/6 passed ===");
+        return passed == 6;
+    }
+
+    // =========================================================================
+    // Internal helpers
+    // =========================================================================
+
+    /**
+     * Starts (or replaces) a looping task for the given viewer.
+     *
+     * <p>The NPC is spawned once on the first tick if not already active, then kept alive
+     * between iterations. On failure, the loop cancels, the NPC is despawned, and the
+     * viewer is messaged.</p>
+     *
+     * @param viewer  the player to loop against
+     * @param label   short packet name logged on each iteration
+     * @param packetFn the packet send operation; returns {@code true} on success
+     */
+    private static void startLoop(SwordPlayer viewer, String label, BooleanPacketOp packetFn) {
+        // Cancel any existing loop first (does not despawn — new loop takes over the NPC)
+        BukkitTask existing = ACTIVE_LOOPS.remove(viewer.player().getUniqueId());
+        if (existing != null) existing.cancel();
+
+        UUID uuid = viewer.player().getUniqueId();
+        Logger log = log();
+
+        BukkitTask task = new BukkitRunnable() {
+            @Override
+            public void run() {
+                // Spawn NPC on first iteration or if it was externally despawned
+                if (!FakePlayerManager.isActive(viewer)) {
+                    FakePlayerManager.spawnFakePlayer(viewer, spawnAhead(viewer));
+                }
+
+                boolean passed = FakePlayerPacketTester.run(log, label, () -> assertSent(packetFn.send()));
+                if (!passed) {
+                    ACTIVE_LOOPS.remove(uuid);
+                    FakePlayerManager.despawnFakePlayer(viewer);
+                    viewer.message(Component.text(
+                        "[PacketTester] Loop stopped — " + label + " failed. See console.",
+                        NamedTextColor.RED));
+                    cancel();
+                }
+            }
+        }.runTaskTimer(Sword.getInstance(), 0L, LOOP_INTERVAL_TICKS);
+
+        ACTIVE_LOOPS.put(uuid, task);
+    }
+
+    /** Returns a location 2 blocks horizontally in front of the viewer. */
+    private static Location spawnAhead(SwordPlayer viewer) {
+        Location loc = viewer.player().getLocation();
+        return loc.clone().add(loc.getDirection().setY(0).normalize().multiply(2));
+    }
+
+    private static Logger log() {
+        return Sword.getInstance().getLogger();
+    }
+
+    /**
+     * Runs a named test action, logging PASS or FAIL (with full stack trace) to the console.
+     *
+     * @return {@code true} if the action completed without throwing
+     */
+    private static boolean run(Logger log, String label, Runnable action) {
+        try {
+            action.run();
+            log.info("[PacketTester] PASS: " + label);
+            return true;
+        } catch (Exception e) {
+            log.log(Level.SEVERE, "[PacketTester] FAIL: " + label, e);
+            return false;
+        }
+    }
+
+    /** Throws {@link IllegalStateException} if the packet method returned {@code false}. */
+    private static void assertSent(boolean result) {
+        if (!result) {
+            throw new IllegalStateException(
+                "Packet method returned false — check the SEVERE log above for the root cause");
+        }
+    }
+
+    /** Functional interface for a packet-send operation that returns a success flag. */
+    @FunctionalInterface
+    private interface BooleanPacketOp {
+        boolean send();
+    }
+}

--- a/src/main/java/btm/sword/system/scene/WorldAnimationController.java
+++ b/src/main/java/btm/sword/system/scene/WorldAnimationController.java
@@ -1,0 +1,97 @@
+package btm.sword.system.scene;
+
+import btm.sword.Sword;
+import btm.sword.system.scene.animation.AnimationDef;
+import net.donnypz.displayentityutils.events.GroupSpawnedEvent;
+import net.donnypz.displayentityutils.managers.DisplayAnimationManager;
+import net.donnypz.displayentityutils.managers.DisplayGroupManager;
+import net.donnypz.displayentityutils.managers.LoadMethod;
+import net.donnypz.displayentityutils.utils.DisplayEntities.DisplayAnimator;
+import net.donnypz.displayentityutils.utils.DisplayEntities.DisplayEntityGroup;
+import net.donnypz.displayentityutils.utils.DisplayEntities.SpawnedDisplayAnimation;
+import net.donnypz.displayentityutils.utils.DisplayEntities.SpawnedDisplayEntityGroup;
+
+/**
+ * Plays a DEU/BDEngine animation as world entities at the owner's location.
+ * <p>
+ * Unlike {@link DEUAnimationController}, this controller does not attach a camera,
+ * lock the player's movement, or modify the activation context in any way.
+ * The animation group is spawned as real server-side entities, visible to all players.
+ * </p>
+ *
+ * <p>The standard Stop button ({@link CameraSystem#stopController}) still works because
+ * this controller extends {@link CameraController} — ownership is tracked normally.</p>
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * AnimationDef def = AnimationRegistry.get("my_anim").orElseThrow();
+ * new WorldAnimationController(def, true).start(player);
+ * }</pre>
+ */
+public class WorldAnimationController extends CameraController {
+
+    private final AnimationDef def;
+    private final boolean loop;
+
+    private SpawnedDisplayEntityGroup spawnedGroup;
+    private DisplayAnimator animator;
+
+    /**
+     * Creates a new world animation controller.
+     *
+     * @param def  the animation definition to play
+     * @param loop if {@code true}, the animation loops; otherwise it plays once
+     */
+    public WorldAnimationController(AnimationDef def, boolean loop) {
+        this.def = def;
+        this.loop = loop;
+    }
+
+    @Override
+    protected void onStart() {
+        DisplayEntityGroup group = DisplayGroupManager.getGroup(LoadMethod.LOCAL, def.groupTag());
+        if (group == null) {
+            Sword.getInstance().getLogger().warning(
+                "[WorldAnimationController] Group not found: " + def.groupTag() + " — stopping controller."
+            );
+            stop();
+            return;
+        }
+
+        SpawnedDisplayAnimation animation = DisplayAnimationManager.getSpawnedDisplayAnimation(
+            def.animTag(), LoadMethod.LOCAL
+        );
+        if (animation == null) {
+            Sword.getInstance().getLogger().warning(
+                "[WorldAnimationController] Animation not found: " + def.animTag() + " — stopping controller."
+            );
+            stop();
+            return;
+        }
+
+        spawnedGroup = group.spawn(owner.player().getLocation(), GroupSpawnedEvent.SpawnReason.CUSTOM);
+
+        DisplayAnimator.AnimationType animType = loop
+            ? DisplayAnimator.AnimationType.LOOP
+            : DisplayAnimator.AnimationType.LINEAR;
+
+        animator = DisplayAnimator.play(spawnedGroup, animation, animType);
+    }
+
+    @Override
+    protected void onStop() {
+        if (animator != null) {
+            animator.stop(spawnedGroup);
+            animator = null;
+        }
+        if (spawnedGroup != null) {
+            spawnedGroup.unregister(true, true);
+            spawnedGroup = null;
+        }
+    }
+
+    @Override
+    protected void onTick() {
+        // No-op — DEU manages the animation loop internally.
+    }
+}

--- a/src/main/java/btm/sword/utility/display/DisplayUtil.java
+++ b/src/main/java/btm/sword/utility/display/DisplayUtil.java
@@ -198,7 +198,6 @@ public class DisplayUtil {
         Vector offset = Config.Direction.UP().multiply(heightOffset);
 
         itemDisplay.setBillboard(Config.Display.ITEM_DISPLAY_FOLLOW_BILLBOARD_MODE);
-        entity.self().addPassenger(itemDisplay);
 
         AtomicInteger iteration = new AtomicInteger(0);
         return TimeArbiter.runTimeBoundBukkitTaskOnTimer(
@@ -215,7 +214,6 @@ public class DisplayUtil {
                     2,
                     DisplayUtil.class, 214
                 );
-                entity.self().addPassenger(itemDisplay); // important line
 
                 if (iteration.incrementAndGet() % Config.Display.ITEM_DISPLAY_FOLLOW_PARTICLE_INTERVAL == 0)
                     Prefab.Particles.BLEED.display(l);

--- a/src/main/resources/animations.yml
+++ b/src/main/resources/animations.yml
@@ -15,3 +15,7 @@ animations:
     anims:
       gentle_v2_default:
         loop: true
+  witha:
+    anims:
+      witha_default:
+        loop: true

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -378,6 +378,7 @@ hostile:
   display_anim_melee: "melee"
   mob_throw_weight: 0.3
   mob_retrieve_pickup_range: 2.0
+  display_teleport_duration: 3
 
 
 umbral:

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -376,6 +376,8 @@ hostile:
   display_anim_walk: "walk"
   display_anim_fall: "fall"
   display_anim_melee: "melee"
+  mob_throw_weight: 0.3
+  mob_retrieve_pickup_range: 2.0
 
 
 umbral:

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -398,3 +398,12 @@ scene:
 animation:
   static_menu_animation_key: gentle_v2_default
   conversion_step_timeout_seconds: 360
+menu_grid:
+  world: world
+  origin_x: 0.0
+  origin_y: 200.0
+  origin_z: 0.0
+  rows: 5
+  cols: 10
+  spacing_x: 5.0
+  spacing_z: 5.0

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -370,6 +370,12 @@ hostile:
   pre_attack_ticks: 24
   retreat_ticks: 40
   flee_health_fraction: 0.2
+  display_group: "witha"
+  display_ride_offset_y: 0.0
+  display_anim_idle: "idle"
+  display_anim_walk: "walk"
+  display_anim_fall: "fall"
+  display_anim_melee: "melee"
 
 
 umbral:
@@ -399,17 +405,7 @@ menu_grid:
   spacing_z: 21.0
   rows: 11
   cols: 11
+  loading_wait_ms: 1500
 join_sequence:
-  world: world
-  spawnpoint_x: -132.0
-  spawnpoint_y: 215.0
-  spawnpoint_z: -783.0
-  spawnpoint_yaw: 0.0
-  opening_x: -186.0
-  opening_y: 256.0
-  opening_z: -1058.0
-  opening_yaw: 0.0
-  opening_animation_key: slash_test_default
-  phase1_duration_ms: 5000
-  phase2_duration_ms: 2000
-  phase3_duration_ms: 5000
+  opening_x: -186.5
+  opening_z: -1058.5

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -388,22 +388,28 @@ menu:
     umbralblade: STONE_SWORD
 scene:
   scene_on_every_join: true
-  safe_anchor_world: world
-  safe_anchor_x: 0.0
-  safe_anchor_y: 500.0
-  safe_anchor_z: 0.0
-  camera_distance: 3.0
-  camera_height: 1.0
-  fake_player_distance: 10.0
 animation:
   static_menu_animation_key: gentle_v2_default
   conversion_step_timeout_seconds: 360
 menu_grid:
+  origin_x: 41.0
+  origin_y: 255.0
+  origin_z: -835.0
+  spacing_x: 20.0
+  spacing_z: 21.0
+  rows: 11
+  cols: 11
+join_sequence:
   world: world
-  origin_x: 0.0
-  origin_y: 200.0
-  origin_z: 0.0
-  rows: 5
-  cols: 10
-  spacing_x: 5.0
-  spacing_z: 5.0
+  spawnpoint_x: -132.0
+  spawnpoint_y: 215.0
+  spawnpoint_z: -783.0
+  spawnpoint_yaw: 0.0
+  opening_x: -186.0
+  opening_y: 256.0
+  opening_z: -1058.0
+  opening_yaw: 0.0
+  opening_animation_key: slash_test_default
+  phase1_duration_ms: 5000
+  phase2_duration_ms: 2000
+  phase3_duration_ms: 5000


### PR DESCRIPTION
## Summary
- Hostile mobs now pathfind back to their lodged thrown weapon and reclaim it via `RetrieveWeaponGoal` / `RetrieveWeaponState`, wired into `HostileStateMachine` and `MobThrowAbility`
- Added `DISPLAY_TELEPORT_DURATION` config (`hostile.display_teleport_duration`, default 3) for smoother display entity interpolation in `DisplayRig`
- Expanded `FakePlayerManager` with a full packet API (relative move, teleport, rotate, animate, velocity, entity flags/equipment)
- Added `FakeAnimation` enum, `FakePlayerPacketTester` looping/batch test harness, and `PacketTestMenu` dev sub-menu for in-game packet testing
- Refined server join pipeline: `MenuSlotGrid` and `InitialJoinCutscene` adjustments

## Test plan
- Start the server and join a test world
- Spawn hostile mobs and throw your weapon at them
- Verify mobs pathfind back to lodged blade and reclaim it
- Check display entity teleport smoothness with the new config value
- Open the dev menu and test packet operations on fake players