### PR TITLE
Feat: SQLite Player Data Persistence (#164)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.34'
     compileOnly 'net.dmulloy2:ProtocolLib:5.4.0'
     compileOnly 'com.github.PZDonny.DisplayEntityUtils:api:3.4.3'
+    implementation 'org.xerial:sqlite-jdbc:3.47.1.0'
 }
 
 tasks {

--- a/src/main/java/btm/sword/Sword.java
+++ b/src/main/java/btm/sword/Sword.java
@@ -100,8 +100,7 @@ public final class Sword extends JavaPlugin {
         // Release all staging grid slots
         MenuSlotGrid.releaseAll();
 
-        // TODO: #129 - Uncomment when persistent data is ready
-        // PlayerDataManager.shutdown();
+        PlayerDataManager.shutdown();
 
         getLogger().info("~ Sword: Combat Evolved has been disabled ~");
     }

--- a/src/main/java/btm/sword/system/action/skill/container/PlayerSkillContainer.java
+++ b/src/main/java/btm/sword/system/action/skill/container/PlayerSkillContainer.java
@@ -122,4 +122,16 @@ public final class PlayerSkillContainer {
     public Map<SkillSlot, SkillId> equippedView() {
         return Map.copyOf(equipped);
     }
+
+    /**
+     * Returns all unlocked skill IDs across every skill type as a flat list.
+     * Used by the persistence layer to save the player's available skill pool.
+     *
+     * @return an unmodifiable flat list of all available (unlocked) skill IDs
+     */
+    public List<SkillId> allAvailableSkillIds() {
+        return availableSkillsMap.values().stream()
+            .flatMap(Set::stream)
+            .toList();
+    }
 }

--- a/src/main/java/btm/sword/system/entity/base/CombatProfile.java
+++ b/src/main/java/btm/sword/system/entity/base/CombatProfile.java
@@ -85,9 +85,11 @@ public class CombatProfile {
      * The maximum number of consecutive air-dodges the entity can perform
      * before landing. Reset in {@link btm.sword.system.entity.impl.Combatant#resetAirDashesPerformed()}.
      */
+    @lombok.Setter
     private int maxAirDodges;
 
-    private final PlayerSkillContainer playerSkillContainer;
+    @lombok.Setter
+    private PlayerSkillContainer playerSkillContainer;
 
     /**
      * Constructs a new {@code CombatProfile} with the default {@link SwordClassType#SWORD_THROWER}

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -108,8 +108,8 @@ public class SwordPlayer extends Combatant {
     private final SlotAnchoredItem shieldItem;
     private final SlotAnchoredItem chestplateItem;
 
-    /** Session-scoped storage for materials, credits, and auto-pickup preferences. */
-    private final PlayerStorage playerStorage = new PlayerStorage();
+    /** Economy storage for materials, credits, and auto-pickup preferences. Loaded from and saved to the database. */
+    private PlayerStorage playerStorage;
 
     private final Supplier<List<Component>> currencyLore =
         () -> List.of(Component.text(playerStorage.getSteelCredits() + " Steel Credits")
@@ -244,6 +244,7 @@ public class SwordPlayer extends Combatant {
      */
     public SwordPlayer(LivingEntity associatedEntity, PlayerData data) {
         super(associatedEntity, data.getCombatProfile());
+        playerStorage = data.getPlayerStorage();
         player = (Player) self;
         profile = player.getPlayerProfile();
         username = profile.getName();

--- a/src/main/java/btm/sword/system/join/ServerJoinArbiter.java
+++ b/src/main/java/btm/sword/system/join/ServerJoinArbiter.java
@@ -82,13 +82,19 @@ public final class ServerJoinArbiter implements Listener {
     @EventHandler(priority = EventPriority.NORMAL)
     public void onPlayerQuit(PlayerQuitEvent event) {
         Player player = event.getPlayer();
-        MenuSlotGrid.releaseSlot(player.getUniqueId());
+        UUID uuid = player.getUniqueId();
+
+        MenuSlotGrid.releaseSlot(uuid);
 
         if (SwordEntityArbiter.get(player) instanceof SwordPlayer sp) {
             CameraSystem.stopController(sp);
             sp.onLeave();
             SwordEntityArbiter.remove(player);
         }
+
+        // Persist this player's data before evicting from cache
+        PlayerDataManager.saveAsync(uuid);
+        PlayerDataManager.evict(uuid);
     }
 
     // =========================================================================

--- a/src/main/java/btm/sword/system/playerdata/PlayerData.java
+++ b/src/main/java/btm/sword/system/playerdata/PlayerData.java
@@ -7,11 +7,20 @@ import btm.sword.system.entity.base.CombatProfile;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * Persistent data container for a single player.
+ * <p>
+ * Holds all data that survives across sessions: identity fields, combat profile,
+ * economy storage, and progression flags. An instance is created fresh on first join
+ * and loaded from the database on subsequent joins.
+ * </p>
+ */
 @Getter
 public class PlayerData {
     private final UUID uuid;
     private final Date dateOfFirstLogin;
     private final CombatProfile combatProfile;
+    private final PlayerStorage playerStorage;
 
     /**
      * Whether this player has completed the initial join sequence (intro cutscene + first setup).
@@ -22,13 +31,39 @@ public class PlayerData {
     @Setter
     private boolean joinSequenceCompleted = false;
 
+    /**
+     * Constructs a new {@code PlayerData} for a first-time player.
+     * All values default to fresh/empty state.
+     *
+     * @param uuid the player's unique ID
+     */
     public PlayerData(UUID uuid) {
         this.uuid = uuid;
         dateOfFirstLogin = new Date();
         combatProfile = new CombatProfile();
-
+        playerStorage = new PlayerStorage();
     }
 
+    /**
+     * Constructs a {@code PlayerData} from data loaded out of the database.
+     * Used exclusively by the persistence layer — do not call from game logic.
+     *
+     * @param uuid                  the player's unique ID
+     * @param dateOfFirstLogin      the stored first-login timestamp
+     * @param joinSequenceCompleted the stored join-sequence completion flag
+     * @param combatProfile         the restored combat profile
+     * @param playerStorage         the restored economy storage
+     */
+    public PlayerData(UUID uuid, Date dateOfFirstLogin, boolean joinSequenceCompleted,
+            CombatProfile combatProfile, PlayerStorage playerStorage) {
+        this.uuid = uuid;
+        this.dateOfFirstLogin = dateOfFirstLogin;
+        this.joinSequenceCompleted = joinSequenceCompleted;
+        this.combatProfile = combatProfile;
+        this.playerStorage = playerStorage;
+    }
+
+    /** @return this player's unique ID (alias for {@link #getUuid()} for convenience). */
     public UUID getUniqueId() {
         return uuid;
     }

--- a/src/main/java/btm/sword/system/playerdata/PlayerDataManager.java
+++ b/src/main/java/btm/sword/system/playerdata/PlayerDataManager.java
@@ -1,79 +1,129 @@
 package btm.sword.system.playerdata;
 
 import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.util.HashMap;
+import java.sql.SQLException;
+import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
-
-import com.google.common.reflect.TypeToken;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 
 import btm.sword.Sword;
-import btm.sword.system.entity.aspect.value.AspectValue;
-import btm.sword.system.entity.aspect.value.ResourceValue;
-import btm.sword.utility.data.RuntimeTypeAdapterFactory;
+import btm.sword.system.playerdata.store.PlayerDataStore;
+import btm.sword.system.playerdata.store.SqlitePlayerDataStore;
 
+/**
+ * Manages persistent player data for all online players.
+ *
+ * <h2>Architecture</h2>
+ * An in-memory {@code Map<UUID, PlayerData>} acts as the hot cache — all in-game reads
+ * hit this map directly at zero latency. The backing {@link PlayerDataStore} (SQLite by
+ * default) is the source of truth on disk.
+ *
+ * <h2>Save strategy</h2>
+ * <ul>
+ *   <li><b>On quit</b> — async save of that player's data only (via the plugin scheduler).</li>
+ *   <li><b>Every 5 minutes</b> — async flush of all online players.</li>
+ *   <li><b>On shutdown</b> — synchronous flush of all cached data before the connection closes.</li>
+ * </ul>
+ */
 public class PlayerDataManager {
-    static RuntimeTypeAdapterFactory<AspectValue> aspectFactory = RuntimeTypeAdapterFactory
-            .of(AspectValue.class, "type")
-            .registerSubtype(AspectValue.class, "aspect")
-            .registerSubtype(ResourceValue.class, "resource");
 
-    static Gson gson = new GsonBuilder()
-            .registerTypeAdapterFactory(aspectFactory)
-            .create();
+    private static final Map<UUID, PlayerData> cache = new ConcurrentHashMap<>();
+    private static PlayerDataStore store;
 
-    private static final Map<UUID, PlayerData> allPlayerData = new HashMap<>();
-    private static final File datafile = new File("plugins/sword/playerdata.json");
-
+    /**
+     * Initialises the data manager: opens the SQLite connection, creates schema,
+     * loads any players already online, and schedules the periodic async flush.
+     */
     public static void initialize() {
-        loadPlayerData();
+        File dbFile = new File("plugins/sword/playerdata.db");
+        SqlitePlayerDataStore sqliteStore = new SqlitePlayerDataStore(dbFile, Sword.getInstance().getLogger());
+        try {
+            sqliteStore.open();
+        } catch (SQLException e) {
+            Sword.getInstance().getLogger().severe("[PlayerData] Failed to open database: " + e.getMessage());
+            // Fall through — store is still assigned so null-checks below protect callers
+        }
+        store = sqliteStore;
 
-        for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+        for (org.bukkit.entity.Player onlinePlayer : Bukkit.getOnlinePlayers()) {
             register(onlinePlayer);
         }
+
+        // Periodic async flush — every 5 minutes
+        Sword.getScheduler().scheduleAtFixedRate(
+            PlayerDataManager::flushAll, 5, 5, TimeUnit.MINUTES);
     }
 
+    /**
+     * Synchronously flushes all cached player data to disk and closes the store connection.
+     * Called once on server shutdown.
+     */
     public static void shutdown() {
-        savePlayerData();
+        if (store == null) return;
+        store.saveAll(cache.keySet(), cache);
+        store.close();
     }
 
+    /**
+     * Registers a player, loading their data from the database if it exists
+     * or creating a fresh default record for first-time players.
+     *
+     * @param entity the player entity to register
+     */
     public static void register(LivingEntity entity) {
-        allPlayerData.putIfAbsent(entity.getUniqueId(), new PlayerData(entity.getUniqueId()));
+        UUID uuid = entity.getUniqueId();
+        if (cache.containsKey(uuid)) return;
+
+        PlayerData loaded = store != null ? store.load(uuid) : null;
+        cache.put(uuid, loaded != null ? loaded : new PlayerData(uuid));
     }
 
+    /**
+     * Returns the cached {@link PlayerData} for the given UUID, or {@code null} if not loaded.
+     *
+     * @param uuid the player's unique ID
+     * @return their data, or {@code null}
+     */
     public static PlayerData getPlayerData(UUID uuid) {
-        return allPlayerData.get(uuid);
+        return cache.get(uuid);
     }
 
-    public static void savePlayerData() {
-        try (FileWriter writer = new FileWriter(datafile)) {
-            gson.toJson(allPlayerData, writer);
-        } catch (IOException e) {
-            Sword.getInstance().getLogger().info(e.getMessage());
-        }
+    /**
+     * Asynchronously saves a single player's data to the database.
+     * Call this when a player quits so their data is persisted promptly.
+     *
+     * @param uuid the player's unique ID
+     */
+    public static void saveAsync(UUID uuid) {
+        PlayerData data = cache.get(uuid);
+        if (data == null || store == null) return;
+        Sword.getScheduler().submit(() -> store.save(uuid, data));
     }
 
-    public static void loadPlayerData() {
-        if (!datafile.exists()) return;
-        try (FileReader reader = new FileReader(datafile)) {
-            Type type = new TypeToken<Map<UUID, PlayerData>>() {}.getType();
-            Map<UUID, PlayerData> loaded = gson.fromJson(reader, type);
-            if (loaded != null) {
-                allPlayerData.clear();
-                allPlayerData.putAll(loaded);
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+    /**
+     * Removes a player's data from the in-memory cache.
+     * Should be called <em>after</em> {@link #saveAsync} on player quit so the data
+     * is still available to the async save task.
+     *
+     * @param uuid the player's unique ID
+     */
+    public static void evict(UUID uuid) {
+        cache.remove(uuid);
+    }
+
+    // =========================================================================
+    // Internal helpers
+    // =========================================================================
+
+    /** Async flush of all currently cached players — called by the periodic scheduler. */
+    private static void flushAll() {
+        if (store == null || cache.isEmpty()) return;
+        Collection<UUID> snapshot = cache.keySet();
+        store.saveAll(snapshot, cache);
     }
 }

--- a/src/main/java/btm/sword/system/playerdata/PlayerStorage.java
+++ b/src/main/java/btm/sword/system/playerdata/PlayerStorage.java
@@ -33,6 +33,38 @@ public class PlayerStorage {
     @Getter
     private boolean autoPickupCredits = false;
 
+    /** Constructs a fresh {@code PlayerStorage} with default values (used for first-time players). */
+    public PlayerStorage() {}
+
+    /**
+     * Constructs a {@code PlayerStorage} pre-populated from persisted data.
+     * Used by the database layer to restore a player's saved economy state.
+     *
+     * @param steelCredits          the player's saved credit balance
+     * @param autoPickupMaterials   saved auto-pickup-materials toggle
+     * @param autoPickupCredits     saved auto-pickup-credits toggle
+     * @param materialCounts        map of saved material counts
+     */
+    public PlayerStorage(int steelCredits, boolean autoPickupMaterials, boolean autoPickupCredits,
+            Map<MaterialType, Integer> materialCounts) {
+        this.steelCredits = steelCredits;
+        this.autoPickupMaterials = autoPickupMaterials;
+        this.autoPickupCredits = autoPickupCredits;
+        this.materialCounts.putAll(materialCounts);
+    }
+
+    // ── Snapshot ───────────────────────────────────────────────────────────────
+
+    /**
+     * Returns an unmodifiable snapshot of all material counts.
+     * Used by the persistence layer to save material data without exposing the mutable map.
+     *
+     * @return a read-only view of material type to count
+     */
+    public java.util.Map<MaterialType, Integer> getMaterialCountsSnapshot() {
+        return java.util.Collections.unmodifiableMap(materialCounts);
+    }
+
     // ── Materials ──────────────────────────────────────────────────────────────
 
     /**

--- a/src/main/java/btm/sword/system/playerdata/store/PlayerDataStore.java
+++ b/src/main/java/btm/sword/system/playerdata/store/PlayerDataStore.java
@@ -1,0 +1,52 @@
+package btm.sword.system.playerdata.store;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+
+import btm.sword.system.playerdata.PlayerData;
+
+/**
+ * Backend-agnostic contract for player data persistence.
+ * <p>
+ * Implementations may back this with SQLite (local dev), MySQL (hosted), or any other
+ * JDBC-compatible store. The {@link btm.sword.system.playerdata.PlayerDataManager} depends
+ * on this interface; swapping the implementation requires no changes to calling code.
+ * </p>
+ */
+public interface PlayerDataStore {
+
+    /**
+     * Loads a single player's data from the backing store.
+     * Returns {@code null} if no record exists for the given UUID (first-time player).
+     *
+     * @param uuid the player's unique ID
+     * @return the loaded {@link PlayerData}, or {@code null} if not found
+     */
+    PlayerData load(UUID uuid);
+
+    /**
+     * Persists a single player's data to the backing store.
+     * Inserts or updates as needed (upsert semantics).
+     *
+     * @param uuid the player's unique ID
+     * @param data the current player data to persist
+     */
+    void save(UUID uuid, PlayerData data);
+
+    /**
+     * Persists data for all players in the given collection.
+     * Equivalent to calling {@link #save} for each entry; implementations may
+     * batch these writes for efficiency.
+     *
+     * @param uuids the UUIDs to save; data is retrieved from the in-memory cache
+     * @param cache the full in-memory player data map
+     */
+    void saveAll(Collection<UUID> uuids, Map<UUID, PlayerData> cache);
+
+    /**
+     * Closes any open connections or resources held by this store.
+     * Called once on server shutdown after the final flush.
+     */
+    void close();
+}

--- a/src/main/java/btm/sword/system/playerdata/store/SqlitePlayerDataStore.java
+++ b/src/main/java/btm/sword/system/playerdata/store/SqlitePlayerDataStore.java
@@ -1,0 +1,203 @@
+package btm.sword.system.playerdata.store;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import btm.sword.system.action.skill.container.PlayerSkillContainer;
+import btm.sword.system.entity.aspect.AspectType;
+import btm.sword.system.entity.aspect.value.AspectValue;
+import btm.sword.system.entity.base.CombatProfile;
+import btm.sword.system.playerdata.PlayerData;
+import btm.sword.system.playerdata.PlayerStorage;
+import btm.sword.system.playerdata.store.repository.AspectRepository;
+import btm.sword.system.playerdata.store.repository.ProfileRepository;
+import btm.sword.system.playerdata.store.repository.SkillRepository;
+import btm.sword.system.playerdata.store.repository.StorageRepository;
+
+/**
+ * SQLite-backed implementation of {@link PlayerDataStore}.
+ * <p>
+ * Uses a single JDBC connection with WAL journal mode for safe async writes.
+ * All operations are synchronous on the calling thread — callers are responsible
+ * for invoking save methods off the main server thread.
+ * </p>
+ *
+ * <p>Schema is created (and migrated) automatically on {@link #open()}.</p>
+ */
+public class SqlitePlayerDataStore implements PlayerDataStore {
+
+    private static final int CURRENT_SCHEMA_VERSION = 1;
+
+    private final File dbFile;
+    private final Logger logger;
+
+    private Connection conn;
+    private ProfileRepository profileRepo;
+    private AspectRepository aspectRepo;
+    private SkillRepository skillRepo;
+    private StorageRepository storageRepo;
+
+    /**
+     * @param dbFile the SQLite database file (created if absent)
+     * @param logger the plugin logger for error reporting
+     */
+    public SqlitePlayerDataStore(File dbFile, Logger logger) {
+        this.dbFile = dbFile;
+        this.logger = logger;
+    }
+
+    /**
+     * Opens the database connection, enables WAL mode, creates tables, and runs migrations.
+     * Must be called before any read/write operations.
+     *
+     * @throws SQLException if the connection or schema setup fails
+     */
+    public void open() throws SQLException {
+        dbFile.getParentFile().mkdirs();
+        conn = DriverManager.getConnection("jdbc:sqlite:" + dbFile.getAbsolutePath());
+
+        // Enable WAL mode for safe concurrent reads and atomic writes
+        try (PreparedStatement stmt = conn.prepareStatement("PRAGMA journal_mode=WAL")) {
+            stmt.execute();
+        }
+        // Disable auto-commit — we manage transactions explicitly per save
+        conn.setAutoCommit(true);
+
+        profileRepo = new ProfileRepository(conn);
+        aspectRepo = new AspectRepository(conn);
+        skillRepo = new SkillRepository(conn);
+        storageRepo = new StorageRepository(conn);
+
+        profileRepo.createTable();
+        aspectRepo.createTable();
+        skillRepo.createTable();
+        storageRepo.createTable();
+        createSchemaVersionTable();
+
+        runMigrations();
+    }
+
+    @Override
+    public PlayerData load(UUID uuid) {
+        try {
+            ProfileRepository.ProfileRow profile = profileRepo.load(uuid);
+            if (profile == null) return null; // first-time player
+
+            Map<AspectType, AspectValue> aspects = aspectRepo.load(uuid);
+            SkillRepository.SkillData skillData = skillRepo.load(uuid);
+            PlayerStorage storage = storageRepo.load(uuid);
+
+            CombatProfile combatProfile = new CombatProfile();
+            // Override config defaults with persisted values (unknown types keep config defaults)
+            aspects.forEach(combatProfile::setStat);
+            combatProfile.setSwordClass(profile.swordClass());
+            combatProfile.setMaxAirDodges(profile.maxAirDodges());
+
+            PlayerSkillContainer skillContainer;
+            if (skillData.equipped().isEmpty() && skillData.available().isEmpty()) {
+                // No skill data saved yet — use default container
+                skillContainer = new PlayerSkillContainer();
+            } else {
+                skillContainer = new PlayerSkillContainer(skillData.available(), skillData.equipped());
+            }
+            combatProfile.setPlayerSkillContainer(skillContainer);
+
+            return new PlayerData(uuid, profile.firstLogin(), profile.joinSequenceCompleted(),
+                combatProfile, storage);
+
+        } catch (SQLException e) {
+            logger.severe("[PlayerData] Failed to load data for " + uuid + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    public void save(UUID uuid, PlayerData data) {
+        try {
+            conn.setAutoCommit(false);
+            try {
+                CombatProfile profile = data.getCombatProfile();
+                profileRepo.save(uuid, profile.getSwordClass(), data.isJoinSequenceCompleted(),
+                    data.getDateOfFirstLogin().getTime(), profile.getMaxAirDodges());
+                aspectRepo.save(uuid, profile.getStats());
+                PlayerSkillContainer skills = profile.getPlayerSkillContainer();
+                skillRepo.save(uuid, skills.equippedView(), skills.allAvailableSkillIds());
+                storageRepo.save(uuid, data.getPlayerStorage());
+                conn.commit();
+            } catch (SQLException e) {
+                conn.rollback();
+                throw e;
+            } finally {
+                conn.setAutoCommit(true);
+            }
+        } catch (SQLException e) {
+            logger.severe("[PlayerData] Failed to save data for " + uuid + ": " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void saveAll(Collection<UUID> uuids, Map<UUID, PlayerData> cache) {
+        for (UUID uuid : uuids) {
+            PlayerData data = cache.get(uuid);
+            if (data != null) save(uuid, data);
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            if (conn != null && !conn.isClosed()) {
+                conn.close();
+            }
+        } catch (SQLException e) {
+            logger.severe("[PlayerData] Failed to close database connection: " + e.getMessage());
+        }
+    }
+
+    // =========================================================================
+    // Schema versioning
+    // =========================================================================
+
+    private void createSchemaVersionTable() throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)")) {
+            stmt.execute();
+        }
+    }
+
+    private int getSchemaVersion() throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "SELECT version FROM schema_version LIMIT 1");
+             ResultSet rs = stmt.executeQuery()) {
+            return rs.next() ? rs.getInt("version") : 0;
+        }
+    }
+
+    private void setSchemaVersion(int version) throws SQLException {
+        try (PreparedStatement del = conn.prepareStatement("DELETE FROM schema_version");
+             PreparedStatement ins = conn.prepareStatement(
+                "INSERT INTO schema_version (version) VALUES (?)")) {
+            del.execute();
+            ins.setInt(1, version);
+            ins.execute();
+        }
+    }
+
+    private void runMigrations() throws SQLException {
+        int version = getSchemaVersion();
+        if (version < CURRENT_SCHEMA_VERSION) {
+            logger.info("[PlayerData] Schema at v" + version + ", migrating to v" + CURRENT_SCHEMA_VERSION);
+            // V0 → V1: initial schema (tables already created above — nothing more to migrate)
+            setSchemaVersion(CURRENT_SCHEMA_VERSION);
+            logger.info("[PlayerData] Schema migration complete.");
+        }
+    }
+}

--- a/src/main/java/btm/sword/system/playerdata/store/repository/AspectRepository.java
+++ b/src/main/java/btm/sword/system/playerdata/store/repository/AspectRepository.java
@@ -1,0 +1,114 @@
+package btm.sword.system.playerdata.store.repository;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.UUID;
+
+import btm.sword.system.entity.aspect.AspectType;
+import btm.sword.system.entity.aspect.value.AspectValue;
+import btm.sword.system.entity.aspect.value.ResourceValue;
+
+/**
+ * Handles reads and writes for the {@code player_aspects} table.
+ * One row per {@code (player, aspect_type)} pair; stores base stat values
+ * for both {@link AspectValue} and {@link ResourceValue} instances.
+ */
+public class AspectRepository {
+
+    private final Connection conn;
+
+    /** @param conn the shared JDBC connection */
+    public AspectRepository(Connection conn) {
+        this.conn = conn;
+    }
+
+    /**
+     * Creates the {@code player_aspects} table if it does not already exist.
+     *
+     * @throws SQLException on any DB error
+     */
+    public void createTable() throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "CREATE TABLE IF NOT EXISTS player_aspects ("
+                + "uuid TEXT NOT NULL, "
+                + "aspect_type TEXT NOT NULL, "
+                + "value REAL NOT NULL, "
+                + "regen_period INTEGER, "
+                + "regen_amount REAL, "
+                + "PRIMARY KEY (uuid, aspect_type)"
+                + ")")) {
+            stmt.execute();
+        }
+    }
+
+    /**
+     * Loads all stored aspect values for the given player.
+     * Unknown or removed aspect types are silently skipped.
+     *
+     * @param uuid the player's unique ID
+     * @return a map of {@link AspectType} to its stored {@link AspectValue} (may be empty)
+     * @throws SQLException on any DB error
+     */
+    public Map<AspectType, AspectValue> load(UUID uuid) throws SQLException {
+        Map<AspectType, AspectValue> result = new EnumMap<>(AspectType.class);
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "SELECT aspect_type, value, regen_period, regen_amount FROM player_aspects WHERE uuid = ?")) {
+            stmt.setString(1, uuid.toString());
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    AspectType type;
+                    try {
+                        type = AspectType.valueOf(rs.getString("aspect_type"));
+                    } catch (IllegalArgumentException e) {
+                        continue; // aspect was removed from the game — skip
+                    }
+                    float value = rs.getFloat("value");
+                    int regenPeriod = rs.getInt("regen_period");
+                    boolean isResource = !rs.wasNull();
+                    if (isResource) {
+                        float regenAmount = rs.getFloat("regen_amount");
+                        result.put(type, new ResourceValue(value, regenPeriod, regenAmount));
+                    } else {
+                        result.put(type, new AspectValue(value));
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Upserts all provided aspect values for the given player in a single batch.
+     *
+     * @param uuid  the player's unique ID
+     * @param stats the current aspect values to persist
+     * @throws SQLException on any DB error
+     */
+    public void save(UUID uuid, Map<AspectType, AspectValue> stats) throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "INSERT INTO player_aspects (uuid, aspect_type, value, regen_period, regen_amount)"
+                + " VALUES (?, ?, ?, ?, ?)"
+                + " ON CONFLICT(uuid, aspect_type) DO UPDATE SET"
+                + " value=excluded.value, regen_period=excluded.regen_period, regen_amount=excluded.regen_amount")) {
+            for (Map.Entry<AspectType, AspectValue> entry : stats.entrySet()) {
+                stmt.setString(1, uuid.toString());
+                stmt.setString(2, entry.getKey().name());
+                stmt.setFloat(3, entry.getValue().getValue());
+                if (entry.getValue() instanceof ResourceValue rv) {
+                    stmt.setInt(4, rv.getRegenPeriod());
+                    stmt.setFloat(5, rv.getRegenAmount());
+                } else {
+                    stmt.setNull(4, Types.INTEGER);
+                    stmt.setNull(5, Types.REAL);
+                }
+                stmt.addBatch();
+            }
+            stmt.executeBatch();
+        }
+    }
+}

--- a/src/main/java/btm/sword/system/playerdata/store/repository/ProfileRepository.java
+++ b/src/main/java/btm/sword/system/playerdata/store/repository/ProfileRepository.java
@@ -1,0 +1,111 @@
+package btm.sword.system.playerdata.store.repository;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Date;
+import java.util.UUID;
+
+import btm.sword.system.playerdata.SwordClassType;
+
+/**
+ * Handles reads and writes for the {@code player_profiles} table.
+ * One row per player; stores identity and progression fields.
+ */
+public class ProfileRepository {
+
+    private final Connection conn;
+
+    /** @param conn the shared JDBC connection */
+    public ProfileRepository(Connection conn) {
+        this.conn = conn;
+    }
+
+    /**
+     * Creates the {@code player_profiles} table if it does not already exist.
+     *
+     * @throws SQLException on any DB error
+     */
+    public void createTable() throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "CREATE TABLE IF NOT EXISTS player_profiles ("
+                + "uuid TEXT PRIMARY KEY, "
+                + "sword_class TEXT NOT NULL DEFAULT 'SWORD_THROWER', "
+                + "join_sequence_completed INTEGER NOT NULL DEFAULT 0, "
+                + "first_login INTEGER NOT NULL, "
+                + "max_air_dodges INTEGER NOT NULL DEFAULT 2"
+                + ")")) {
+            stmt.execute();
+        }
+    }
+
+    /**
+     * Loads profile data for the given player.
+     * Returns {@code null} if no row exists.
+     *
+     * @param uuid the player's unique ID
+     * @return a {@link ProfileRow} with the stored data, or {@code null}
+     * @throws SQLException on any DB error
+     */
+    public ProfileRow load(UUID uuid) throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "SELECT sword_class, join_sequence_completed, first_login, max_air_dodges"
+                + " FROM player_profiles WHERE uuid = ?")) {
+            stmt.setString(1, uuid.toString());
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (!rs.next()) return null;
+                SwordClassType swordClass;
+                try {
+                    swordClass = SwordClassType.valueOf(rs.getString("sword_class"));
+                } catch (IllegalArgumentException e) {
+                    swordClass = SwordClassType.SWORD_THROWER;
+                }
+                boolean joinDone = rs.getInt("join_sequence_completed") == 1;
+                Date firstLogin = new Date(rs.getLong("first_login"));
+                int maxAirDodges = rs.getInt("max_air_dodges");
+                return new ProfileRow(swordClass, joinDone, firstLogin, maxAirDodges);
+            }
+        }
+    }
+
+    /**
+     * Upserts profile data for the given player.
+     * Inserts a new row or updates existing fields (excluding {@code first_login}).
+     *
+     * @param uuid                  the player's unique ID
+     * @param swordClass            the player's combat class
+     * @param joinSequenceCompleted whether the player has completed the intro cutscene
+     * @param firstLoginMs          the first-login timestamp in epoch millis
+     * @param maxAirDodges          the player's air-dodge cap
+     * @throws SQLException on any DB error
+     */
+    public void save(UUID uuid, SwordClassType swordClass, boolean joinSequenceCompleted,
+            long firstLoginMs, int maxAirDodges) throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "INSERT INTO player_profiles (uuid, sword_class, join_sequence_completed, first_login, max_air_dodges)"
+                + " VALUES (?, ?, ?, ?, ?)"
+                + " ON CONFLICT(uuid) DO UPDATE SET"
+                + " sword_class=excluded.sword_class,"
+                + " join_sequence_completed=excluded.join_sequence_completed,"
+                + " max_air_dodges=excluded.max_air_dodges")) {
+            stmt.setString(1, uuid.toString());
+            stmt.setString(2, swordClass.name());
+            stmt.setInt(3, joinSequenceCompleted ? 1 : 0);
+            stmt.setLong(4, firstLoginMs);
+            stmt.setInt(5, maxAirDodges);
+            stmt.execute();
+        }
+    }
+
+    /**
+     * Raw data loaded from {@code player_profiles}.
+     *
+     * @param swordClass            the stored combat class
+     * @param joinSequenceCompleted the stored intro-cutscene completion flag
+     * @param firstLogin            the stored first-login timestamp
+     * @param maxAirDodges          the stored air-dodge cap
+     */
+    public record ProfileRow(SwordClassType swordClass, boolean joinSequenceCompleted,
+            Date firstLogin, int maxAirDodges) {}
+}

