### PR TITLE
Feat: Clean internal APIs for scoreboard and bossbar manipulation

### DIFF
--- a/src/main/java/btm/sword/Sword.java
+++ b/src/main/java/btm/sword/Sword.java
@@ -20,6 +20,8 @@ import btm.sword.listeners.WorldListener;
 import btm.sword.listeners.packet.MovementListener;
 import btm.sword.system.action.throwing.InteractiveItemArbiter;
 import btm.sword.system.action.throwing.ProjectileManager;
+import btm.sword.system.display.BossBarManager;
+import btm.sword.system.display.ScoreboardManager;
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.inventory.InventoryMenuManager;
 import btm.sword.system.join.MenuSlotGrid;
@@ -88,6 +90,10 @@ public final class Sword extends JavaPlugin {
 
     @Override
     public void onDisable() {
+        // Clean up all active scoreboards and boss bars
+        ScoreboardManager.removeAll();
+        BossBarManager.removeAll();
+
         // Clean up all entity displays (sheathed weapons, status displays)
         SwordEntityArbiter.removeAllDisplays();
 

--- a/src/main/java/btm/sword/system/display/BossBarManager.java
+++ b/src/main/java/btm/sword/system/display/BossBarManager.java
@@ -1,0 +1,132 @@
+package btm.sword.system.display;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.bukkit.entity.Player;
+
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
+
+/**
+ * Global manager for {@link SwordBossBar} instances.
+ *
+ * <p>Tracks all active boss bars and handles lifecycle events — most importantly,
+ * removing players from all bars when they disconnect. Boss bars are registered
+ * automatically on creation and deregistered when {@link SwordBossBar#remove()} is called.</p>
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * // Persistent bar shown to multiple players
+ * SwordBossBar bar = BossBarManager.create(
+ *     Component.text("Dungeon Boss").color(NamedTextColor.RED),
+ *     1.0f,
+ *     BossBar.Color.RED,
+ *     BossBar.Overlay.PROGRESS
+ * );
+ * bar.addViewer(player1);
+ * bar.addViewer(player2);
+ * bar.setProgress(0.3f); // update during encounter
+ * bar.remove();          // clean up when done
+ *
+ * // Timed countdown bar
+ * SwordBossBar countdown = BossBarManager.createTimed(
+ *     Component.text("Round starts in 10s"),
+ *     1.0f, BossBar.Color.YELLOW, 10, TimeUnit.SECONDS
+ * );
+ * countdown.addViewer(player);
+ * }</pre>
+ *
+ * <h2>Limits and notes</h2>
+ * <ul>
+ *   <li>Minecraft clients display up to ~20 boss bars simultaneously, though 1–3 is typical.</li>
+ *   <li>Progress values are clamped to {@code [0.0, 1.0]} by {@link SwordBossBar#setProgress}.</li>
+ *   <li>Available colors: {@code PINK, BLUE, RED, GREEN, YELLOW, PURPLE, WHITE}.</li>
+ *   <li>Available overlays: {@code PROGRESS} (solid), {@code NOTCHED_6}, {@code NOTCHED_10},
+ *       {@code NOTCHED_12}, {@code NOTCHED_20}.</li>
+ * </ul>
+ */
+public final class BossBarManager {
+
+    private static final List<SwordBossBar> activeBars = new ArrayList<>();
+
+    private BossBarManager() {}
+
+    /**
+     * Creates and registers a new boss bar with a solid progress overlay.
+     *
+     * @param title    the display title
+     * @param progress the initial fill progress (0.0–1.0)
+     * @param color    the bar color
+     * @return the newly created boss bar
+     */
+    public static SwordBossBar create(Component title, float progress, BossBar.Color color) {
+        return create(title, progress, color, BossBar.Overlay.PROGRESS);
+    }
+
+    /**
+     * Creates and registers a new boss bar.
+     *
+     * @param title    the display title
+     * @param progress the initial fill progress (0.0–1.0)
+     * @param color    the bar color
+     * @param overlay  the segment overlay style
+     * @return the newly created boss bar
+     */
+    public static SwordBossBar create(Component title, float progress, BossBar.Color color, BossBar.Overlay overlay) {
+        SwordBossBar bar = new SwordBossBar(title, progress, color, overlay);
+        activeBars.add(bar);
+        return bar;
+    }
+
+    /**
+     * Creates and registers a boss bar that automatically removes itself after the given duration.
+     *
+     * @param title    the display title
+     * @param progress the initial fill progress (0.0–1.0)
+     * @param color    the bar color
+     * @param duration the delay before auto-removal
+     * @param unit     the time unit of the delay
+     * @return the newly created timed boss bar
+     */
+    public static SwordBossBar createTimed(
+            Component title, float progress, BossBar.Color color, int duration, TimeUnit unit) {
+        SwordBossBar bar = create(title, progress, color);
+        bar.removeAfter(duration, unit);
+        return bar;
+    }
+
+    /**
+     * Removes the given player from all active boss bars they are viewing.
+     * Called automatically by {@code ServerJoinArbiter.onPlayerQuit}.
+     *
+     * @param player the player who disconnected
+     */
+    public static void onPlayerQuit(Player player) {
+        for (SwordBossBar bar : activeBars) {
+            if (bar.hasViewer(player)) {
+                bar.removeViewer(player);
+            }
+        }
+    }
+
+    /**
+     * Destroys all active boss bars. Called on plugin disable.
+     */
+    public static void removeAll() {
+        List<SwordBossBar> snapshot = new ArrayList<>(activeBars);
+        snapshot.forEach(SwordBossBar::remove);
+        activeBars.clear();
+    }
+
+    /**
+     * Internal: called by {@link SwordBossBar#remove()} to deregister the bar.
+     * Not intended for external use.
+     *
+     * @param bar the bar to deregister
+     */
+    static void unregister(SwordBossBar bar) {
+        activeBars.remove(bar);
+    }
+}

--- a/src/main/java/btm/sword/system/display/README.md
+++ b/src/main/java/btm/sword/system/display/README.md
@@ -1,0 +1,148 @@
+# Display System
+
+Clean internal APIs for scoreboard and boss bar manipulation, built on Paper's Adventure API.
+Both systems are lifecycle-managed — players are cleaned up automatically on disconnect, and
+all resources are released on plugin disable.
+
+---
+
+## Scoreboard API
+
+**Classes:** `SwordScoreboard`, `ScoreboardManager`
+
+Per-player sidebar scoreboards with top-down line management (line 1 = top).
+Each player gets their own isolated `Scoreboard` object, so there is no cross-player
+interference.
+
+### Quick start
+
+```java
+// Create and show a scoreboard
+SwordScoreboard board = ScoreboardManager.create(player, Component.text("Combat HUD"));
+board.setLine(1, Component.text("HP").color(NamedTextColor.RED).append(Component.text(": 100")));
+board.setLine(2, Component.empty());  // blank spacer
+board.setLine(3, Component.text("Soulfire: 50").color(NamedTextColor.AQUA));
+board.show();
+
+// Update a line
+board.setLine(1, Component.text("HP: 75").color(NamedTextColor.RED));
+
+// Hide/show toggle
+board.hide();
+board.show();
+
+// Destroy when done
+board.remove();
+```
+
+### API surface
+
+| Method | Description |
+|---|---|
+| `ScoreboardManager.create(player, title)` | Create + register a scoreboard |
+| `ScoreboardManager.get(player)` | Retrieve an existing scoreboard (Optional) |
+| `ScoreboardManager.remove(player)` | Destroy the player's scoreboard |
+| `board.setTitle(Component)` | Update the sidebar title |
+| `board.setLine(int, Component)` | Set line 1–15 (1 = top) |
+| `board.clearLine(int)` | Remove a single line |
+| `board.clear()` | Remove all lines |
+| `board.show()` / `board.hide()` | Toggle visibility |
+| `board.remove()` | Destroy permanently |
+
+### Limits
+
+- **15 lines maximum** — Minecraft sidebar constraint.
+- Lines use `Score.customName(Component)` (Paper 1.20.4+) for rich text without team hacks.
+
+---
+
+## Boss Bar API
+
+**Classes:** `SwordBossBar`, `BossBarManager`
+
+Multi-viewer boss bars with progress tracking, timed auto-removal, and full
+Adventure API formatting support.
+
+### Quick start
+
+```java
+// Persistent boss bar shown to all players in an encounter
+SwordBossBar bar = BossBarManager.create(
+    Component.text("Ancient Guardian").color(NamedTextColor.RED),
+    1.0f,
+    BossBar.Color.RED,
+    BossBar.Overlay.NOTCHED_10
+);
+bar.addViewer(player1);
+bar.addViewer(player2);
+
+// Drain health over time
+bar.setProgress(0.5f);
+bar.setTitle(Component.text("Ancient Guardian [Enraged]").color(NamedTextColor.DARK_RED));
+
+// Clean up when encounter ends
+bar.remove();
+```
+
+```java
+// Timed countdown bar (auto-removes after 10 seconds)
+SwordBossBar countdown = BossBarManager.createTimed(
+    Component.text("Round starts in 10s"),
+    1.0f, BossBar.Color.YELLOW, 10, TimeUnit.SECONDS
+);
+countdown.addViewer(player);
+
+// Timed bar with a completion callback
+BossBarManager.create(Component.text("Capturing..."), 0f, BossBar.Color.GREEN)
+    .removeAfter(5, TimeUnit.SECONDS, bar -> bar.setTitle(Component.text("Captured!")));
+```
+
+### API surface
+
+| Method | Description |
+|---|---|
+| `BossBarManager.create(title, progress, color)` | Solid-progress bar |
+| `BossBarManager.create(title, progress, color, overlay)` | Full control |
+| `BossBarManager.createTimed(title, progress, color, duration, unit)` | Auto-removing bar |
+| `bar.setTitle(Component)` | Update the title |
+| `bar.setProgress(float)` | Set fill 0.0–1.0 (clamped) |
+| `bar.setColor(BossBar.Color)` | Change bar color |
+| `bar.setOverlay(BossBar.Overlay)` | Change segment style |
+| `bar.addViewer(Player)` | Show to a player |
+| `bar.removeViewer(Player)` | Hide from a player |
+| `bar.clearViewers()` | Hide from all viewers |
+| `bar.removeAfter(duration, unit)` | Schedule auto-removal |
+| `bar.removeAfter(duration, unit, onComplete)` | Auto-removal with callback |
+| `bar.remove()` | Destroy immediately |
+
+### Colors and overlays
+
+**Colors:** `PINK`, `BLUE`, `RED`, `GREEN`, `YELLOW`, `PURPLE`, `WHITE`
+
+**Overlays:**
+
+| Overlay | Description |
+|---|---|
+| `PROGRESS` | Solid bar (default) |
+| `NOTCHED_6` | 6 segments |
+| `NOTCHED_10` | 10 segments |
+| `NOTCHED_12` | 12 segments |
+| `NOTCHED_20` | 20 segments |
+
+### Limits and notes
+
+- Minecraft clients can display up to ~20 boss bars simultaneously; 1–3 is the practical limit.
+- A bar is shown to a player only while they remain online. Disconnecting auto-removes them.
+- `remove()` is idempotent — calling it more than once is safe.
+
+---
+
+## Lifecycle hooks
+
+Both systems hook into the server lifecycle automatically:
+
+| Event | Action |
+|---|---|
+| Player joins | (no action; bars/boards are created on demand) |
+| Player quits | `ScoreboardManager.onPlayerQuit` + `BossBarManager.onPlayerQuit` |
+| Plugin disable | `ScoreboardManager.removeAll()` + `BossBarManager.removeAll()` |

--- a/src/main/java/btm/sword/system/display/ScoreboardManager.java
+++ b/src/main/java/btm/sword/system/display/ScoreboardManager.java
@@ -1,0 +1,94 @@
+package btm.sword.system.display;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.bukkit.entity.Player;
+
+import net.kyori.adventure.text.Component;
+
+/**
+ * Global manager for per-player {@link SwordScoreboard} instances.
+ *
+ * <p>Maintains a registry of active scoreboards keyed by player UUID, handling creation,
+ * retrieval, and cleanup. Player disconnections are handled automatically via
+ * {@link #onPlayerQuit(Player)}, which is called by the join arbiter.</p>
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * // Create and show a scoreboard
+ * SwordScoreboard board = ScoreboardManager.create(player, Component.text("HUD"));
+ * board.setLine(1, Component.text("HP: 100"));
+ * board.show();
+ *
+ * // Update a line later
+ * ScoreboardManager.get(player).ifPresent(b -> b.setLine(1, Component.text("HP: 75")));
+ *
+ * // Remove on player quit
+ * ScoreboardManager.onPlayerQuit(player);
+ * }</pre>
+ */
+public final class ScoreboardManager {
+
+    private static final Map<UUID, SwordScoreboard> boards = new HashMap<>();
+
+    private ScoreboardManager() {}
+
+    /**
+     * Creates a new {@link SwordScoreboard} for the player and registers it.
+     * If a scoreboard already exists for this player it is replaced and destroyed.
+     *
+     * @param player the player to create a scoreboard for
+     * @param title  the sidebar title
+     * @return the newly created scoreboard
+     */
+    public static SwordScoreboard create(Player player, Component title) {
+        remove(player);
+        SwordScoreboard board = new SwordScoreboard(player, title);
+        boards.put(player.getUniqueId(), board);
+        return board;
+    }
+
+    /**
+     * Returns the active {@link SwordScoreboard} for the given player, if any.
+     *
+     * @param player the player to look up
+     * @return an {@link Optional} containing the scoreboard, or empty if none exists
+     */
+    public static Optional<SwordScoreboard> get(Player player) {
+        return Optional.ofNullable(boards.get(player.getUniqueId()));
+    }
+
+    /**
+     * Hides and destroys the scoreboard for the given player, removing it from the registry.
+     * Safe to call even if no scoreboard exists for this player.
+     *
+     * @param player the player whose scoreboard to remove
+     */
+    public static void remove(Player player) {
+        SwordScoreboard existing = boards.remove(player.getUniqueId());
+        if (existing != null) {
+            existing.remove();
+        }
+    }
+
+    /**
+     * Cleans up the scoreboard for a player who has disconnected.
+     * Called automatically by {@code ServerJoinArbiter.onPlayerQuit}.
+     *
+     * @param player the player who quit
+     */
+    public static void onPlayerQuit(Player player) {
+        remove(player);
+    }
+
+    /**
+     * Destroys all registered scoreboards. Called on plugin disable.
+     */
+    public static void removeAll() {
+        boards.values().forEach(SwordScoreboard::remove);
+        boards.clear();
+    }
+}

--- a/src/main/java/btm/sword/system/display/SwordBossBar.java
+++ b/src/main/java/btm/sword/system/display/SwordBossBar.java
@@ -1,0 +1,205 @@
+package btm.sword.system.display;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import btm.sword.system.control.SwordScheduler;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
+
+/**
+ * A managed wrapper around an Adventure {@link BossBar} with viewer tracking and lifecycle control.
+ *
+ * <p>Supports progress updates, color and overlay changes, multi-viewer management, and
+ * time-based auto-removal. When a player disconnects, the {@link BossBarManager} automatically
+ * removes them from all active bars via {@link BossBarManager#onPlayerQuit(Player)}.</p>
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * // Persistent bar
+ * SwordBossBar bar = BossBarManager.create(Component.text("Boss HP"), 1.0f, BossBar.Color.RED);
+ * bar.addViewer(player);
+ * bar.setProgress(0.5f);
+ *
+ * // Timed bar (auto-removes after 5 seconds)
+ * SwordBossBar timer = BossBarManager.createTimed(
+ *     Component.text("Round starts in 5s"), 1.0f, BossBar.Color.YELLOW, 5, TimeUnit.SECONDS);
+ * timer.addViewer(player);
+ * }</pre>
+ *
+ * <p>Obtain instances via {@link BossBarManager} — do not construct directly.</p>
+ */
+public final class SwordBossBar {
+
+    private final BossBar bossBar;
+    private final Set<UUID> viewers = new HashSet<>();
+    private boolean removed;
+
+    /**
+     * Constructs a new boss bar. Use {@link BossBarManager#create} instead of calling directly.
+     *
+     * @param title   the initial title
+     * @param progress the initial progress (0.0–1.0)
+     * @param color   the bar color
+     * @param overlay the segment overlay style
+     */
+    SwordBossBar(Component title, float progress, BossBar.Color color, BossBar.Overlay overlay) {
+        this.bossBar = BossBar.bossBar(title, progress, color, overlay);
+        this.removed = false;
+    }
+
+    /**
+     * Sets the displayed title text.
+     *
+     * @param title the new title component
+     */
+    public void setTitle(Component title) {
+        bossBar.name(title);
+    }
+
+    /**
+     * Sets the fill progress of the bar. Values are clamped to {@code [0.0, 1.0]}.
+     *
+     * @param progress the new progress value
+     */
+    public void setProgress(float progress) {
+        bossBar.progress(Math.max(0f, Math.min(1f, progress)));
+    }
+
+    /**
+     * Sets the bar color.
+     *
+     * @param color the new {@link BossBar.Color}
+     */
+    public void setColor(BossBar.Color color) {
+        bossBar.color(color);
+    }
+
+    /**
+     * Sets the segment overlay style (e.g. solid, 6 notches, 10 notches, 12 notches, 20 notches).
+     *
+     * @param overlay the new {@link BossBar.Overlay}
+     */
+    public void setOverlay(BossBar.Overlay overlay) {
+        bossBar.overlay(overlay);
+    }
+
+    /**
+     * Shows this boss bar to the given player. Has no effect if the bar has already been removed.
+     *
+     * @param player the player to add as a viewer
+     */
+    public void addViewer(Player player) {
+        if (removed) return;
+        viewers.add(player.getUniqueId());
+        player.showBossBar(bossBar);
+    }
+
+    /**
+     * Hides this boss bar from the given player and removes them from the viewer set.
+     *
+     * @param player the player to remove
+     */
+    public void removeViewer(Player player) {
+        viewers.remove(player.getUniqueId());
+        if (player.isOnline()) {
+            player.hideBossBar(bossBar);
+        }
+    }
+
+    /**
+     * Hides this boss bar from all current viewers.
+     */
+    public void clearViewers() {
+        Set<UUID> snapshot = new HashSet<>(viewers);
+        for (UUID uuid : snapshot) {
+            Player p = Bukkit.getPlayer(uuid);
+            if (p != null) {
+                removeViewer(p);
+            } else {
+                viewers.remove(uuid);
+            }
+        }
+    }
+
+    /**
+     * Returns whether the given player is currently a viewer of this bar.
+     *
+     * @param player the player to check
+     * @return {@code true} if the player is a viewer
+     */
+    public boolean hasViewer(Player player) {
+        return viewers.contains(player.getUniqueId());
+    }
+
+    /**
+     * Destroys this boss bar, clearing all viewers and unregistering it from the
+     * {@link BossBarManager}. After calling this, the instance should be discarded.
+     * Calling this more than once is a no-op.
+     */
+    public void remove() {
+        if (removed) return;
+        removed = true;
+        clearViewers();
+        BossBarManager.unregister(this);
+    }
+
+    /**
+     * Schedules this boss bar to automatically remove itself after the given duration.
+     *
+     * @param duration the delay before removal
+     * @param unit     the time unit of the delay
+     */
+    public void removeAfter(int duration, TimeUnit unit) {
+        SwordScheduler.runBukkitTaskLater(this::remove, duration, unit);
+    }
+
+    /**
+     * Schedules this boss bar to automatically remove itself after the given duration,
+     * invoking {@code onComplete} just before removal.
+     *
+     * @param duration   the delay before removal
+     * @param unit       the time unit of the delay
+     * @param onComplete callback invoked with this bar immediately before it is removed
+     */
+    public void removeAfter(int duration, TimeUnit unit, Consumer<SwordBossBar> onComplete) {
+        SwordScheduler.runBukkitTaskLater(() -> {
+            onComplete.accept(this);
+            remove();
+        }, duration, unit);
+    }
+
+    /**
+     * Returns the underlying Adventure {@link BossBar} for direct manipulation.
+     *
+     * @return the wrapped boss bar
+     */
+    public BossBar getBossBar() {
+        return bossBar;
+    }
+
+    /**
+     * Returns whether this bar has been removed.
+     *
+     * @return {@code true} if removed
+     */
+    public boolean isRemoved() {
+        return removed;
+    }
+
+    /**
+     * Returns an unmodifiable view of the UUIDs currently registered as viewers.
+     *
+     * @return unmodifiable set of viewer UUIDs
+     */
+    public Set<UUID> getViewerIds() {
+        return Collections.unmodifiableSet(viewers);
+    }
+}

--- a/src/main/java/btm/sword/system/display/SwordScoreboard.java
+++ b/src/main/java/btm/sword/system/display/SwordScoreboard.java
@@ -2,6 +2,7 @@ package btm.sword.system.display;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Criteria;
 import org.bukkit.scoreboard.DisplaySlot;
 import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.RenderType;
@@ -49,7 +50,7 @@ public final class SwordScoreboard {
     SwordScoreboard(Player player, Component title) {
         this.player = player;
         this.scoreboard = Bukkit.getScoreboardManager().getNewScoreboard();
-        this.objective = scoreboard.registerNewObjective("sword_hud", "dummy", title, RenderType.INTEGER);
+        this.objective = scoreboard.registerNewObjective("sword_hud", Criteria.DUMMY, title, RenderType.INTEGER);
         this.objective.setDisplaySlot(DisplaySlot.SIDEBAR);
         this.visible = false;
     }

--- a/src/main/java/btm/sword/system/display/SwordScoreboard.java
+++ b/src/main/java/btm/sword/system/display/SwordScoreboard.java
@@ -1,0 +1,155 @@
+package btm.sword.system.display;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.RenderType;
+import org.bukkit.scoreboard.Score;
+import org.bukkit.scoreboard.Scoreboard;
+
+import net.kyori.adventure.text.Component;
+
+/**
+ * A per-player sidebar scoreboard wrapper with easy line management.
+ *
+ * <p>Manages a dedicated {@link Scoreboard} and SIDEBAR {@link Objective} for a single player.
+ * Lines are numbered top-down (line 1 = topmost, line {@value #MAX_LINES} = bottommost) and
+ * support full Adventure {@link Component} formatting. Showing and hiding is handled by
+ * swapping the player's active scoreboard.</p>
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * SwordScoreboard board = ScoreboardManager.create(player, Component.text("Combat HUD"));
+ * board.setLine(1, Component.text("Health: 100").color(NamedTextColor.RED));
+ * board.setLine(2, Component.empty());
+ * board.setLine(3, Component.text("Soulfire: 50").color(NamedTextColor.BLUE));
+ * board.show();
+ * }</pre>
+ *
+ * <p>Obtain instances via {@link ScoreboardManager#create} — do not construct directly.</p>
+ */
+public final class SwordScoreboard {
+
+    /** Maximum number of sidebar lines supported by Minecraft's scoreboard. */
+    public static final int MAX_LINES = 15;
+
+    private final Player player;
+    private final Scoreboard scoreboard;
+    private final Objective objective;
+    private boolean visible;
+
+    /**
+     * Constructs a new scoreboard for the given player.
+     * Use {@link ScoreboardManager#create} instead of calling this directly.
+     *
+     * @param player the player who owns this scoreboard
+     * @param title  the initial sidebar title
+     */
+    SwordScoreboard(Player player, Component title) {
+        this.player = player;
+        this.scoreboard = Bukkit.getScoreboardManager().getNewScoreboard();
+        this.objective = scoreboard.registerNewObjective("sword_hud", "dummy", title, RenderType.INTEGER);
+        this.objective.setDisplaySlot(DisplaySlot.SIDEBAR);
+        this.visible = false;
+    }
+
+    /**
+     * Updates the sidebar title.
+     *
+     * @param title the new title component
+     */
+    public void setTitle(Component title) {
+        objective.displayName(title);
+    }
+
+    /**
+     * Sets a line of text on the scoreboard.
+     *
+     * <p>Line 1 is the topmost row; line {@value #MAX_LINES} is the bottommost. Passing
+     * {@link Component#empty()} creates a blank spacer line. Has no effect if {@code line}
+     * is outside {@code [1, MAX_LINES]}.</p>
+     *
+     * @param line the line number (1 = top, {@value #MAX_LINES} = bottom)
+     * @param text the component to display
+     */
+    public void setLine(int line, Component text) {
+        if (line < 1 || line > MAX_LINES) return;
+        Score score = objective.getScore(entryName(line));
+        score.setScore(MAX_LINES - line);
+        score.customName(text);
+    }
+
+    /**
+     * Removes a single line from the scoreboard, leaving that row empty.
+     *
+     * @param line the line number to remove (1–{@value #MAX_LINES})
+     */
+    public void clearLine(int line) {
+        if (line < 1 || line > MAX_LINES) return;
+        scoreboard.resetScores(entryName(line));
+    }
+
+    /**
+     * Removes all lines from the scoreboard, leaving it empty.
+     */
+    public void clear() {
+        for (int i = 1; i <= MAX_LINES; i++) {
+            clearLine(i);
+        }
+    }
+
+    /**
+     * Shows this scoreboard to the player by setting it as their active scoreboard.
+     */
+    public void show() {
+        player.setScoreboard(scoreboard);
+        visible = true;
+    }
+
+    /**
+     * Hides this scoreboard by restoring the player to the main server scoreboard.
+     * Has no effect if the player is offline.
+     */
+    public void hide() {
+        if (player.isOnline()) {
+            player.setScoreboard(Bukkit.getScoreboardManager().getMainScoreboard());
+        }
+        visible = false;
+    }
+
+    /**
+     * Hides and permanently destroys this scoreboard, unregistering its objective.
+     * After calling this, the instance should be discarded.
+     */
+    public void remove() {
+        hide();
+        objective.unregister();
+    }
+
+    /**
+     * Returns whether this scoreboard is currently shown to the player.
+     *
+     * @return {@code true} if visible
+     */
+    public boolean isVisible() {
+        return visible;
+    }
+
+    /**
+     * Returns the player this scoreboard belongs to.
+     *
+     * @return the owning player
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Produces a stable, unique internal entry name for the given line slot.
+     * These names are never shown to players directly when {@code customName} is set.
+     */
+    private static String entryName(int line) {
+        return "sword_line_" + line;
+    }
+}

--- a/src/main/java/btm/sword/system/display/SwordScoreboard.java
+++ b/src/main/java/btm/sword/system/display/SwordScoreboard.java
@@ -9,6 +9,7 @@ import org.bukkit.scoreboard.RenderType;
 import org.bukkit.scoreboard.Score;
 import org.bukkit.scoreboard.Scoreboard;
 
+import io.papermc.paper.scoreboard.numbers.NumberFormat;
 import net.kyori.adventure.text.Component;
 
 /**
@@ -52,6 +53,7 @@ public final class SwordScoreboard {
         this.scoreboard = Bukkit.getScoreboardManager().getNewScoreboard();
         this.objective = scoreboard.registerNewObjective("sword_hud", Criteria.DUMMY, title, RenderType.INTEGER);
         this.objective.setDisplaySlot(DisplaySlot.SIDEBAR);
+        this.objective.numberFormat(NumberFormat.blank());
         this.visible = false;
     }
 

--- a/src/main/java/btm/sword/system/inventory/menu/DevMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/DevMenu.java
@@ -1,6 +1,8 @@
 package btm.sword.system.inventory.menu;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -8,12 +10,18 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import btm.sword.config.Config;
+import btm.sword.system.control.SwordScheduler;
+import btm.sword.system.display.BossBarManager;
+import btm.sword.system.display.ScoreboardManager;
+import btm.sword.system.display.SwordBossBar;
+import btm.sword.system.display.SwordScoreboard;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.item.ItemStackBuilder;
 import btm.sword.system.scene.DEUAnimationController;
 import btm.sword.system.scene.SceneManager;
 import btm.sword.system.scene.animation.AnimationDef;
 import btm.sword.system.scene.animation.AnimationRegistry;
+import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -180,11 +188,71 @@ public class DevMenu extends Menu {
             click -> new ItemLibraryMenu(swordPlayer).open()
         );
 
+        SimpleItem bossBarTest = new SimpleItem(
+            new ItemStackBuilder(Material.ORANGE_BANNER)
+                .name(Component.text("Boss Bar Fill Test", NamedTextColor.GOLD, TextDecoration.BOLD))
+                .lore(List.of(Component.text("Spawns a bar that fills over 5 seconds", NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> {
+                SwordBossBar bar = BossBarManager.create(
+                    Component.text("Charging...", NamedTextColor.YELLOW),
+                    0f,
+                    BossBar.Color.YELLOW,
+                    BossBar.Overlay.NOTCHED_10
+                );
+                bar.addViewer(player);
+                int steps = 20;
+                int intervalMs = 250;
+                for (int i = 1; i <= steps; i++) {
+                    final float progress = (float) i / steps;
+                    SwordScheduler.runBukkitTaskLater(() -> bar.setProgress(progress), i * intervalMs, TimeUnit.MILLISECONDS);
+                }
+                SwordScheduler.runBukkitTaskLater(() -> {
+                    bar.setTitle(Component.text("Charged!", NamedTextColor.GREEN));
+                    bar.setColor(BossBar.Color.GREEN);
+                }, steps * intervalMs, TimeUnit.MILLISECONDS);
+                SwordScheduler.runBukkitTaskLater(bar::remove, steps * intervalMs + 1000, TimeUnit.MILLISECONDS);
+            }
+        );
+
+        boolean hasScoreboard = ScoreboardManager.get(player).isPresent();
+        SimpleItem scoreboardTest = new SimpleItem(
+            new ItemStackBuilder(hasScoreboard ? Material.LIME_BANNER : Material.WHITE_BANNER)
+                .name(Component.text("Scoreboard Test", NamedTextColor.GREEN, TextDecoration.BOLD))
+                .lore(List.of(Component.text(
+                    hasScoreboard ? "Click to remove the test scoreboard" : "Click to show a test scoreboard",
+                    NamedTextColor.DARK_GRAY
+                )))
+                .build(),
+            click -> {
+                Optional<SwordScoreboard> existing = ScoreboardManager.get(player);
+                if (existing.isPresent()) {
+                    ScoreboardManager.remove(player);
+                    swordPlayer.message(Component.text("Scoreboard removed.", NamedTextColor.YELLOW));
+                } else {
+                    SwordScoreboard board = ScoreboardManager.create(
+                        player,
+                        Component.text("✦ Sword Test", NamedTextColor.GOLD, TextDecoration.BOLD)
+                    );
+                    board.setLine(1, Component.text("HP", NamedTextColor.RED)
+                        .append(Component.text(": 100", NamedTextColor.WHITE)));
+                    board.setLine(2, Component.empty());
+                    board.setLine(3, Component.text("Soulfire", NamedTextColor.AQUA)
+                        .append(Component.text(": 75", NamedTextColor.WHITE)));
+                    board.setLine(4, Component.empty());
+                    board.setLine(5, Component.text("Toughness", NamedTextColor.GRAY)
+                        .append(Component.text(": 50", NamedTextColor.WHITE)));
+                    board.show();
+                    swordPlayer.message(Component.text("Scoreboard shown. Click again to remove.", NamedTextColor.GREEN));
+                }
+            }
+        );
+
         Gui gui = Gui.normal()
             .setStructure(
                 "# # # # # # # # #",
                 "# J N S F . L C #",
-                "# P X . . . . E #",
+                "# P X B K . . E #",
                 "# R I . T . M W #",
                 "# # # < . > # # #")
             .addIngredient('#', BORDER)
@@ -197,6 +265,8 @@ public class DevMenu extends Menu {
             .addIngredient('F', fakePlayerScene)
             .addIngredient('L', itemLibrary)
             .addIngredient('X', joinCutscene)
+            .addIngredient('B', bossBarTest)
+            .addIngredient('K', scoreboardTest)
             .addIngredient('C', creativeInventory)
             .addIngredient('W', woodenAxe)
             .addIngredient('E', witherSkeletonEgg)

--- a/src/main/java/btm/sword/system/join/ServerJoinArbiter.java
+++ b/src/main/java/btm/sword/system/join/ServerJoinArbiter.java
@@ -18,6 +18,8 @@ import org.bukkit.util.Vector;
 
 import btm.sword.config.Config;
 import btm.sword.system.control.SwordScheduler;
+import btm.sword.system.display.BossBarManager;
+import btm.sword.system.display.ScoreboardManager;
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.playerdata.PlayerData;
@@ -84,6 +86,10 @@ public final class ServerJoinArbiter implements Listener {
         UUID uuid = player.getUniqueId();
 
         MenuSlotGrid.releaseSlot(uuid);
+
+        // Remove player from any active scoreboards and boss bars
+        ScoreboardManager.onPlayerQuit(player);
+        BossBarManager.onPlayerQuit(player);
 
         if (SwordEntityArbiter.get(player) instanceof SwordPlayer sp) {
             CameraSystem.stopController(sp);


### PR DESCRIPTION
## Summary
- New `SwordScoreboard` / `ScoreboardManager` for per-player sidebars with rich text support (up to 15 lines)
- New `SwordBossBar` / `BossBarManager` for multi-viewer boss bars with progress/color/overlay control and timed auto-removal
- Lifecycle hooks: auto-cleanup on player disconnect and plugin disable

## Implementation Details

### SwordScoreboard / ScoreboardManager
- `SwordScoreboard` wraps a per-player sidebar scoreboard
- Line 1 is the top line, supports up to 15 lines total
- Uses `Score.customName(Component)` for rich text formatting
- `ScoreboardManager` provides global registry (create, get, remove)
- Auto-cleanup: `ScoreboardManager.onPlayerQuit(player)` removes scoreboards on disconnect
- Full cleanup: `ScoreboardManager.removeAll()` called in `Sword.onDisable()`

### SwordBossBar / BossBarManager
- `SwordBossBar` wraps Adventure BossBar with viewer tracking
- Full control over progress, color, overlay, and flags
- Supports timed auto-removal via `createTimed(duration)`
- `BossBarManager` provides global registry (create, createTimed, remove)
- Auto-cleanup: `BossBarManager.onPlayerQuit(player)` removes viewer on disconnect
- Full cleanup: `BossBarManager.removeAll()` called in `Sword.onDisable()`

### Lifecycle Integration
- `ServerJoinArbiter.onPlayerQuit()` now calls cleanup hooks for both managers
- `Sword.onDisable()` now calls `removeAll()` for both managers

### Documentation
Complete Javadoc on all public methods, plus full README with usage examples, API tables, and color/overlay reference.

## Test Plan
- Test scoreboard creation, line updates, and cleanup on disconnect
- Test boss bar creation, viewer tracking, color/progress/overlay changes
- Test timed boss bar auto-removal
- Verify cleanup on plugin disable