--- a/src/main/java/btm/sword/system/playerdata/store/repository/SkillRepository.java
+++ b/src/main/java/btm/sword/system/playerdata/store/repository/SkillRepository.java
@@ -1,0 +1,154 @@
+package btm.sword.system.playerdata.store.repository;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import btm.sword.system.action.skill.Skill;
+import btm.sword.system.action.skill.SkillId;
+import btm.sword.system.action.skill.SkillRegistry;
+import btm.sword.system.action.skill.container.SkillSlot;
+
+/**
+ * Handles reads and writes for the {@code player_skill_slots} and
+ * {@code player_available_skills} tables.
+ * <p>
+ * Equipped slots are stored as one row per {@code (uuid, slot)} pair.
+ * Available (unlocked) skills are stored as one row per {@code (uuid, skill_id)} pair.
+ * </p>
+ */
+public class SkillRepository {
+
+    private final Connection conn;
+
+    /** @param conn the shared JDBC connection */
+    public SkillRepository(Connection conn) {
+        this.conn = conn;
+    }
+
+    /**
+     * Creates both skill tables if they do not already exist.
+     *
+     * @throws SQLException on any DB error
+     */
+    public void createTable() throws SQLException {
+        try (PreparedStatement s1 = conn.prepareStatement(
+                "CREATE TABLE IF NOT EXISTS player_skill_slots ("
+                + "uuid TEXT NOT NULL, slot TEXT NOT NULL, skill_id TEXT NOT NULL,"
+                + " PRIMARY KEY (uuid, slot))");
+             PreparedStatement s2 = conn.prepareStatement(
+                "CREATE TABLE IF NOT EXISTS player_available_skills ("
+                + "uuid TEXT NOT NULL, skill_id TEXT NOT NULL,"
+                + " PRIMARY KEY (uuid, skill_id))")) {
+            s1.execute();
+            s2.execute();
+        }
+    }
+
+    /**
+     * Loads the equipped-slot map and available-skill list for the given player.
+     *
+     * @param uuid the player's unique ID
+     * @return a {@link SkillData} containing both equipped and available skill sets
+     * @throws SQLException on any DB error
+     */
+    public SkillData load(UUID uuid) throws SQLException {
+        EnumMap<SkillSlot, SkillId> equipped = new EnumMap<>(SkillSlot.class);
+        List<SkillId> available = new ArrayList<>();
+
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "SELECT slot, skill_id FROM player_skill_slots WHERE uuid = ?")) {
+            stmt.setString(1, uuid.toString());
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    try {
+                        SkillSlot slot = SkillSlot.valueOf(rs.getString("slot"));
+                        SkillId id = SkillId.parse(rs.getString("skill_id"));
+                        equipped.put(slot, id);
+                    } catch (IllegalArgumentException e) {
+                        // Removed slot or invalid id — skip
+                    }
+                }
+            }
+        }
+
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "SELECT skill_id FROM player_available_skills WHERE uuid = ?")) {
+            stmt.setString(1, uuid.toString());
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    try {
+                        available.add(SkillId.parse(rs.getString("skill_id")));
+                    } catch (IllegalArgumentException e) {
+                        // Invalid id — skip
+                    }
+                }
+            }
+        }
+
+        return new SkillData(available, equipped);
+    }
+
+    /**
+     * Replaces all skill data for the given player.
+     * Deletes existing rows and re-inserts the provided data.
+     *
+     * @param uuid      the player's unique ID
+     * @param equipped  the current equipped-slot map
+     * @param available the current available (unlocked) skill list
+     * @throws SQLException on any DB error
+     */
+    public void save(UUID uuid, Map<SkillSlot, SkillId> equipped, List<SkillId> available)
+            throws SQLException {
+        try (PreparedStatement del1 = conn.prepareStatement(
+                "DELETE FROM player_skill_slots WHERE uuid = ?");
+             PreparedStatement del2 = conn.prepareStatement(
+                "DELETE FROM player_available_skills WHERE uuid = ?")) {
+            del1.setString(1, uuid.toString());
+            del1.execute();
+            del2.setString(1, uuid.toString());
+            del2.execute();
+        }
+
+        if (!equipped.isEmpty()) {
+            try (PreparedStatement stmt = conn.prepareStatement(
+                    "INSERT INTO player_skill_slots (uuid, slot, skill_id) VALUES (?, ?, ?)")) {
+                for (Map.Entry<SkillSlot, SkillId> entry : equipped.entrySet()) {
+                    stmt.setString(1, uuid.toString());
+                    stmt.setString(2, entry.getKey().name());
+                    stmt.setString(3, entry.getValue().asString());
+                    stmt.addBatch();
+                }
+                stmt.executeBatch();
+            }
+        }
+
+        if (!available.isEmpty()) {
+            try (PreparedStatement stmt = conn.prepareStatement(
+                    "INSERT INTO player_available_skills (uuid, skill_id) VALUES (?, ?)")) {
+                for (SkillId id : available) {
+                    Skill skill = SkillRegistry.get(id);
+                    if (skill == null) continue; // skill was removed from game — don't persist
+                    stmt.setString(1, uuid.toString());
+                    stmt.setString(2, id.asString());
+                    stmt.addBatch();
+                }
+                stmt.executeBatch();
+            }
+        }
+    }
+
+    /**
+     * Raw skill data loaded from the database.
+     *
+     * @param available the list of all unlocked skill IDs
+     * @param equipped  the map of equipped skill slots to their assigned skill
+     */
+    public record SkillData(List<SkillId> available, EnumMap<SkillSlot, SkillId> equipped) {}
+}

--- a/src/main/java/btm/sword/system/playerdata/store/repository/StorageRepository.java
+++ b/src/main/java/btm/sword/system/playerdata/store/repository/StorageRepository.java
@@ -1,0 +1,142 @@
+package btm.sword.system.playerdata.store.repository;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.UUID;
+
+import btm.sword.system.item.material.MaterialType;
+import btm.sword.system.playerdata.PlayerStorage;
+
+/**
+ * Handles reads and writes for the {@code player_storage} and {@code player_materials} tables.
+ * <p>
+ * {@code player_storage} stores per-player economy scalars (credits, auto-pickup toggles).
+ * {@code player_materials} stores per-player material counts as one row per material type.
+ * </p>
+ */
+public class StorageRepository {
+
+    private final Connection conn;
+
+    /** @param conn the shared JDBC connection */
+    public StorageRepository(Connection conn) {
+        this.conn = conn;
+    }
+
+    /**
+     * Creates both storage tables if they do not already exist.
+     *
+     * @throws SQLException on any DB error
+     */
+    public void createTable() throws SQLException {
+        try (PreparedStatement s1 = conn.prepareStatement(
+                "CREATE TABLE IF NOT EXISTS player_storage ("
+                + "uuid TEXT PRIMARY KEY, "
+                + "steel_credits INTEGER NOT NULL DEFAULT 100, "
+                + "auto_pickup_materials INTEGER NOT NULL DEFAULT 0, "
+                + "auto_pickup_credits INTEGER NOT NULL DEFAULT 0)");
+             PreparedStatement s2 = conn.prepareStatement(
+                "CREATE TABLE IF NOT EXISTS player_materials ("
+                + "uuid TEXT NOT NULL, "
+                + "material_type TEXT NOT NULL, "
+                + "count INTEGER NOT NULL DEFAULT 0, "
+                + "PRIMARY KEY (uuid, material_type))")) {
+            s1.execute();
+            s2.execute();
+        }
+    }
+
+    /**
+     * Loads economy storage data for the given player.
+     * Returns a fresh default {@link PlayerStorage} if no row exists (first-time player).
+     *
+     * @param uuid the player's unique ID
+     * @return the loaded (or default) {@link PlayerStorage}
+     * @throws SQLException on any DB error
+     */
+    public PlayerStorage load(UUID uuid) throws SQLException {
+        int credits = 100;
+        boolean autoMaterials = false;
+        boolean autoCredits = false;
+
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "SELECT steel_credits, auto_pickup_materials, auto_pickup_credits"
+                + " FROM player_storage WHERE uuid = ?")) {
+            stmt.setString(1, uuid.toString());
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    credits = rs.getInt("steel_credits");
+                    autoMaterials = rs.getInt("auto_pickup_materials") == 1;
+                    autoCredits = rs.getInt("auto_pickup_credits") == 1;
+                }
+            }
+        }
+
+        Map<MaterialType, Integer> materialCounts = new EnumMap<>(MaterialType.class);
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "SELECT material_type, count FROM player_materials WHERE uuid = ?")) {
+            stmt.setString(1, uuid.toString());
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    try {
+                        MaterialType type = MaterialType.valueOf(rs.getString("material_type"));
+                        materialCounts.put(type, rs.getInt("count"));
+                    } catch (IllegalArgumentException e) {
+                        // Removed material type — skip
+                    }
+                }
+            }
+        }
+
+        return new PlayerStorage(credits, autoMaterials, autoCredits, materialCounts);
+    }
+
+    /**
+     * Upserts all economy data for the given player.
+     *
+     * @param uuid    the player's unique ID
+     * @param storage the current player storage to persist
+     * @throws SQLException on any DB error
+     */
+    public void save(UUID uuid, PlayerStorage storage) throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "INSERT INTO player_storage (uuid, steel_credits, auto_pickup_materials, auto_pickup_credits)"
+                + " VALUES (?, ?, ?, ?)"
+                + " ON CONFLICT(uuid) DO UPDATE SET"
+                + " steel_credits=excluded.steel_credits,"
+                + " auto_pickup_materials=excluded.auto_pickup_materials,"
+                + " auto_pickup_credits=excluded.auto_pickup_credits")) {
+            stmt.setString(1, uuid.toString());
+            stmt.setInt(2, storage.getSteelCredits());
+            stmt.setInt(3, storage.isAutoPickupMaterials() ? 1 : 0);
+            stmt.setInt(4, storage.isAutoPickupCredits() ? 1 : 0);
+            stmt.execute();
+        }
+
+        // Delete existing material rows and re-insert non-zero counts
+        try (PreparedStatement del = conn.prepareStatement(
+                "DELETE FROM player_materials WHERE uuid = ?")) {
+            del.setString(1, uuid.toString());
+            del.execute();
+        }
+
+        Map<MaterialType, Integer> counts = storage.getMaterialCountsSnapshot();
+        if (!counts.isEmpty()) {
+            try (PreparedStatement stmt = conn.prepareStatement(
+                    "INSERT INTO player_materials (uuid, material_type, count) VALUES (?, ?, ?)")) {
+                for (Map.Entry<MaterialType, Integer> entry : counts.entrySet()) {
+                    if (entry.getValue() <= 0) continue;
+                    stmt.setString(1, uuid.toString());
+                    stmt.setString(2, entry.getKey().name());
+                    stmt.setInt(3, entry.getValue());
+                    stmt.addBatch();
+                }
+                stmt.executeBatch();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces the disabled Gson/JSON flat-file system with an embedded SQLite database (`plugins/sword/playerdata.db`)
- Splits persistence into four domain repositories (Profile, Aspect, Skill, Storage) behind a `PlayerDataStore` interface — swap to MySQL later by implementing one class
- `PlayerStorage` (credits, materials, auto-pickup toggles) is now persisted — previously session-only and reset on every login
- Async save on quit, 5-minute periodic flush, synchronous flush on shutdown

## Test plan
- [x] Join as a new player — confirm `playerdata.db` is created and `player_profiles` row exists
- [x] Quit and rejoin — confirm intro cutscene does not replay and stats are intact
- [x] Earn credits or materials, quit, rejoin — confirm economy data persisted
- [x] Inspect DB with DB Browser for SQLite to verify all six tables are populated correctly

Closes #164
Closes #129