### PR TITLE
[Feat] Mob type registry and weapon slot display (#260, #261)

### DIFF
--- a/src/main/java/btm/sword/Sword.java
+++ b/src/main/java/btm/sword/Sword.java
@@ -23,6 +23,7 @@ import btm.sword.system.action.throwing.ProjectileManager;
 import btm.sword.system.display.BossBarManager;
 import btm.sword.system.display.ScoreboardManager;
 import btm.sword.system.entity.SwordEntityArbiter;
+import btm.sword.system.entity.display.WeaponDisplayRegistry;
 import btm.sword.system.entity.mob.MobTypeRegistry;
 import btm.sword.system.inventory.InventoryMenuManager;
 import btm.sword.system.join.MenuSlotGrid;
@@ -81,6 +82,7 @@ public final class Sword extends JavaPlugin {
 
         AnimationRegistry.initialize(this);
         MobTypeRegistry.initialize(this);
+        WeaponDisplayRegistry.initialize(this);
 
         PlayerDataManager.initialize();
 

--- a/src/main/java/btm/sword/Sword.java
+++ b/src/main/java/btm/sword/Sword.java
@@ -17,12 +17,15 @@ import btm.sword.listeners.InputListener;
 import btm.sword.listeners.PlayerListener;
 import btm.sword.listeners.SystemListener;
 import btm.sword.listeners.WorldListener;
+import btm.sword.listeners.packet.EntityPacketListener;
 import btm.sword.listeners.packet.MovementListener;
 import btm.sword.system.action.throwing.InteractiveItemArbiter;
 import btm.sword.system.action.throwing.ProjectileManager;
 import btm.sword.system.display.BossBarManager;
 import btm.sword.system.display.ScoreboardManager;
 import btm.sword.system.entity.SwordEntityArbiter;
+import btm.sword.system.entity.display.DEUAnimationHook;
+import btm.sword.system.entity.display.WeaponAnchorPacketHook;
 import btm.sword.system.entity.display.WeaponDisplayRegistry;
 import btm.sword.system.entity.mob.MobTypeRegistry;
 import btm.sword.system.inventory.InventoryMenuManager;
@@ -60,11 +63,14 @@ public final class Sword extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new PlayerListener(), this);
         getServer().getPluginManager().registerEvents(new ServerJoinArbiter(), this);
         getServer().getPluginManager().registerEvents(new EntityListener(), this);
+        getServer().getPluginManager().registerEvents(new DEUAnimationHook(), this);
+        WeaponAnchorPacketHook.register();
         getServer().getPluginManager().registerEvents(new WorldListener(), this);
         getServer().getPluginManager().registerEvents(new SystemListener(), this);
 
         protocolManager = ProtocolLibrary.getProtocolManager();
         protocolManager.addPacketListener(new MovementListener());
+        protocolManager.addPacketListener(new EntityPacketListener());
 
         // Register commands using Paper's Brigadier lifecycle system
         LifecycleEventManager<@NotNull Plugin> manager = this.getLifecycleManager();

--- a/src/main/java/btm/sword/Sword.java
+++ b/src/main/java/btm/sword/Sword.java
@@ -23,6 +23,7 @@ import btm.sword.system.action.throwing.ProjectileManager;
 import btm.sword.system.display.BossBarManager;
 import btm.sword.system.display.ScoreboardManager;
 import btm.sword.system.entity.SwordEntityArbiter;
+import btm.sword.system.entity.mob.MobTypeRegistry;
 import btm.sword.system.inventory.InventoryMenuManager;
 import btm.sword.system.join.MenuSlotGrid;
 import btm.sword.system.join.ServerJoinArbiter;
@@ -79,6 +80,7 @@ public final class Sword extends JavaPlugin {
         InventoryMenuManager.registerAll();
 
         AnimationRegistry.initialize(this);
+        MobTypeRegistry.initialize(this);
 
         PlayerDataManager.initialize();
 

--- a/src/main/java/btm/sword/commands/SwordCommands.java
+++ b/src/main/java/btm/sword/commands/SwordCommands.java
@@ -16,6 +16,7 @@ import btm.sword.config.ConfigManager;
 import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.entity.mob.MobTypeRegistry;
 import btm.sword.system.item.material.MaterialType;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
@@ -117,6 +118,7 @@ public final class SwordCommands {
         sender.sendMessage(Component.text("Reloading Sword: Combat Evolved configuration...", NamedTextColor.YELLOW));
 
         try {
+            MobTypeRegistry.reload();
             boolean success = ConfigManager.getInstance().reload();
 
             if (success) {

--- a/src/main/java/btm/sword/commands/SwordCommands.java
+++ b/src/main/java/btm/sword/commands/SwordCommands.java
@@ -15,6 +15,7 @@ import com.mojang.brigadier.arguments.StringArgumentType;
 import btm.sword.config.ConfigManager;
 import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.SwordEntityArbiter;
+import btm.sword.system.entity.display.WeaponDisplayRegistry;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.entity.mob.MobTypeRegistry;
 import btm.sword.system.item.material.MaterialType;
@@ -119,6 +120,7 @@ public final class SwordCommands {
 
         try {
             MobTypeRegistry.reload();
+            WeaponDisplayRegistry.reload();
             boolean success = ConfigManager.getInstance().reload();
 
             if (success) {

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -2768,6 +2768,14 @@ public class Config {
             v -> LOGGING_VERBOSE_LISTENER = v,
             ConfigurationSection::getBoolean); }
 
+        /** Log detailed animation state changes and transitions. */
+        public static boolean LOGGING_VERBOSE_ANIMATION = false;
+        static { register(
+            "debug.logging_verbose_animation",
+            LOGGING_VERBOSE_ANIMATION, Boolean.class,
+            v -> LOGGING_VERBOSE_ANIMATION = v,
+            ConfigurationSection::getBoolean); }
+
         // Visualization configuration
         public static boolean VISUALIZATION_SHOW_HITBOXES = false;
         static { register(

--- a/src/main/java/btm/sword/listeners/EntityListener.java
+++ b/src/main/java/btm/sword/listeners/EntityListener.java
@@ -55,7 +55,7 @@ public class EntityListener implements Listener {
         // to mark it as the weapon slot; the runtime item is then set via setWeaponSlotItem().
         if (entity instanceof ItemDisplay itemDisplay) {
             ItemStack displayed = itemDisplay.getItemStack();
-            if (displayed != null && displayed.getType() == Material.LIGHTNING_ROD) {
+            if (displayed.getType() == Material.LIGHTNING_ROD) {
                 itemDisplay.addScoreboardTag(DisplayRig.WEAPON_SLOT_TAG);
             }
         }

--- a/src/main/java/btm/sword/listeners/EntityListener.java
+++ b/src/main/java/btm/sword/listeners/EntityListener.java
@@ -4,6 +4,7 @@ package btm.sword.listeners;
 import org.bukkit.Location;
 import org.bukkit.damage.DamageSource;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.ItemDisplay;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -16,8 +17,11 @@ import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.base.SwordEntity;
+import btm.sword.system.entity.display.DisplayRig;
 import btm.sword.system.entity.impl.Combatant;
+import btm.sword.system.entity.impl.Hostile;
 import btm.sword.utility.Prefab;
+import net.donnypz.displayentityutils.events.AnimationCompleteEvent;
 
 public class EntityListener implements Listener {
     /**
@@ -42,6 +46,15 @@ public class EntityListener implements Listener {
             if (swordEntity != null) {
                 swordEntity.resetResources();
                 swordEntity.onSpawn();
+            }
+        }
+        // Tag any near-zero-scale item display so DisplayRig can find it as a weapon slot.
+        if (entity instanceof ItemDisplay itemDisplay) {
+            org.joml.Vector3f scale = itemDisplay.getTransformation().getScale();
+            if (Math.abs(scale.x) < DisplayRig.WEAPON_SLOT_SCALE_THRESHOLD
+                    && Math.abs(scale.y) < DisplayRig.WEAPON_SLOT_SCALE_THRESHOLD
+                    && Math.abs(scale.z) < DisplayRig.WEAPON_SLOT_SCALE_THRESHOLD) {
+                itemDisplay.addScoreboardTag(DisplayRig.WEAPON_SLOT_TAG);
             }
         }
     }
@@ -99,6 +112,26 @@ public class EntityListener implements Listener {
         if(event.getEntity() instanceof LivingEntity && event.getDamage() < 7474040) {
             event.setDamage(0.01);
             ((LivingEntity) event.getEntity()).heal(100);
+        }
+    }
+
+    /**
+     * Detects when a DEU animation finishes on a hostile mob's display rig.
+     * If the mob is in its death animation, deal lethal damage to trigger the actual kill.
+     *
+     * @param event the {@link AnimationCompleteEvent} fired by DEU when an animation ends
+     */
+    @EventHandler
+    public void onAnimationComplete(AnimationCompleteEvent event) {
+        Entity vehicle = event.getGroup().getVehicle();
+        if (!(vehicle instanceof LivingEntity livingEntity)) return;
+        SwordEntity swordEntity = SwordEntityArbiter.get(livingEntity);
+        if (!(swordEntity instanceof Hostile hostile)) return;
+        if (!hostile.isInDeathAnimation()) return;
+        String tag = event.getAnimation().getAnimationTag();
+        DisplayRig rig = hostile.getDisplayRig();
+        if (rig != null && tag != null && tag.equals(rig.dieAnimTag())) {
+            livingEntity.damage(74077740);
         }
     }
 

--- a/src/main/java/btm/sword/listeners/EntityListener.java
+++ b/src/main/java/btm/sword/listeners/EntityListener.java
@@ -2,6 +2,7 @@ package btm.sword.listeners;
 
 
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.damage.DamageSource;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.ItemDisplay;
@@ -10,6 +11,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
 import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
@@ -48,12 +50,12 @@ public class EntityListener implements Listener {
                 swordEntity.onSpawn();
             }
         }
-        // Tag any near-zero-scale item display so DisplayRig can find it as a weapon slot.
+        // Tag any LIGHTNING_ROD item display as a weapon slot for DisplayRig.
+        // Place a LIGHTNING_ROD item on the desired display entity part in your DEU group
+        // to mark it as the weapon slot; the runtime item is then set via setWeaponSlotItem().
         if (entity instanceof ItemDisplay itemDisplay) {
-            org.joml.Vector3f scale = itemDisplay.getTransformation().getScale();
-            if (Math.abs(scale.x) < DisplayRig.WEAPON_SLOT_SCALE_THRESHOLD
-                    && Math.abs(scale.y) < DisplayRig.WEAPON_SLOT_SCALE_THRESHOLD
-                    && Math.abs(scale.z) < DisplayRig.WEAPON_SLOT_SCALE_THRESHOLD) {
+            ItemStack displayed = itemDisplay.getItemStack();
+            if (displayed != null && displayed.getType() == Material.LIGHTNING_ROD) {
                 itemDisplay.addScoreboardTag(DisplayRig.WEAPON_SLOT_TAG);
             }
         }

--- a/src/main/java/btm/sword/listeners/packet/EntityPacketListener.java
+++ b/src/main/java/btm/sword/listeners/packet/EntityPacketListener.java
@@ -1,0 +1,77 @@
+package btm.sword.listeners.packet;
+
+import java.util.List;
+
+import org.bukkit.plugin.Plugin;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.ListeningWhitelist;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.events.PacketListener;
+import com.comphenix.protocol.wrappers.WrappedDataValue;
+
+import btm.sword.Sword;
+import btm.sword.utility.Debug;
+
+public class EntityPacketListener implements PacketListener {
+
+    @Override
+    public void onPacketSending(PacketEvent event) {
+        PacketType type = event.getPacketType();
+
+        // Only handle entity-related packets
+        if (!type.name().startsWith("ENTITY") && type != PacketType.Play.Server.ENTITY_METADATA) return;
+
+        Debug.listener("Sending packet: " + type);
+
+        try {
+            List<WrappedDataValue> metadata = event.getPacket().getDataValueCollectionModifier().read(0);
+            if (metadata != null) {
+                StringBuilder indices = new StringBuilder();
+                for (WrappedDataValue e : metadata) {
+                    indices.append(e.getIndex()).append(" ");
+                }
+                Debug.listener("Entity ID: " + event.getPacket().getIntegers().read(0)
+                    + " Metadata indices: [" + indices.toString().trim() + "]");
+            }
+        } catch (Exception e) {
+            Debug.listener("Error reading packet metadata: " + e);
+        }
+    }
+
+    @Override
+    public void onPacketReceiving(PacketEvent event) {
+        // No incoming handling for now
+    }
+
+    @Override
+    public ListeningWhitelist getSendingWhitelist() {
+        return ListeningWhitelist.newBuilder()
+            .priority(ListenerPriority.NORMAL)
+            .types(
+                PacketType.Play.Server.ENTITY_METADATA,
+                PacketType.Play.Server.ENTITY_EQUIPMENT,
+                PacketType.Play.Server.ENTITY_VELOCITY,
+                PacketType.Play.Server.ENTITY_TELEPORT,
+                PacketType.Play.Server.ENTITY_HEAD_ROTATION,
+                PacketType.Play.Server.ENTITY_LOOK,
+                PacketType.Play.Server.ENTITY_STATUS,
+                PacketType.Play.Server.ENTITY_EFFECT,
+                PacketType.Play.Server.ENTITY_DESTROY,
+                PacketType.Play.Server.ENTITY_SOUND,
+                PacketType.Play.Server.ENTITY_MOVE_LOOK
+            )
+            .build();
+    }
+
+    @Override
+    public ListeningWhitelist getReceivingWhitelist() {
+        return ListeningWhitelist.EMPTY_WHITELIST;
+    }
+
+    @Override
+    public Plugin getPlugin() {
+        return Sword.getInstance();
+    }
+}

--- a/src/main/java/btm/sword/listeners/packet/MovementListener.java
+++ b/src/main/java/btm/sword/listeners/packet/MovementListener.java
@@ -10,11 +10,12 @@ import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.events.ListenerPriority;
 import com.comphenix.protocol.events.ListeningWhitelist;
 import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.events.PacketListener;
 
 import btm.sword.Sword;
 import btm.sword.utility.Debug;
 
-public class MovementListener implements com.comphenix.protocol.events.PacketListener {
+public class MovementListener implements PacketListener {
     public static final HashSet<UUID> lockedPlayers = new HashSet<>();
 
     @Override

--- a/src/main/java/btm/sword/system/action/throwing/ThrowAction.java
+++ b/src/main/java/btm/sword/system/action/throwing/ThrowAction.java
@@ -42,6 +42,9 @@ public class ThrowAction extends SwordAction {
      * @param executor the combatant beginning a throw action
      */
     public static void throwReady(Combatant executor) {
+        if (executor instanceof SwordPlayer sp) {
+            sp.setBlocking(false);
+        }
         throwReady(executor, null);
     }
 

--- a/src/main/java/btm/sword/system/action/utility/UtilityAction.java
+++ b/src/main/java/btm/sword/system/action/utility/UtilityAction.java
@@ -25,7 +25,7 @@ public class UtilityAction extends SwordAction {
                     SwordEntityArbiter.getOrAdd(livingEntity).hit(
                         executor, 100,
                         0, 7777777, 7777777,
-                        1, l.getDirection().multiply(100));
+                        1, l.getDirection().multiply(0.1));
                 } catch (NullPointerException e) {
                     // some nonsense occurred
                 }

--- a/src/main/java/btm/sword/system/entity/SwordEntityArbiter.java
+++ b/src/main/java/btm/sword/system/entity/SwordEntityArbiter.java
@@ -21,6 +21,8 @@ import btm.sword.system.entity.impl.Dummy;
 import btm.sword.system.entity.impl.Hostile;
 import btm.sword.system.entity.impl.Passive;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.entity.mob.MobTypeDefinition;
+import btm.sword.system.entity.mob.MobTypeRegistry;
 import btm.sword.system.playerdata.PlayerDataManager;
 
 /**
@@ -136,7 +138,10 @@ public class SwordEntityArbiter {
             case ZOMBIE, SKELETON, WITHER_SKELETON, ENDERMAN, WARDEN, RAVAGER, CAVE_SPIDER, PILLAGER, ZOMBIFIED_PIGLIN,
                  HOGLIN, HUSK, SHULKER, SILVERFISH, SLIME, SPIDER, ENDER_DRAGON, EVOKER, ELDER_GUARDIAN, ENDERMITE,
                  BLAZE, MAGMA_CUBE, PHANTOM, WITCH, ILLUSIONER -> {
-                return new Hostile(entity, new CombatProfile());
+                CombatProfile profile = new CombatProfile();
+                MobTypeDefinition mobType = MobTypeRegistry.getByEntityType(entity.getType());
+                if (mobType != null) mobType.applyTo(profile);
+                return new Hostile(entity, profile);
             }
             case ARMOR_STAND -> {
                 if (entity instanceof ArmorStand stand) {

--- a/src/main/java/btm/sword/system/entity/SwordEntityArbiter.java
+++ b/src/main/java/btm/sword/system/entity/SwordEntityArbiter.java
@@ -20,6 +20,7 @@ import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.impl.Dummy;
 import btm.sword.system.entity.impl.Hostile;
 import btm.sword.system.entity.impl.Passive;
+import btm.sword.system.entity.impl.RigHostile;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.entity.mob.MobTypeDefinition;
 import btm.sword.system.entity.mob.MobTypeRegistry;
@@ -141,6 +142,10 @@ public class SwordEntityArbiter {
                 CombatProfile profile = new CombatProfile();
                 MobTypeDefinition mobType = MobTypeRegistry.getByEntityType(entity.getType());
                 if (mobType != null) mobType.applyTo(profile);
+                // Use RigHostile for mobs whose visuals are driven by a DEU display rig.
+                if (mobType != null && mobType.displayGroup() != null) {
+                    return new RigHostile(entity, profile);
+                }
                 return new Hostile(entity, profile);
             }
             case ARMOR_STAND -> {

--- a/src/main/java/btm/sword/system/entity/ai/ability/MobThrowAbility.java
+++ b/src/main/java/btm/sword/system/entity/ai/ability/MobThrowAbility.java
@@ -75,13 +75,14 @@ public class MobThrowAbility implements MobAbility {
         if (distance < 0.001) return;
         toTarget.normalize();
 
-        ItemStack projectile = h.getItemStackInHand(true);
+        ItemStack projectile = h.getThrowableItem();
         if (projectile == null || projectile.isEmpty()) {
             executeDirtThrow(h, toTarget);
             return;
         }
 
         ThrowAction.throwReady(h, projectile);
+        h.onWeaponThrown();
 
         if (h.getThrownItem() != null) {
             h.getThrownItem().setLaunchDirection(toTarget);

--- a/src/main/java/btm/sword/system/entity/ai/state/RetrieveWeaponState.java
+++ b/src/main/java/btm/sword/system/entity/ai/state/RetrieveWeaponState.java
@@ -78,7 +78,7 @@ public class RetrieveWeaponState extends HostileAIFacade {
         lodged.setRetrieved(true);
 
         if (lodged.getItemStack() != null && !lodged.getItemStack().isEmpty()) {
-            h.setItemStackInHand(lodged.getItemStack(), true);
+            h.receiveRetrievedWeapon(lodged.getItemStack());
             Prefab.Particles.GRAB_CLOUD.display(display.getLocation());
         }
 

--- a/src/main/java/btm/sword/system/entity/ai/state/RetrieveWeaponState.java
+++ b/src/main/java/btm/sword/system/entity/ai/state/RetrieveWeaponState.java
@@ -49,6 +49,7 @@ public class RetrieveWeaponState extends HostileAIFacade {
         ItemDisplay display = lodged.getDisplay();
         if (display == null || !display.isValid()) {
             h.setLodgedThrowItem(null);
+            h.onWeaponRetrieved();
             return;
         }
 
@@ -83,5 +84,6 @@ public class RetrieveWeaponState extends HostileAIFacade {
 
         lodged.dispose();
         h.setLodgedThrowItem(null);
+        h.onWeaponRetrieved();
     }
 }

--- a/src/main/java/btm/sword/system/entity/base/SwordEntity.java
+++ b/src/main/java/btm/sword/system/entity/base/SwordEntity.java
@@ -516,6 +516,10 @@ public abstract class SwordEntity {
         return afflictions.get(afflictionClass);
     }
 
+    protected boolean shouldDeferDeath() {
+        return false;
+    }
+
     /**
      * Applies a hit to this entity from a given source {@link Combatant}, triggering resource damage,
      * invulnerability, knockback, afflictions, and toughness breaking effects.
@@ -574,11 +578,13 @@ public abstract class SwordEntity {
             if (changeShards(-baseNumShards)) {
                 onZeroHealth();
 
-                SwordScheduler.runBukkitTaskLater(() -> {
-                    self.damage(74077740, source.self());
-                    if (!self.isDead())
-                        self.setHealth(0); },
-                    SwordTimeUnit.MILLISECONDS_PER_TICK * 2, TimeUnit.MILLISECONDS);
+                if (!shouldDeferDeath()) {
+                    SwordScheduler.runBukkitTaskLater(() -> {
+                        self.damage(74077740, source.self());
+                        if (!self.isDead())
+                            self.setHealth(0); },
+                        SwordTimeUnit.MILLISECONDS_PER_TICK * 2, TimeUnit.MILLISECONDS);
+                }
                 return;
             }
             shardsLostDuringToughnessBreak += baseNumShards;

--- a/src/main/java/btm/sword/system/entity/display/DEUAnimationHook.java
+++ b/src/main/java/btm/sword/system/entity/display/DEUAnimationHook.java
@@ -1,0 +1,69 @@
+package btm.sword.system.entity.display;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+import btm.sword.system.control.SwordScheduler;
+import net.donnypz.displayentityutils.events.AnimationStateChangeEvent;
+import net.donnypz.displayentityutils.utils.DisplayEntities.SpawnedDisplayEntityGroup;
+
+/**
+ * Bukkit event listener that re-applies weapon-slot transforms after DEU state-machine transitions.
+ *
+ * <p>DEU's {@link net.donnypz.displayentityutils.utils.DisplayEntities.machine.DisplayStateMachine}
+ * always uses {@code playUsingPackets} when transitioning states, which sends per-player
+ * PacketEvents metadata packets asynchronously from frame 0. If those packets reach a client
+ * before the {@link WeaponAnchorPacketHook} intercepts them (due to pipeline ordering between
+ * ProtocolLib and PacketEvents), the anchor briefly shows its vanilla state (LIGHTNING_ROD at
+ * near-zero scale). This listener schedules a short-delay call to
+ * {@link DisplayRig#reapplyWeaponTransform()} to close that window.</p>
+ *
+ * <p>Register once at plugin startup via {@link btm.sword.Sword#onEnable()}.</p>
+ */
+public final class DEUAnimationHook implements Listener {
+
+    /**
+     * Active rigs keyed by their DEU group. {@link ConcurrentHashMap} because
+     * {@link AnimationStateChangeEvent} may fire from non-primary threads in some DEU versions.
+     */
+    private static final Map<SpawnedDisplayEntityGroup, DisplayRig> RIGS = new ConcurrentHashMap<>();
+
+    /**
+     * Registers a rig so that its weapon transform is re-applied after state transitions.
+     * Called from {@link DisplayRig#spawn}.
+     *
+     * @param group the spawned group backing this rig
+     * @param rig   the rig to track
+     */
+    public static void track(SpawnedDisplayEntityGroup group, DisplayRig rig) {
+        RIGS.put(group, rig);
+    }
+
+    /**
+     * Removes the rig from tracking. Called from {@link DisplayRig#despawn}.
+     *
+     * @param group the group to stop tracking
+     */
+    public static void untrack(SpawnedDisplayEntityGroup group) {
+        RIGS.remove(group);
+    }
+
+    /**
+     * After a state-machine transition, schedule a short-delay re-apply of the weapon transform.
+     *
+     * <p>The 2-tick delay gives DEU's async frame-0 packet send time to complete before we
+     * assert server-side state. The re-apply packet is generated via the Bukkit API so
+     * ProtocolLib can intercept and force correct values on the wire.</p>
+     */
+    @EventHandler
+    public void onAnimationStateChange(AnimationStateChangeEvent event) {
+        if (!(event.getGroup() instanceof SpawnedDisplayEntityGroup group)) return;
+        DisplayRig rig = RIGS.get(group);
+        if (rig == null) return;
+        SwordScheduler.runBukkitTaskLater(rig::reapplyWeaponTransform, 100, TimeUnit.MILLISECONDS);
+    }
+}

--- a/src/main/java/btm/sword/system/entity/display/DisplayRig.java
+++ b/src/main/java/btm/sword/system/entity/display/DisplayRig.java
@@ -7,7 +7,6 @@ import org.bukkit.entity.Display;
 import org.bukkit.entity.ItemDisplay;
 import org.bukkit.entity.Mob;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.util.Transformation;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
@@ -38,7 +37,6 @@ import net.donnypz.displayentityutils.utils.controller.GroupFollowProperties;
  * present, is triggered by {@link #triggerDeath()} and plays once before the mob is killed.</p>
  *
  * <p>Weapon slot display: if the DEU group contains a {@link Material#LIGHTNING_ROD}
- * {@link ItemDisplay} whose scale is below {@link #WEAPON_SLOT_SCALE_THRESHOLD} on all axes,
  * that entity is used as the weapon-slot anchor. Call {@link #setWeaponSlotItem(ItemStack)}
  * to show an item at the mob's hand; the display follows the mob's position and yaw.
  * Per-material offset/rotation/scale is loaded from {@link WeaponDisplayRegistry}.</p>
@@ -76,12 +74,6 @@ public class DisplayRig {
      */
     private final @Nullable SpawnedDisplayEntityPart weaponAnchorPart;
 
-    /**
-     * The anchor's original transformation captured at spawn, used to restore the invisible
-     * near-zero-scale state when the weapon slot is cleared.
-     */
-    private final @Nullable Transformation weaponAnchorOriginalTransform;
-
     /** Periodic refresh task; non-null while a weapon is actively shown. */
     private @Nullable TimeArbiter.TaskHandle weaponRefreshTask;
 
@@ -100,8 +92,6 @@ public class DisplayRig {
         this.weaponAnchor = weaponAnchor;
         this.weaponAnchorPart = weaponAnchor != null
             ? SpawnedDisplayEntityPart.getPart(weaponAnchor) : null;
-        this.weaponAnchorOriginalTransform = weaponAnchor != null
-            ? weaponAnchor.getTransformation() : null;
     }
 
     /**
@@ -187,39 +177,20 @@ public class DisplayRig {
 
         if (weaponAnchor == null || !weaponAnchor.isValid()) return;
 
-        final Vector3f baseTrans = weaponAnchorOriginalTransform != null
-            ? new Vector3f(weaponAnchorOriginalTransform.getTranslation())
-            : new Vector3f();
-
         if (item == null || item.getType() == Material.AIR) {
             // Hidden state: keep the hook active so DEU's item-reset packets are suppressed.
             currentWeaponItem = null;
             WeaponAnchorPacketHook.override(
                 weaponAnchor, new ItemStack(Material.AIR), 0.001f, new Quaternionf(), new Vector3f());
             weaponAnchor.setGlowing(false);
-            weaponAnchor.setInterpolationDelay(0);
-            weaponAnchor.setInterpolationDuration(0);
-            weaponAnchor.setTransformation(new Transformation(
-                baseTrans, new Quaternionf(), new Vector3f(0.001f, 0.001f, 0.001f), new Quaternionf()
-            ));
             weaponAnchor.setItemStack(new ItemStack(Material.AIR));
             return;
         }
 
         // Armed state.
         currentWeaponItem = item;
-        final WeaponDisplayTransform t = WeaponDisplayRegistry.get(item.getType());
-        final Quaternionf rotOffset = new Quaternionf().rotateXYZ(
-            (float) Math.toRadians(t.rotX()),
-            (float) Math.toRadians(t.rotY()),
-            (float) Math.toRadians(t.rotZ())
-        );
-        final float scale = t.scale();
-        final Vector3f translationOffset = new Vector3f(t.offsetRight(), t.offsetUp(), t.offsetForward());
-        final ItemDisplay anchor = weaponAnchor;
 
-        // Register hook before the first metadata flush so even that packet is intercepted.
-        WeaponAnchorPacketHook.override(anchor, item, scale, rotOffset, translationOffset);
+        final ItemDisplay anchor = weaponAnchor;
 
         // 5-tick refresh: forces a Bukkit metadata packet so DEU state-machine resets are
         // overridden within one loop cycle. The packet hook intercepts these too.
@@ -229,14 +200,9 @@ public class DisplayRig {
                 anchor.setGlowing(true);
                 anchor.setGlowColorOverride(Config.SwordColor.ATTACK_QUICK_GLOW);
                 anchor.setItemDisplayTransform(ItemDisplay.ItemDisplayTransform.THIRDPERSON_LEFTHAND);
-//                anchor.setInterpolationDelay(0);
-//                anchor.setInterpolationDuration(0);
-//                anchor.setTransformation(new Transformation(
-//                    baseTrans, new Quaternionf(), new Vector3f(scale, scale, scale), new Quaternionf()
-//                ));
                 anchor.setItemStack(item);
             },
-            null, null, 0, 5,
+            null, null, 0, 1,
             DisplayRig.class, "setWeaponSlotItem"
         );
     }

--- a/src/main/java/btm/sword/system/entity/display/DisplayRig.java
+++ b/src/main/java/btm/sword/system/entity/display/DisplayRig.java
@@ -4,12 +4,10 @@ import java.util.List;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Display;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.ItemDisplay;
 import org.bukkit.entity.Mob;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Transformation;
-import org.bukkit.util.Vector;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
@@ -24,6 +22,7 @@ import net.donnypz.displayentityutils.managers.LoadMethod;
 import net.donnypz.displayentityutils.utils.DisplayEntities.DisplayAnimator;
 import net.donnypz.displayentityutils.utils.DisplayEntities.DisplayEntityGroup;
 import net.donnypz.displayentityutils.utils.DisplayEntities.SpawnedDisplayEntityGroup;
+import net.donnypz.displayentityutils.utils.DisplayEntities.SpawnedDisplayEntityPart;
 import net.donnypz.displayentityutils.utils.DisplayEntities.machine.DisplayStateMachine;
 import net.donnypz.displayentityutils.utils.DisplayEntities.machine.MachineState;
 import net.donnypz.displayentityutils.utils.FollowType;
@@ -55,12 +54,6 @@ public class DisplayRig {
      */
     public static final String WEAPON_SLOT_TAG = "sword_weapon_slot";
 
-    /**
-     * Scale threshold below which all three axes of an {@link ItemDisplay} must fall
-     * for it to be treated as a weapon-slot anchor.
-     */
-    public static final float WEAPON_SLOT_SCALE_THRESHOLD = 0.05f;
-
     private final Mob mob;
     private final SpawnedDisplayEntityGroup group;
     private final DisplayStateMachine stateMachine;
@@ -77,10 +70,26 @@ public class DisplayRig {
     /** The tiny LIGHTNING_ROD anchor within the DEU group that marks the main-hand weapon slot. */
     private final @Nullable ItemDisplay weaponAnchor;
 
-    /** The live item display entity that follows the mob's hand and shows the held item. */
-    private @Nullable ItemDisplay weaponDisplay;
-    /** Task handle for the mob-follow loop; non-null while a weapon is being shown. */
-    private @Nullable TimeArbiter.TaskHandle weaponFollowTask;
+    /**
+     * The DEU part wrapper for the weapon anchor, used to call DEU's own transform setters
+     * (which ultimately delegate to the Bukkit Display API but keep the call within DEU's model).
+     */
+    private final @Nullable SpawnedDisplayEntityPart weaponAnchorPart;
+
+    /**
+     * The anchor's original transformation captured at spawn, used to restore the invisible
+     * near-zero-scale state when the weapon slot is cleared.
+     */
+    private final @Nullable Transformation weaponAnchorOriginalTransform;
+
+    /** Periodic refresh task; non-null while a weapon is actively shown. */
+    private @Nullable TimeArbiter.TaskHandle weaponRefreshTask;
+
+    /**
+     * The item currently shown in the weapon slot, or {@code null} when hidden.
+     * Used by {@link #reapplyWeaponTransform()} to re-apply after DEU state transitions.
+     */
+    private @Nullable ItemStack currentWeaponItem;
 
     private DisplayRig(Mob mob, SpawnedDisplayEntityGroup group, DisplayStateMachine stateMachine,
             String dieAnimTag, @Nullable ItemDisplay weaponAnchor) {
@@ -89,6 +98,10 @@ public class DisplayRig {
         this.stateMachine = stateMachine;
         this.dieAnimTag = dieAnimTag;
         this.weaponAnchor = weaponAnchor;
+        this.weaponAnchorPart = weaponAnchor != null
+            ? SpawnedDisplayEntityPart.getPart(weaponAnchor) : null;
+        this.weaponAnchorOriginalTransform = weaponAnchor != null
+            ? weaponAnchor.getTransformation() : null;
     }
 
     /**
@@ -113,7 +126,6 @@ public class DisplayRig {
         if (group == null) return null;
 
         group.rideEntity(mob);
-        group.setRideOffset(new Vector(0, -mob.getHeight() + Config.Hostile.DISPLAY_RIDE_OFFSET_Y, 0));
 
         for (Display display : group.getPartEntities(Display.class)) {
             display.setTeleportDuration(Config.Hostile.DISPLAY_TELEPORT_DURATION);
@@ -137,90 +149,95 @@ public class DisplayRig {
         ItemDisplay weaponAnchor = null;
         for (ItemDisplay id : group.getPartEntities(ItemDisplay.class)) {
             ItemStack item = id.getItemStack();
-            if (item == null || item.getType() != Material.LIGHTNING_ROD) continue;
-            org.joml.Vector3f scale = id.getTransformation().getScale();
-            if (scale.x < WEAPON_SLOT_SCALE_THRESHOLD
-                    && scale.y < WEAPON_SLOT_SCALE_THRESHOLD
-                    && scale.z < WEAPON_SLOT_SCALE_THRESHOLD) {
-                weaponAnchor = id;
-                break;
-            }
+            if (item.getType() != Material.LIGHTNING_ROD) continue;
+            weaponAnchor = id;
+            break;
         }
 
+
         String dieTag = slots.die().tag() != null ? slots.die().tag() : "";
-        return new DisplayRig(mob, group, stateMachine, dieTag, weaponAnchor);
+        DisplayRig rig = new DisplayRig(mob, group, stateMachine, dieTag, weaponAnchor);
+        DEUAnimationHook.track(group, rig);
+        return rig;
     }
 
     // -----------------------------------------------------------------------
     // Weapon slot
 
     /**
-     * Shows the given item at the mob's main-hand weapon slot by spawning an
-     * {@link ItemDisplay} that mirrors the weapon-anchor bone's transform each tick.
+     * Shows the given item at the mob's main-hand weapon slot, or hides the slot.
      *
-     * <p>DEU writes the anchor's animated {@link Transformation} server-side on every
-     * animation frame. Each tick our follow task reads that transform and applies it
-     * (combined with the per-material user adjustments) to the weapon display so it
-     * tracks the bone's position <em>and</em> orientation through every animation state.</p>
+     * <p>This method drives two distinct hook states:</p>
+     * <ul>
+     *   <li><b>Armed</b> ({@code item} is a real weapon): registers a {@link WeaponAnchorPacketHook}
+     *       override that forces the weapon item, scale, and rotation offset on every outgoing
+     *       metadata packet for the anchor. A 5-tick refresh loop triggers periodic Bukkit-side
+     *       metadata flushes so DEU state-machine resets are overridden promptly.</li>
+     *   <li><b>Hidden</b> ({@code item} is {@code null} or AIR): registers the hook with
+     *       {@code AIR} and near-zero scale so DEU's own reset packets (which would restore the
+     *       LIGHTNING_ROD marker) are still intercepted and suppressed.</li>
+     * </ul>
      *
-     * <p>Passing {@code null} or an air stack hides the weapon display.</p>
-     *
-     * @param item the item to display, or {@code null} to clear
+     * @param item the item to display, or {@code null} to hide the slot
      */
     public void setWeaponSlotItem(@Nullable ItemStack item) {
-        clearWeaponDisplay();
+        // Tear down previous state before registering the new one.
+        stopWeaponRefreshTask();
+        if (weaponAnchor != null) WeaponAnchorPacketHook.clear(weaponAnchor);
 
-        if (weaponAnchor == null) return;
-        if (item == null || item.getType().isAir()) return;
+        if (weaponAnchor == null || !weaponAnchor.isValid()) return;
 
+        final Vector3f baseTrans = weaponAnchorOriginalTransform != null
+            ? new Vector3f(weaponAnchorOriginalTransform.getTranslation())
+            : new Vector3f();
+
+        if (item == null || item.getType() == Material.AIR) {
+            // Hidden state: keep the hook active so DEU's item-reset packets are suppressed.
+            currentWeaponItem = null;
+            WeaponAnchorPacketHook.override(
+                weaponAnchor, new ItemStack(Material.AIR), 0.001f, new Quaternionf(), new Vector3f());
+            weaponAnchor.setGlowing(false);
+            weaponAnchor.setInterpolationDelay(0);
+            weaponAnchor.setInterpolationDuration(0);
+            weaponAnchor.setTransformation(new Transformation(
+                baseTrans, new Quaternionf(), new Vector3f(0.001f, 0.001f, 0.001f), new Quaternionf()
+            ));
+            weaponAnchor.setItemStack(new ItemStack(Material.AIR));
+            return;
+        }
+
+        // Armed state.
+        currentWeaponItem = item;
         final WeaponDisplayTransform t = WeaponDisplayRegistry.get(item.getType());
-
-        weaponDisplay = (ItemDisplay) mob.getWorld().spawnEntity(
-            weaponAnchor.getLocation(), EntityType.ITEM_DISPLAY
-        );
-        weaponDisplay.setItemStack(item);
-
-        // Precompute static parts of the user adjustment (these don't change per tick).
-        final Quaternionf userRot = new Quaternionf().rotateXYZ(
+        final Quaternionf rotOffset = new Quaternionf().rotateXYZ(
             (float) Math.toRadians(t.rotX()),
             (float) Math.toRadians(t.rotY()),
             (float) Math.toRadians(t.rotZ())
         );
-        final Vector3f userOffset = new Vector3f(t.offsetRight(), t.offsetUp(), t.offsetForward());
         final float scale = t.scale();
-        final ItemDisplay display = weaponDisplay;
+        final Vector3f translationOffset = new Vector3f(t.offsetRight(), t.offsetUp(), t.offsetForward());
         final ItemDisplay anchor = weaponAnchor;
 
-        // Each tick: read the anchor's current animated transform (set by DEU) and mirror
-        // it onto our weapon display, then teleport to match the anchor's server-side position.
-        weaponFollowTask = TimeArbiter.runTimeBoundBukkitTaskOnTimer(
+        // Register hook before the first metadata flush so even that packet is intercepted.
+        WeaponAnchorPacketHook.override(anchor, item, scale, rotOffset, translationOffset);
+
+        // 5-tick refresh: forces a Bukkit metadata packet so DEU state-machine resets are
+        // overridden within one loop cycle. The packet hook intercepts these too.
+        weaponRefreshTask = TimeArbiter.runTimeBoundBukkitTaskOnTimer(
             () -> {
-                if (!anchor.isValid() || !display.isValid()) return;
-
-                Transformation anchorT = anchor.getTransformation();
-
-                // Bone rotation (from DEU animation) composed with user's additional rotation.
-                Quaternionf finalRot = anchorT.getLeftRotation().mul(userRot, new Quaternionf());
-
-                // Bone translation + user's local offset.
-                Vector3f finalTrans = anchorT.getTranslation().add(userOffset, new Vector3f());
-
-                display.setTransformation(new Transformation(
-                    finalTrans,
-                    finalRot,
-                    new Vector3f(scale, scale, scale),
-                    new Quaternionf()
-                ));
-
-                // Sync server-side position so the display follows the mob as it moves.
-                TimeArbiter.teleportDisplay(
-                    display, anchor.getLocation(), null,
-                    Config.Hostile.DISPLAY_TELEPORT_DURATION,
-                    DisplayRig.class, 0
-                );
+                if (!mob.isValid() || !anchor.isValid()) return;
+                anchor.setGlowing(true);
+                anchor.setGlowColorOverride(Config.SwordColor.ATTACK_QUICK_GLOW);
+                anchor.setItemDisplayTransform(ItemDisplay.ItemDisplayTransform.THIRDPERSON_LEFTHAND);
+//                anchor.setInterpolationDelay(0);
+//                anchor.setInterpolationDuration(0);
+//                anchor.setTransformation(new Transformation(
+//                    baseTrans, new Quaternionf(), new Vector3f(scale, scale, scale), new Quaternionf()
+//                ));
+                anchor.setItemStack(item);
             },
-            null, null, 0, 1,
-            DisplayRig.class, "weaponSlotSync"
+            null, null, 0, 5,
+            DisplayRig.class, "setWeaponSlotItem"
         );
     }
 
@@ -288,10 +305,29 @@ public class DisplayRig {
     // Lifecycle
 
     /**
+     * Re-applies the currently armed weapon transform to the anchor using DEU's part API.
+     *
+     * <p>Called by {@link DEUAnimationHook} a few ticks after a state-machine transition.
+     * DEU's {@code playUsingPackets} sends frame-0 packets asynchronously; if those packets
+     * bypass ProtocolLib's pipeline position, a brief reset window can occur. This call
+     * re-asserts the correct server-side entity state (scale + item) so that both
+     * the ProtocolLib hook and any subsequent server-to-client resends reflect our values.</p>
+     */
+    public void reapplyWeaponTransform() {
+        if (currentWeaponItem == null || weaponAnchorPart == null || weaponAnchor == null) return;
+        if (!weaponAnchor.isValid()) return;
+        WeaponDisplayTransform t = WeaponDisplayRegistry.get(currentWeaponItem.getType());
+        // Use DEU's part API to set scale — sends a Bukkit metadata packet that the hook intercepts.
+        weaponAnchorPart.setDisplayScale(t.scale(), t.scale(), t.scale());
+        weaponAnchor.setItemStack(currentWeaponItem);
+    }
+
+    /**
      * Removes the spawned group from the world and unregisters the state machine.
      * Must be called when the mob dies or is removed.
      */
     public void despawn() {
+        DEUAnimationHook.untrack(group);
         clearWeaponDisplay();
         stateMachine.removeGroup(group);
         group.unregister(true, true);
@@ -300,15 +336,16 @@ public class DisplayRig {
     // -----------------------------------------------------------------------
     // Private helpers
 
-    /** Cancels the follow task and removes the weapon display entity. */
+    /** Cancels the refresh task and fully removes the packet hook. Called only from {@link #despawn}. */
     private void clearWeaponDisplay() {
-        if (weaponFollowTask != null) {
-            weaponFollowTask.cancel();
-            weaponFollowTask = null;
-        }
-        if (weaponDisplay != null && weaponDisplay.isValid()) {
-            weaponDisplay.remove();
-            weaponDisplay = null;
+        stopWeaponRefreshTask();
+        if (weaponAnchor != null) WeaponAnchorPacketHook.clear(weaponAnchor);
+    }
+
+    private void stopWeaponRefreshTask() {
+        if (weaponRefreshTask != null) {
+            weaponRefreshTask.cancel();
+            weaponRefreshTask = null;
         }
     }
 

--- a/src/main/java/btm/sword/system/entity/display/DisplayRig.java
+++ b/src/main/java/btm/sword/system/entity/display/DisplayRig.java
@@ -18,7 +18,6 @@ import btm.sword.Sword;
 import btm.sword.config.Config;
 import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.mob.AnimationSlots;
-import btm.sword.utility.display.DisplayUtil;
 import net.donnypz.displayentityutils.events.GroupSpawnedEvent;
 import net.donnypz.displayentityutils.managers.DisplayGroupManager;
 import net.donnypz.displayentityutils.managers.LoadMethod;
@@ -157,8 +156,12 @@ public class DisplayRig {
 
     /**
      * Shows the given item at the mob's main-hand weapon slot by spawning an
-     * {@link ItemDisplay} that follows the mob using the transform from
-     * {@link WeaponDisplayRegistry}. Clears any previously displayed item.
+     * {@link ItemDisplay} that mirrors the weapon-anchor bone's transform each tick.
+     *
+     * <p>DEU writes the anchor's animated {@link Transformation} server-side on every
+     * animation frame. Each tick our follow task reads that transform and applies it
+     * (combined with the per-material user adjustments) to the weapon display so it
+     * tracks the bone's position <em>and</em> orientation through every animation state.</p>
      *
      * <p>Passing {@code null} or an air stack hides the weapon display.</p>
      *
@@ -170,18 +173,54 @@ public class DisplayRig {
         if (weaponAnchor == null) return;
         if (item == null || item.getType().isAir()) return;
 
-        WeaponDisplayTransform t = WeaponDisplayRegistry.get(item.getType());
+        final WeaponDisplayTransform t = WeaponDisplayRegistry.get(item.getType());
 
         weaponDisplay = (ItemDisplay) mob.getWorld().spawnEntity(
             weaponAnchor.getLocation(), EntityType.ITEM_DISPLAY
         );
         weaponDisplay.setItemStack(item);
-        applyTransform(weaponDisplay, t);
 
-        weaponFollowTask = DisplayUtil.itemDisplayFollowMob(
-            mob, weaponDisplay,
-            t.offsetRight(), t.offsetUp(), t.offsetForward(),
-            Config.Hostile.DISPLAY_TELEPORT_DURATION, 2
+        // Precompute static parts of the user adjustment (these don't change per tick).
+        final Quaternionf userRot = new Quaternionf().rotateXYZ(
+            (float) Math.toRadians(t.rotX()),
+            (float) Math.toRadians(t.rotY()),
+            (float) Math.toRadians(t.rotZ())
+        );
+        final Vector3f userOffset = new Vector3f(t.offsetRight(), t.offsetUp(), t.offsetForward());
+        final float scale = t.scale();
+        final ItemDisplay display = weaponDisplay;
+        final ItemDisplay anchor = weaponAnchor;
+
+        // Each tick: read the anchor's current animated transform (set by DEU) and mirror
+        // it onto our weapon display, then teleport to match the anchor's server-side position.
+        weaponFollowTask = TimeArbiter.runTimeBoundBukkitTaskOnTimer(
+            () -> {
+                if (!anchor.isValid() || !display.isValid()) return;
+
+                Transformation anchorT = anchor.getTransformation();
+
+                // Bone rotation (from DEU animation) composed with user's additional rotation.
+                Quaternionf finalRot = anchorT.getLeftRotation().mul(userRot, new Quaternionf());
+
+                // Bone translation + user's local offset.
+                Vector3f finalTrans = anchorT.getTranslation().add(userOffset, new Vector3f());
+
+                display.setTransformation(new Transformation(
+                    finalTrans,
+                    finalRot,
+                    new Vector3f(scale, scale, scale),
+                    new Quaternionf()
+                ));
+
+                // Sync server-side position so the display follows the mob as it moves.
+                TimeArbiter.teleportDisplay(
+                    display, anchor.getLocation(), null,
+                    Config.Hostile.DISPLAY_TELEPORT_DURATION,
+                    DisplayRig.class, 0
+                );
+            },
+            null, null, 0, 1,
+            DisplayRig.class, "weaponSlotSync"
         );
     }
 
@@ -271,24 +310,6 @@ public class DisplayRig {
             weaponDisplay.remove();
             weaponDisplay = null;
         }
-    }
-
-    /**
-     * Applies a {@link WeaponDisplayTransform}'s rotation and scale to an {@link ItemDisplay}
-     * via its {@link Transformation}. Offset is handled separately by the follow task.
-     */
-    private static void applyTransform(ItemDisplay display, WeaponDisplayTransform t) {
-        Quaternionf rot = new Quaternionf().rotateXYZ(
-            (float) Math.toRadians(t.rotX()),
-            (float) Math.toRadians(t.rotY()),
-            (float) Math.toRadians(t.rotZ())
-        );
-        display.setTransformation(new Transformation(
-            new Vector3f(0, 0, 0),
-            rot,
-            new Vector3f(t.scale(), t.scale(), t.scale()),
-            new Quaternionf()
-        ));
     }
 
     private static void addState(

--- a/src/main/java/btm/sword/system/entity/display/DisplayRig.java
+++ b/src/main/java/btm/sword/system/entity/display/DisplayRig.java
@@ -2,16 +2,23 @@ package btm.sword.system.entity.display;
 
 import java.util.List;
 
+import org.bukkit.Material;
 import org.bukkit.entity.Display;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.ItemDisplay;
 import org.bukkit.entity.Mob;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Transformation;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.Nullable;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
 
 import btm.sword.Sword;
 import btm.sword.config.Config;
+import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.mob.AnimationSlots;
+import btm.sword.utility.display.DisplayUtil;
 import net.donnypz.displayentityutils.events.GroupSpawnedEvent;
 import net.donnypz.displayentityutils.managers.DisplayGroupManager;
 import net.donnypz.displayentityutils.managers.LoadMethod;
@@ -25,13 +32,18 @@ import net.donnypz.displayentityutils.utils.controller.GroupFollowProperties;
 
 /**
  * Visual display rig attached to a {@link Mob}.
- * <p>
- * Wraps a {@link SpawnedDisplayEntityGroup} and a {@link DisplayStateMachine}.
+ *
+ * <p>Wraps a {@link SpawnedDisplayEntityGroup} and a {@link DisplayStateMachine}.
  * The machine automatically transitions between IDLE, WALK, and FALLING states based
  * on the mob's movement. The MELEE state is triggered manually by the AI FSM
  * (see {@link btm.sword.system.entity.ai.state.AttackState}). The DEATH state, when
- * present, is triggered by {@link #triggerDeath()} and plays once before the mob is killed.
- * </p>
+ * present, is triggered by {@link #triggerDeath()} and plays once before the mob is killed.</p>
+ *
+ * <p>Weapon slot display: if the DEU group contains a {@link Material#LIGHTNING_ROD}
+ * {@link ItemDisplay} whose scale is below {@link #WEAPON_SLOT_SCALE_THRESHOLD} on all axes,
+ * that entity is used as the weapon-slot anchor. Call {@link #setWeaponSlotItem(ItemStack)}
+ * to show an item at the mob's hand; the display follows the mob's position and yaw.
+ * Per-material offset/rotation/scale is loaded from {@link WeaponDisplayRegistry}.</p>
  *
  * <p>Call {@link #spawn(Mob, String, AnimationSlots)} to create a rig.
  * Call {@link #despawn()} when the mob dies to clean up entities.</p>
@@ -40,21 +52,37 @@ public class DisplayRig {
 
     /**
      * Scoreboard tag added by {@link btm.sword.listeners.EntityListener} to any
-     * {@link ItemDisplay} that holds a {@link org.bukkit.Material#LIGHTNING_ROD} item at spawn.
-     * Place a LIGHTNING_ROD on the desired display entity part in your DEU group to designate
-     * it as the weapon slot; the runtime item is then swapped via {@link #setWeaponSlotItem}.
+     * {@link ItemDisplay} that holds a {@link Material#LIGHTNING_ROD} item at spawn.
      */
     public static final String WEAPON_SLOT_TAG = "sword_weapon_slot";
 
+    /**
+     * Scale threshold below which all three axes of an {@link ItemDisplay} must fall
+     * for it to be treated as a weapon-slot anchor.
+     */
+    public static final float WEAPON_SLOT_SCALE_THRESHOLD = 0.05f;
+
+    private final Mob mob;
     private final SpawnedDisplayEntityGroup group;
     private final DisplayStateMachine stateMachine;
     /** Non-empty when a die animation was registered; used by the animation-complete listener. */
     private final String dieAnimTag;
 
-    private DisplayRig(SpawnedDisplayEntityGroup group, DisplayStateMachine stateMachine, String dieAnimTag) {
+    /** The tiny LIGHTNING_ROD anchor within the DEU group that marks the main-hand weapon slot. */
+    private final @Nullable ItemDisplay weaponAnchor;
+
+    /** The live item display entity that follows the mob's hand and shows the held item. */
+    private @Nullable ItemDisplay weaponDisplay;
+    /** Task handle for the mob-follow loop; non-null while a weapon is being shown. */
+    private @Nullable TimeArbiter.TaskHandle weaponFollowTask;
+
+    private DisplayRig(Mob mob, SpawnedDisplayEntityGroup group, DisplayStateMachine stateMachine,
+            String dieAnimTag, @Nullable ItemDisplay weaponAnchor) {
+        this.mob = mob;
         this.group = group;
         this.stateMachine = stateMachine;
         this.dieAnimTag = dieAnimTag;
+        this.weaponAnchor = weaponAnchor;
     }
 
     /**
@@ -76,12 +104,11 @@ public class DisplayRig {
         }
 
         SpawnedDisplayEntityGroup group = def.spawn(mob.getLocation(), GroupSpawnedEvent.SpawnReason.CUSTOM);
+        if (group == null) return null;
+
         group.rideEntity(mob);
-        // Offset the rig downward by the mob's height so the rig sits at ground level,
-        // with DISPLAY_RIDE_OFFSET_Y as a fine-tuning knob on top of that.
         group.setRideOffset(new Vector(0, -mob.getHeight() + Config.Hostile.DISPLAY_RIDE_OFFSET_Y, 0));
 
-        // Apply teleport duration to every display part for smooth client-side movement.
         for (Display display : group.getPartEntities(Display.class)) {
             display.setTeleportDuration(Config.Hostile.DISPLAY_TELEPORT_DURATION);
         }
@@ -100,13 +127,62 @@ public class DisplayRig {
         addState(stateMachine, MachineState.StateType.DEATH,   slots.die().tag(),    true);
         stateMachine.addGroup(group);
 
-        return new DisplayRig(group, stateMachine, slots.die().tag() != null ? slots.die().tag() : "");
+        // Find the main-hand weapon-slot anchor: a LIGHTNING_ROD ItemDisplay at near-zero scale.
+        ItemDisplay weaponAnchor = null;
+        for (ItemDisplay id : group.getPartEntities(ItemDisplay.class)) {
+            ItemStack item = id.getItemStack();
+            if (item == null || item.getType() != Material.LIGHTNING_ROD) continue;
+            org.joml.Vector3f scale = id.getTransformation().getScale();
+            if (scale.x < WEAPON_SLOT_SCALE_THRESHOLD
+                    && scale.y < WEAPON_SLOT_SCALE_THRESHOLD
+                    && scale.z < WEAPON_SLOT_SCALE_THRESHOLD) {
+                weaponAnchor = id;
+                break;
+            }
+        }
+
+        String dieTag = slots.die().tag() != null ? slots.die().tag() : "";
+        return new DisplayRig(mob, group, stateMachine, dieTag, weaponAnchor);
     }
+
+    // -----------------------------------------------------------------------
+    // Weapon slot
+
+    /**
+     * Shows the given item at the mob's main-hand weapon slot by spawning an
+     * {@link ItemDisplay} that follows the mob using the transform from
+     * {@link WeaponDisplayRegistry}. Clears any previously displayed item.
+     *
+     * <p>Passing {@code null} or an air stack hides the weapon display.</p>
+     *
+     * @param item the item to display, or {@code null} to clear
+     */
+    public void setWeaponSlotItem(@Nullable ItemStack item) {
+        clearWeaponDisplay();
+
+        if (weaponAnchor == null) return;
+        if (item == null || item.getType().isAir()) return;
+
+        WeaponDisplayTransform t = WeaponDisplayRegistry.get(item.getType());
+
+        weaponDisplay = (ItemDisplay) mob.getWorld().spawnEntity(
+            weaponAnchor.getLocation(), EntityType.ITEM_DISPLAY
+        );
+        weaponDisplay.setItemStack(item);
+        applyTransform(weaponDisplay, t);
+
+        weaponFollowTask = DisplayUtil.itemDisplayFollowMob(
+            mob, weaponDisplay,
+            t.offsetRight(), t.offsetUp(), t.offsetForward(),
+            Config.Hostile.DISPLAY_TELEPORT_DURATION, 2
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // State machine
 
     /**
      * Manually overrides the current animation state.
-     * States registered with {@code transitionLock = true} (e.g. MELEE, DEATH) hold until
-     * the animation completes, then the machine resumes automatic transitions.
      *
      * @param type the state to transition to
      */
@@ -115,8 +191,7 @@ public class DisplayRig {
     }
 
     /**
-     * Triggers the DEATH animation if one was registered. After the animation completes,
-     * DEU fires {@link net.donnypz.displayentityutils.events.AnimationCompleteEvent}.
+     * Triggers the DEATH animation if one was registered.
      * If no die animation was registered this is a no-op.
      */
     public void triggerDeath() {
@@ -125,11 +200,7 @@ public class DisplayRig {
         }
     }
 
-    /**
-     * Returns {@code true} if a die animation was registered for this rig.
-     *
-     * @return whether a DEATH state exists on the state machine
-     */
+    /** Returns {@code true} if a die animation was registered for this rig. */
     public boolean hasDieAnimation() {
         return !dieAnimTag.isEmpty();
     }
@@ -137,62 +208,62 @@ public class DisplayRig {
     /**
      * Returns the DEU animation tag registered for the DEATH state,
      * or an empty string if none was registered.
-     *
-     * @return the die animation tag
      */
     public String dieAnimTag() {
         return dieAnimTag;
     }
 
-    /**
-     * Returns the underlying {@link SpawnedDisplayEntityGroup}.
-     *
-     * @return the spawned group
-     */
+    /** Returns the underlying {@link SpawnedDisplayEntityGroup}. */
     public SpawnedDisplayEntityGroup group() {
         return group;
     }
 
-    /**
-     * Returns the weapon-slot {@link ItemDisplay} inside this rig — the part entity whose
-     * scale was near-zero at spawn time and was tagged with {@link #WEAPON_SLOT_TAG} by
-     * {@link btm.sword.listeners.EntityListener}.
-     *
-     * @return the tagged item display, or {@code null} if none was found in the group
-     */
-    public @Nullable ItemDisplay getWeaponSlot() {
-        for (ItemDisplay display : group.getPartEntities(ItemDisplay.class)) {
-            if (display.getScoreboardTags().contains(WEAPON_SLOT_TAG)) return display;
-        }
-        return null;
-    }
-
-    /**
-     * Sets the item shown by the weapon-slot display entity.
-     * Does nothing if this rig has no weapon slot.
-     *
-     * @param item the item to display; {@code null} or air clears the slot
-     */
-    public void setWeaponSlotItem(@Nullable ItemStack item) {
-        ItemDisplay slot = getWeaponSlot();
-        if (slot != null) slot.setItemStack(item);
-    }
+    // -----------------------------------------------------------------------
+    // Lifecycle
 
     /**
      * Removes the spawned group from the world and unregisters the state machine.
      * Must be called when the mob dies or is removed.
      */
     public void despawn() {
+        clearWeaponDisplay();
         stateMachine.removeGroup(group);
         group.unregister(true, true);
     }
 
+    // -----------------------------------------------------------------------
+    // Private helpers
+
+    /** Cancels the follow task and removes the weapon display entity. */
+    private void clearWeaponDisplay() {
+        if (weaponFollowTask != null) {
+            weaponFollowTask.cancel();
+            weaponFollowTask = null;
+        }
+        if (weaponDisplay != null && weaponDisplay.isValid()) {
+            weaponDisplay.remove();
+            weaponDisplay = null;
+        }
+    }
+
     /**
-     * Registers a {@link MachineState} in the machine if {@code animTag} is non-empty.
-     * Looping states use {@link DisplayAnimator.AnimationType#LOOP};
-     * locked states use {@link DisplayAnimator.AnimationType#LINEAR} so DEU knows when
-     * the animation ends and can release the transition lock.
+     * Applies a {@link WeaponDisplayTransform}'s rotation and scale to an {@link ItemDisplay}
+     * via its {@link Transformation}. Offset is handled separately by the follow task.
      */
+    private static void applyTransform(ItemDisplay display, WeaponDisplayTransform t) {
+        Quaternionf rot = new Quaternionf().rotateXYZ(
+            (float) Math.toRadians(t.rotX()),
+            (float) Math.toRadians(t.rotY()),
+            (float) Math.toRadians(t.rotZ())
+        );
+        display.setTransformation(new Transformation(
+            new Vector3f(0, 0, 0),
+            rot,
+            new Vector3f(t.scale(), t.scale(), t.scale()),
+            new Quaternionf()
+        ));
+    }
+
     private static void addState(
             DisplayStateMachine machine,
             MachineState.StateType type,

--- a/src/main/java/btm/sword/system/entity/display/DisplayRig.java
+++ b/src/main/java/btm/sword/system/entity/display/DisplayRig.java
@@ -68,6 +68,13 @@ public class DisplayRig {
     /** Non-empty when a die animation was registered; used by the animation-complete listener. */
     private final String dieAnimTag;
 
+    /**
+     * Set to {@code true} by {@link #lockOnDeath()} once the death sequence begins.
+     * Any subsequent {@link #setState} calls are silently dropped so the DEATH
+     * animation cannot be interrupted or replaced.
+     */
+    private boolean isDying;
+
     /** The tiny LIGHTNING_ROD anchor within the DEU group that marks the main-hand weapon slot. */
     private final @Nullable ItemDisplay weaponAnchor;
 
@@ -183,10 +190,12 @@ public class DisplayRig {
 
     /**
      * Manually overrides the current animation state.
+     * No-op if the rig is locked in the death animation ({@link #lockOnDeath()} was called).
      *
      * @param type the state to transition to
      */
     public void setState(MachineState.StateType type) {
+        if (isDying) return;
         stateMachine.setState(type, group);
     }
 
@@ -198,6 +207,24 @@ public class DisplayRig {
         if (!dieAnimTag.isEmpty()) {
             stateMachine.setState(MachineState.StateType.DEATH, group);
         }
+    }
+
+    /**
+     * Freezes the rig in place and locks all subsequent animation state changes.
+     *
+     * <p>Called when the mob enters its death sequence. After this:</p>
+     * <ul>
+     *   <li>The group stops riding the mob — its server-side position is frozen
+     *       at the point of death regardless of mob movement or gravity.</li>
+     *   <li>The yaw follow is cancelled.</li>
+     *   <li>{@link #setState} becomes a permanent no-op, preventing the state
+     *       machine from transitioning away from DEATH.</li>
+     * </ul>
+     */
+    public void lockOnDeath() {
+        isDying = true;
+        group.dismount();
+        group.stopFollowingEntity();
     }
 
     /** Returns {@code true} if a die animation was registered for this rig. */

--- a/src/main/java/btm/sword/system/entity/display/DisplayRig.java
+++ b/src/main/java/btm/sword/system/entity/display/DisplayRig.java
@@ -39,18 +39,12 @@ import net.donnypz.displayentityutils.utils.controller.GroupFollowProperties;
 public class DisplayRig {
 
     /**
-     * Scoreboard tag added to any {@link ItemDisplay} whose scale is below this threshold
-     * on all axes at spawn time. Used to identify the weapon-slot display entity inside
-     * a DEU group so external code can control what item it shows.
+     * Scoreboard tag added by {@link btm.sword.listeners.EntityListener} to any
+     * {@link ItemDisplay} that holds a {@link org.bukkit.Material#LIGHTNING_ROD} item at spawn.
+     * Place a LIGHTNING_ROD on the desired display entity part in your DEU group to designate
+     * it as the weapon slot; the runtime item is then swapped via {@link #setWeaponSlotItem}.
      */
     public static final String WEAPON_SLOT_TAG = "sword_weapon_slot";
-
-    /**
-     * Scale threshold below which an {@link ItemDisplay} is treated as a weapon slot.
-     * Set the display entity's scale to near-zero (e.g. {@code 0.001}) in your DEU group
-     * to mark it for capture.
-     */
-    public static final float WEAPON_SLOT_SCALE_THRESHOLD = 0.05f;
 
     private final SpawnedDisplayEntityGroup group;
     private final DisplayStateMachine stateMachine;

--- a/src/main/java/btm/sword/system/entity/display/DisplayRig.java
+++ b/src/main/java/btm/sword/system/entity/display/DisplayRig.java
@@ -3,12 +3,15 @@ package btm.sword.system.entity.display;
 import java.util.List;
 
 import org.bukkit.entity.Display;
+import org.bukkit.entity.ItemDisplay;
 import org.bukkit.entity.Mob;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.Nullable;
 
 import btm.sword.Sword;
 import btm.sword.config.Config;
+import btm.sword.system.entity.mob.AnimationSlots;
 import net.donnypz.displayentityutils.events.GroupSpawnedEvent;
 import net.donnypz.displayentityutils.managers.DisplayGroupManager;
 import net.donnypz.displayentityutils.managers.LoadMethod;
@@ -26,31 +29,50 @@ import net.donnypz.displayentityutils.utils.controller.GroupFollowProperties;
  * Wraps a {@link SpawnedDisplayEntityGroup} and a {@link DisplayStateMachine}.
  * The machine automatically transitions between IDLE, WALK, and FALLING states based
  * on the mob's movement. The MELEE state is triggered manually by the AI FSM
- * (see {@link btm.sword.system.entity.ai.state.AttackState}).
+ * (see {@link btm.sword.system.entity.ai.state.AttackState}). The DEATH state, when
+ * present, is triggered by {@link #triggerDeath()} and plays once before the mob is killed.
  * </p>
  *
- * <p>To spawn a rig for a mob, call {@link #spawn(Mob, String)} with the mob and
- * the DEU group tag. Call {@link #despawn()} when the mob dies to clean up entities.</p>
+ * <p>Call {@link #spawn(Mob, String, AnimationSlots)} to create a rig.
+ * Call {@link #despawn()} when the mob dies to clean up entities.</p>
  */
 public class DisplayRig {
 
+    /**
+     * Scoreboard tag added to any {@link ItemDisplay} whose scale is below this threshold
+     * on all axes at spawn time. Used to identify the weapon-slot display entity inside
+     * a DEU group so external code can control what item it shows.
+     */
+    public static final String WEAPON_SLOT_TAG = "sword_weapon_slot";
+
+    /**
+     * Scale threshold below which an {@link ItemDisplay} is treated as a weapon slot.
+     * Set the display entity's scale to near-zero (e.g. {@code 0.001}) in your DEU group
+     * to mark it for capture.
+     */
+    public static final float WEAPON_SLOT_SCALE_THRESHOLD = 0.05f;
+
     private final SpawnedDisplayEntityGroup group;
     private final DisplayStateMachine stateMachine;
+    /** Non-empty when a die animation was registered; used by the animation-complete listener. */
+    private final String dieAnimTag;
 
-    private DisplayRig(SpawnedDisplayEntityGroup group, DisplayStateMachine stateMachine) {
+    private DisplayRig(SpawnedDisplayEntityGroup group, DisplayStateMachine stateMachine, String dieAnimTag) {
         this.group = group;
         this.stateMachine = stateMachine;
+        this.dieAnimTag = dieAnimTag;
     }
 
     /**
-     * Spawns a display rig for the given mob using the named DEU group tag.
-     * Returns {@code null} if the group cannot be found in DEU's local storage.
+     * Spawns a display rig for the given mob using the named DEU group tag and per-type
+     * animation slots.
      *
      * @param mob      the mob to attach the rig to
      * @param groupTag the DEU group tag to spawn
-     * @return the new rig, or {@code null} on failure
+     * @param slots    the animation slot tags to register on the state machine
+     * @return the new rig, or {@code null} if the group cannot be found in DEU's local storage
      */
-    public static @Nullable DisplayRig spawn(Mob mob, String groupTag) {
+    public static @Nullable DisplayRig spawn(Mob mob, String groupTag, AnimationSlots slots) {
         DisplayEntityGroup def = DisplayGroupManager.getGroup(LoadMethod.LOCAL, groupTag);
         if (def == null) {
             Sword.getInstance().getLogger().warning(
@@ -77,24 +99,89 @@ public class DisplayRig {
         group.followEntityDirection(mob, yawFollow);
 
         DisplayStateMachine stateMachine = new DisplayStateMachine(mob.getUniqueId() + "_rig");
-        addState(stateMachine, MachineState.StateType.IDLE, Config.Hostile.DISPLAY_ANIM_IDLE, false);
-        addState(stateMachine, MachineState.StateType.WALK, Config.Hostile.DISPLAY_ANIM_WALK, false);
-        addState(stateMachine, MachineState.StateType.FALLING, Config.Hostile.DISPLAY_ANIM_FALL, false);
-        addState(stateMachine, MachineState.StateType.MELEE, Config.Hostile.DISPLAY_ANIM_MELEE, true);
+        addState(stateMachine, MachineState.StateType.IDLE,    slots.idle().tag(),   false);
+        addState(stateMachine, MachineState.StateType.WALK,    slots.walk().tag(),   false);
+        addState(stateMachine, MachineState.StateType.FALLING, slots.fall().tag(),   false);
+        addState(stateMachine, MachineState.StateType.MELEE,   slots.attack().tag(), true);
+        addState(stateMachine, MachineState.StateType.DEATH,   slots.die().tag(),    true);
         stateMachine.addGroup(group);
 
-        return new DisplayRig(group, stateMachine);
+        return new DisplayRig(group, stateMachine, slots.die().tag() != null ? slots.die().tag() : "");
     }
 
     /**
      * Manually overrides the current animation state.
-     * States registered with {@code transitionLock = true} (e.g. MELEE) hold until
+     * States registered with {@code transitionLock = true} (e.g. MELEE, DEATH) hold until
      * the animation completes, then the machine resumes automatic transitions.
      *
      * @param type the state to transition to
      */
     public void setState(MachineState.StateType type) {
         stateMachine.setState(type, group);
+    }
+
+    /**
+     * Triggers the DEATH animation if one was registered. After the animation completes,
+     * DEU fires {@link net.donnypz.displayentityutils.events.AnimationCompleteEvent}.
+     * If no die animation was registered this is a no-op.
+     */
+    public void triggerDeath() {
+        if (!dieAnimTag.isEmpty()) {
+            stateMachine.setState(MachineState.StateType.DEATH, group);
+        }
+    }
+
+    /**
+     * Returns {@code true} if a die animation was registered for this rig.
+     *
+     * @return whether a DEATH state exists on the state machine
+     */
+    public boolean hasDieAnimation() {
+        return !dieAnimTag.isEmpty();
+    }
+
+    /**
+     * Returns the DEU animation tag registered for the DEATH state,
+     * or an empty string if none was registered.
+     *
+     * @return the die animation tag
+     */
+    public String dieAnimTag() {
+        return dieAnimTag;
+    }
+
+    /**
+     * Returns the underlying {@link SpawnedDisplayEntityGroup}.
+     *
+     * @return the spawned group
+     */
+    public SpawnedDisplayEntityGroup group() {
+        return group;
+    }
+
+    /**
+     * Returns the weapon-slot {@link ItemDisplay} inside this rig — the part entity whose
+     * scale was near-zero at spawn time and was tagged with {@link #WEAPON_SLOT_TAG} by
+     * {@link btm.sword.listeners.EntityListener}.
+     *
+     * @return the tagged item display, or {@code null} if none was found in the group
+     */
+    public @Nullable ItemDisplay getWeaponSlot() {
+        for (ItemDisplay display : group.getPartEntities(ItemDisplay.class)) {
+            if (display.getScoreboardTags().contains(WEAPON_SLOT_TAG)) return display;
+        }
+        return null;
+    }
+
+    /**
+     * Sets the item shown by the weapon-slot display entity.
+     * Does nothing if this rig has no weapon slot.
+     *
+     * @param item the item to display; {@code null} or air clears the slot
+     */
+    public void setWeaponSlotItem(@Nullable ItemStack item) {
+        ItemDisplay slot = getWeaponSlot();
+        if (slot != null) slot.setItemStack(item);
     }
 
     /**

--- a/src/main/java/btm/sword/system/entity/display/WeaponAnchorPacketHook.java
+++ b/src/main/java/btm/sword/system/entity/display/WeaponAnchorPacketHook.java
@@ -1,0 +1,213 @@
+package btm.sword.system.entity.display;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.bukkit.entity.ItemDisplay;
+import org.bukkit.inventory.ItemStack;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.utility.MinecraftReflection;
+import com.comphenix.protocol.wrappers.Vector3F;
+import com.comphenix.protocol.wrappers.WrappedDataValue;
+
+import btm.sword.Sword;
+import btm.sword.utility.Debug;
+
+/**
+ * ProtocolLib-based final-authority override for weapon-slot anchor {@link ItemDisplay} entities.
+ *
+ * <p>Registers a {@code ENTITY_METADATA} packet listener that intercepts outgoing metadata
+ * for any tracked anchor and forces the desired item, scale, translation, and rotation before
+ * the packet reaches any client. This hook owns five indices:</p>
+ * <ul>
+ *   <li>Index 11 — translation ({@code Vector3f}): DEU's animated value is preserved and the
+ *       per-material translation offset is added on top.</li>
+ *   <li>Index 12 — scale ({@code Vector3f}): forced to the configured weapon scale.</li>
+ *   <li>Index 13 — left rotation ({@code Quaternionf}): composed with a per-material rotation
+ *       offset on top of whatever DEU provides.</li>
+ *   <li>Index 14 — right rotation ({@code Quaternionf}): forced to identity.</li>
+ *   <li>Index 23 — item ({@code ItemStack}): forced to the weapon item (or AIR when hidden).</li>
+ * </ul>
+ *
+ * <p>This means DEU can reset the item, change the scale, or do anything else server-side —
+ * none of it reaches clients while an override is active.</p>
+ *
+ * <p>Call {@link #register()} once at plugin startup.
+ * Call {@link #override} when a weapon is equipped and {@link #clear} when it is removed.</p>
+ */
+public final class WeaponAnchorPacketHook {
+
+    // Display entity metadata indices — stable since 1.19.4 through 1.21.x.
+    /** Index 8: interpolation start delta ticks (int) on {@link org.bukkit.entity.Display}. */
+    private static final int INDEX_INTERPOLATION_DELAY = 8;
+    /** Index 9: transformation interpolation duration (int) on {@link org.bukkit.entity.Display}. */
+    private static final int INDEX_INTERPOLATION_DURATION = 9;
+
+    private static final int INDEX_TRANSLATION = 11;
+    /** Index 12: uniform scale {@code Vector3f} on {@link org.bukkit.entity.Display}. */
+    private static final int INDEX_SCALE = 12;
+    /** Index 13: left rotation {@code Quaternionf} on {@link org.bukkit.entity.Display}. */
+    private static final int INDEX_LEFT_ROTATION = 13;
+    /** Index 14: right rotation {@code Quaternionf} on {@link org.bukkit.entity.Display}. */
+    private static final int INDEX_RIGHT_ROTATION = 14;
+    /** Index 23: displayed item on {@link ItemDisplay}. */
+    private static final int INDEX_ITEM = 23;
+
+    /**
+     * Active overrides keyed by entity ID (int, not UUID) for O(1) lookup on the hot packet path.
+     * {@link ConcurrentHashMap} because {@code onPacketSending} runs on ProtocolLib's async I/O thread.
+     */
+    private static final Map<Integer, OverrideState> OVERRIDES = new ConcurrentHashMap<>();
+
+    /**
+     * Immutable snapshot of what a weapon-slot anchor should display.
+     *
+     * @param nmsItem          pre-converted NMS {@code ItemStack} (avoids per-packet Bukkit→NMS conversion)
+     * @param scale            uniform weapon scale
+     * @param rotOffset        additional rotation right-multiplied onto DEU's animated left rotation
+     * @param translationOffset per-material offset added on top of DEU's animated bone translation
+     */
+    record OverrideState(Object nmsItem, float scale, Quaternionf rotOffset, Vector3f translationOffset) { }
+
+    /**
+     * Registers the {@code ENTITY_METADATA} packet listener with ProtocolLib.
+     * Must be called once during plugin startup, before any mobs are spawned.
+     */
+    public static void register() {
+        ProtocolLibrary.getProtocolManager().addPacketListener(
+            new PacketAdapter(Sword.getInstance(), ListenerPriority.HIGHEST,
+                PacketType.Play.Server.ENTITY_METADATA) {
+                @Override
+                public void onPacketSending(PacketEvent event) {
+                    int entityId = event.getPacket().getIntegers().read(0);
+                    OverrideState state = OVERRIDES.get(entityId);
+                    if (state == null) return;
+
+                    List<WrappedDataValue> metadata =
+                        event.getPacket().getDataValueCollectionModifier().read(0);
+                    if (metadata == null) return;
+
+                    boolean touched = false;
+                    for (WrappedDataValue entry : metadata) {
+                        switch (entry.getIndex()) {
+                            case INDEX_INTERPOLATION_DELAY -> {
+                                // Force zero so our transformations apply immediately —
+                                // prevents DEU's per-frame interpolation setup from causing
+                                // the client to blend toward a previous near-zero-scale state.
+                                entry.setValue(0);
+                                touched = true;
+                            }
+                            case INDEX_INTERPOLATION_DURATION -> {
+                                entry.setValue(0);
+                                touched = true;
+                            }
+                            case INDEX_TRANSLATION -> {
+                                Object raw = entry.getValue();
+
+                                if (raw instanceof Vector3F v) {
+                                    Vector3f base = new Vector3f(v.getX(), v.getY(), v.getZ());
+
+                                    Vector3f finalPos = base.add(new Vector3f(1, 1, 1)); // <-- YOU control this
+
+                                    entry.setValue(new Vector3F(finalPos.x, finalPos.y, finalPos.z));
+                                    touched = true;
+                                } else if (raw instanceof Vector3f v) {
+                                    Vector3f finalPos = new Vector3f(v).add(new Vector3f(1, 1, 1));
+
+                                    entry.setValue(finalPos);
+                                    touched = true;
+                                }
+                            }
+                            case INDEX_SCALE -> {
+                                Object cur = entry.getValue();
+                                float s = state.scale();
+                                if (cur instanceof Vector3F) {
+                                    entry.setValue(new Vector3F(s, s, s));
+                                } else {
+                                    entry.setValue(new Vector3f(s, s, s));
+                                }
+                                Debug.animation("PacketHook scale: entity=" + entityId
+                                    + " type=" + (cur != null ? cur.getClass().getSimpleName() : "null")
+                                    + " -> " + s);
+                                touched = true;
+                            }
+                            case INDEX_LEFT_ROTATION -> {
+                                Object raw = entry.getValue();
+                                if (raw instanceof Quaternionf deuRot) {
+                                    entry.setValue(new Quaternionf(deuRot).mul(state.rotOffset()));
+                                }
+                                Debug.animation("PacketHook rot: entity=" + entityId
+                                    + " type=" + (raw != null ? raw.getClass().getSimpleName() : "null"));
+                                touched = true;
+                            }
+                            case INDEX_RIGHT_ROTATION -> {
+                                // Force identity — right rotation is unused for weapon display.
+                                entry.setValue(new Quaternionf());
+                                touched = true;
+                            }
+                            case INDEX_ITEM -> {
+                                entry.setValue(state.nmsItem());
+                                touched = true;
+                            }
+                            default -> { }
+                        }
+                    }
+
+                    if (touched) {
+                        // Log ALL indices in this packet so we can see exactly what DEU sends.
+                        StringBuilder indices = new StringBuilder();
+                        for (WrappedDataValue e : metadata) {
+                            indices.append(e.getIndex()).append(' ');
+                        }
+                        Debug.animation("PacketHook: overrode entity=" + entityId
+                            + " entries=" + metadata.size() + " indices=[" + indices.toString().trim() + "]");
+                    }
+                }
+            }
+        );
+    }
+
+    /**
+     * Begins overriding all outgoing metadata for the given anchor entity.
+     *
+     * <p>The NMS item is pre-converted at registration time to avoid per-packet conversion cost.
+     * Any metadata DEU sends for this entity (transformation resets, item resets, etc.) will be
+     * silently overridden before reaching clients.</p>
+     *
+     * @param anchor            the weapon-slot anchor {@link ItemDisplay}
+     * @param item              the item to display (must not be AIR; use {@link #clear} to hide)
+     * @param scale             uniform scale for the weapon
+     * @param rotOffset         additional rotation composited onto DEU's animated bone rotation
+     * @param translationOffset per-material offset added on top of DEU's animated bone translation
+     */
+    public static void override(ItemDisplay anchor, ItemStack item, float scale,
+            Quaternionf rotOffset, Vector3f translationOffset) {
+        Object nmsItem = MinecraftReflection.getMinecraftItemStack(item);
+        OVERRIDES.put(anchor.getEntityId(), new OverrideState(nmsItem, scale, rotOffset, translationOffset));
+        Debug.animation("PacketHook: override registered entity=" + anchor.getEntityId()
+            + " item=" + item.getType() + " scale=" + scale);
+    }
+
+    /**
+     * Stops overriding metadata for the given anchor, returning full control to DEU.
+     *
+     * <p><strong>Must be called before</strong> any cleanup {@code setItemStack} or
+     * {@code setTransformation} calls so those server-side packets reach clients unintercepted.</p>
+     *
+     * @param anchor the anchor to release
+     */
+    public static void clear(ItemDisplay anchor) {
+        OVERRIDES.remove(anchor.getEntityId());
+        Debug.animation("PacketHook: override cleared entity=" + anchor.getEntityId());
+    }
+
+    private WeaponAnchorPacketHook() { }
+}

--- a/src/main/java/btm/sword/system/entity/display/WeaponDisplayRegistry.java
+++ b/src/main/java/btm/sword/system/entity/display/WeaponDisplayRegistry.java
@@ -1,0 +1,176 @@
+package btm.sword.system.entity.display;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import btm.sword.Sword;
+
+/**
+ * Registry for per-material {@link WeaponDisplayTransform} entries loaded from
+ * {@code weapon_display.yml}.
+ *
+ * <p>Call {@link #initialize(JavaPlugin)} once during {@code Sword.onEnable()}.
+ * Hot-reloads call {@link #reload()}; the dev menu editor calls {@link #set} and
+ * {@link #save()} to persist in-session tweaks back to disk.</p>
+ *
+ * <h2>YAML format</h2>
+ * <pre>
+ * materials:
+ *   IRON_SWORD:
+ *     offset_right:   0.3
+ *     offset_up:      1.4
+ *     offset_forward: 0.1
+ *     rot_x:  0.0
+ *     rot_y: 45.0
+ *     rot_z:  0.0
+ *     scale:  1.0
+ * </pre>
+ */
+public class WeaponDisplayRegistry {
+
+    private static final String FILE_NAME = "weapon_display.yml";
+    private static Map<Material, WeaponDisplayTransform> transforms = new EnumMap<>(Material.class);
+    private static JavaPlugin plugin;
+
+    private WeaponDisplayRegistry() {}
+
+    /**
+     * Initialises the registry from {@code weapon_display.yml}, copying the bundled default
+     * if the file does not yet exist.
+     *
+     * @param javaPlugin the owning plugin instance
+     */
+    public static void initialize(JavaPlugin javaPlugin) {
+        plugin = javaPlugin;
+        saveDefaultIfAbsent();
+        reload();
+    }
+
+    /**
+     * Re-parses {@code weapon_display.yml} without restarting the server.
+     */
+    public static void reload() {
+        File file = new File(plugin.getDataFolder(), FILE_NAME);
+        if (!file.exists()) {
+            transforms = new EnumMap<>(Material.class);
+            return;
+        }
+
+        YamlConfiguration yaml = YamlConfiguration.loadConfiguration(file);
+        Map<Material, WeaponDisplayTransform> loaded = new EnumMap<>(Material.class);
+
+        ConfigurationSection materialsSection = yaml.getConfigurationSection("materials");
+        if (materialsSection != null) {
+            for (String matName : materialsSection.getKeys(false)) {
+                Material mat;
+                try {
+                    mat = Material.valueOf(matName.toUpperCase());
+                } catch (IllegalArgumentException e) {
+                    Sword.getInstance().getLogger().warning(
+                        "[WeaponDisplayRegistry] Unknown material '" + matName + "' — skipping."
+                    );
+                    continue;
+                }
+                ConfigurationSection s = materialsSection.getConfigurationSection(matName);
+                if (s == null) continue;
+
+                loaded.put(mat, new WeaponDisplayTransform(
+                    (float) s.getDouble("offset_right",   0),
+                    (float) s.getDouble("offset_up",      0),
+                    (float) s.getDouble("offset_forward", 0),
+                    (float) s.getDouble("rot_x",  0),
+                    (float) s.getDouble("rot_y",  0),
+                    (float) s.getDouble("rot_z",  0),
+                    (float) s.getDouble("scale",  1.0)
+                ));
+            }
+        }
+
+        transforms = loaded;
+        Sword.getInstance().getLogger().info(
+            "[WeaponDisplayRegistry] Loaded " + transforms.size() + " material transform(s)."
+        );
+    }
+
+    /**
+     * Returns the transform for the given material, or {@link WeaponDisplayTransform#DEFAULT}
+     * if none is configured.
+     *
+     * @param material the item material
+     * @return the registered transform or DEFAULT
+     */
+    public static WeaponDisplayTransform get(Material material) {
+        return transforms.getOrDefault(material, WeaponDisplayTransform.DEFAULT);
+    }
+
+    /**
+     * Updates the in-memory transform for a material.
+     * Call {@link #save()} afterwards to persist the change.
+     *
+     * @param material  the material key
+     * @param transform the new transform
+     */
+    public static void set(Material material, WeaponDisplayTransform transform) {
+        Map<Material, WeaponDisplayTransform> mutable = new EnumMap<>(transforms);
+        mutable.put(material, transform);
+        transforms = mutable;
+    }
+
+    /**
+     * Writes all current in-memory transforms back to {@code weapon_display.yml}.
+     */
+    public static void save() {
+        File file = new File(plugin.getDataFolder(), FILE_NAME);
+        YamlConfiguration yaml = new YamlConfiguration();
+
+        for (Map.Entry<Material, WeaponDisplayTransform> entry : transforms.entrySet()) {
+            String base = "materials." + entry.getKey().name();
+            WeaponDisplayTransform t = entry.getValue();
+            yaml.set(base + ".offset_right",   (double) t.offsetRight());
+            yaml.set(base + ".offset_up",       (double) t.offsetUp());
+            yaml.set(base + ".offset_forward",  (double) t.offsetForward());
+            yaml.set(base + ".rot_x",  (double) t.rotX());
+            yaml.set(base + ".rot_y",  (double) t.rotY());
+            yaml.set(base + ".rot_z",  (double) t.rotZ());
+            yaml.set(base + ".scale",  (double) t.scale());
+        }
+
+        try {
+            yaml.save(file);
+        } catch (IOException e) {
+            Sword.getInstance().getLogger().warning(
+                "[WeaponDisplayRegistry] Failed to save weapon_display.yml: " + e.getMessage()
+            );
+        }
+    }
+
+    // -------------------------------------------------------
+
+    private static void saveDefaultIfAbsent() {
+        File file = new File(plugin.getDataFolder(), FILE_NAME);
+        if (file.exists()) return;
+        try (InputStream in = plugin.getResource(FILE_NAME)) {
+            if (in == null) {
+                Sword.getInstance().getLogger().warning(
+                    "[WeaponDisplayRegistry] No bundled weapon_display.yml found in jar."
+                );
+                return;
+            }
+            file.getParentFile().mkdirs();
+            Files.copy(in, file.toPath());
+        } catch (IOException e) {
+            Sword.getInstance().getLogger().warning(
+                "[WeaponDisplayRegistry] Failed to save default weapon_display.yml: " + e.getMessage()
+            );
+        }
+    }
+}

--- a/src/main/java/btm/sword/system/entity/display/WeaponDisplayTransform.java
+++ b/src/main/java/btm/sword/system/entity/display/WeaponDisplayTransform.java
@@ -1,0 +1,26 @@
+package btm.sword.system.entity.display;
+
+/**
+ * Configurable transform applied to the weapon-slot {@link org.bukkit.entity.ItemDisplay}
+ * that follows a display-rig mob's main hand.
+ *
+ * <p>Offsets are in the mob's local coordinate frame (right/up/forward), rotations are
+ * Euler angles in degrees, and scale is uniform.</p>
+ *
+ * @param offsetRight   world-right offset relative to the mob's facing (positive = mob's right)
+ * @param offsetUp      vertical offset (positive = up)
+ * @param offsetForward forward offset relative to the mob's facing (positive = in front)
+ * @param rotX          local X-axis rotation in degrees
+ * @param rotY          local Y-axis rotation in degrees
+ * @param rotZ          local Z-axis rotation in degrees
+ * @param scale         uniform scale applied to the item display
+ */
+public record WeaponDisplayTransform(
+        float offsetRight, float offsetUp, float offsetForward,
+        float rotX, float rotY, float rotZ,
+        float scale) {
+
+    /** Default transform: no offset, no rotation, scale 1. */
+    public static final WeaponDisplayTransform DEFAULT =
+        new WeaponDisplayTransform(0, 0, 0, 0, 0, 0, 1.0f);
+}

--- a/src/main/java/btm/sword/system/entity/impl/Hostile.java
+++ b/src/main/java/btm/sword/system/entity/impl/Hostile.java
@@ -12,12 +12,13 @@ import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Mob;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
 
 import com.destroystokyo.paper.entity.Pathfinder;
@@ -86,6 +87,13 @@ public class Hostile extends Combatant {
     /** Visual display rig; {@code null} when the group tag is unset or the group is not found. */
     @Getter private DisplayRig displayRig;
 
+    /**
+     * {@code true} when this mob's visuals are driven by a DEU display rig rather than vanilla
+     * equipment rendering. Vanilla gear is stripped on construction; items are shown via the rig's
+     * weapon slot display entity instead.
+     */
+    @Getter private boolean usesDisplayRig;
+
     /** {@code true} while the death animation is playing — defers the Bukkit kill. */
     @Getter private boolean inDeathAnimation;
     private WanderProfile wanderProfile = WanderProfile.ROAMER;
@@ -150,16 +158,26 @@ public class Hostile extends Combatant {
         possibleAbilities.add(new MobSlashAbility());
         possibleAbilities.add(new MobThrowAbility());
 
+        MobTypeDefinition mobTypeDef = MobTypeRegistry.getByEntityType(associatedEntity.getType());
+        usesDisplayRig = mobTypeDef != null && mobTypeDef.displayGroup() != null;
+
         EntityEquipment equipment = associatedEntity.getEquipment();
         if (equipment != null) {
-            if (associatedEntity.getType() == EntityType.PILLAGER) {
-                // Zombie is driven by the display rig — strip all vanilla gear so nothing shows.
+            if (usesDisplayRig) {
+                // Rig drives visuals — strip all vanilla gear so nothing bleeds through.
                 equipment.setItemInMainHand(ItemStack.of(Material.AIR));
                 equipment.setItemInOffHand(ItemStack.of(Material.AIR));
                 equipment.setHelmet(ItemStack.of(Material.AIR));
                 equipment.setChestplate(ItemStack.of(Material.AIR));
                 equipment.setLeggings(ItemStack.of(Material.AIR));
                 equipment.setBoots(ItemStack.of(Material.AIR));
+
+                self.clearActivePotionEffects();
+                self.addPotionEffect(new PotionEffect(
+                    PotionEffectType.SLOWNESS,
+                    PotionEffect.INFINITE_DURATION,
+                    2,
+                    false, false));
             } else {
                 equipment.setItemInMainHand(itemInRightHand);
                 equipment.setItemInOffHand(itemInLeftHand);
@@ -199,6 +217,9 @@ public class Hostile extends Combatant {
                     if (mob.isValid()) {
                         mob.setInvisible(true);
                         displayRig = DisplayRig.spawn(mob, type.displayGroup(), type.animationSlots());
+                        if (displayRig != null) {
+                            displayRig.setWeaponSlotItem(itemInRightHand);
+                        }
                     }
                 },
                 50, TimeUnit.MILLISECONDS
@@ -346,6 +367,35 @@ public class Hostile extends Combatant {
                 entry.setValue(remaining);
             }
         }
+    }
+
+    /**
+     * Returns the item this mob can throw.
+     * <p>
+     * For display-rig mobs the logical item is tracked in {@link #itemInRightHand} because
+     * vanilla equipment is stripped to AIR; for normal mobs, returns whatever is in the
+     * vanilla main hand via {@link #getItemStackInHand(boolean)}.
+     *
+     * @return the throwable item, or the current main-hand item for non-rig mobs
+     */
+    public ItemStack getThrowableItem() {
+        return usesDisplayRig ? itemInRightHand : getItemStackInHand(true);
+    }
+
+    /**
+     * Clears the weapon-slot display when this mob has thrown its main-hand item.
+     * No-op if no display rig is present.
+     */
+    public void onWeaponThrown() {
+        if (displayRig != null) displayRig.setWeaponSlotItem(null);
+    }
+
+    /**
+     * Restores the weapon-slot display when this mob retrieves its thrown item.
+     * No-op if no display rig is present.
+     */
+    public void onWeaponRetrieved() {
+        if (displayRig != null) displayRig.setWeaponSlotItem(itemInRightHand);
     }
 
     public Location getOrigin() {

--- a/src/main/java/btm/sword/system/entity/impl/Hostile.java
+++ b/src/main/java/btm/sword/system/entity/impl/Hostile.java
@@ -383,6 +383,17 @@ public class Hostile extends Combatant {
     }
 
     /**
+     * Called by {@link btm.sword.system.entity.ai.state.RetrieveWeaponState} when the mob
+     * reclaims its thrown weapon. The default behaviour equips the item to the mob's vanilla
+     * main hand. Display-rig subclasses override this to update only the rig weapon slot.
+     *
+     * @param item the recovered item stack
+     */
+    public void receiveRetrievedWeapon(ItemStack item) {
+        setItemStackInHand(item, true);
+    }
+
+    /**
      * Clears the weapon-slot display when this mob has thrown its main-hand item.
      * No-op if no display rig is present.
      */

--- a/src/main/java/btm/sword/system/entity/impl/Hostile.java
+++ b/src/main/java/btm/sword/system/entity/impl/Hostile.java
@@ -23,7 +23,6 @@ import org.bukkit.util.Vector;
 import com.destroystokyo.paper.entity.Pathfinder;
 import com.destroystokyo.paper.entity.ai.GoalType;
 
-import btm.sword.config.Config;
 import btm.sword.system.action.throwing.types.DroppedItem;
 import btm.sword.system.action.throwing.types.ThrownItem;
 import btm.sword.system.control.SwordScheduler;
@@ -39,6 +38,8 @@ import btm.sword.system.entity.aspect.Resource;
 import btm.sword.system.entity.base.CombatProfile;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.display.DisplayRig;
+import btm.sword.system.entity.mob.MobTypeDefinition;
+import btm.sword.system.entity.mob.MobTypeRegistry;
 import btm.sword.system.item.weapon.WeaponType;
 import btm.sword.utility.Debug;
 import lombok.Getter;
@@ -84,6 +85,9 @@ public class Hostile extends Combatant {
 
     /** Visual display rig; {@code null} when the group tag is unset or the group is not found. */
     @Getter private DisplayRig displayRig;
+
+    /** {@code true} while the death animation is playing — defers the Bukkit kill. */
+    @Getter private boolean inDeathAnimation;
     private WanderProfile wanderProfile = WanderProfile.ROAMER;
     private SwordEntity currentTarget;
     private SwordEntity nearestScannedTarget;
@@ -187,15 +191,14 @@ public class Hostile extends Combatant {
         // Defer display rig spawn by one tick — spawning display entities synchronously during
         // EntityAddToWorldEvent causes a Paper chunk-system error because the host chunk is
         // still mid-update when this event fires.
-        if (mob.getType() == EntityType.ZOMBIE) {
-            // Defer display rig spawn by one tick — spawning display entities synchronously during
-            // EntityAddToWorldEvent causes a Paper chunk-system error because the host chunk is
-            // still mid-update when this event fires.
+        MobTypeDefinition mobType = MobTypeRegistry.getByEntityType(mob.getType());
+        if (mobType != null && mobType.displayGroup() != null) {
+            final MobTypeDefinition type = mobType;
             SwordScheduler.runBukkitTaskLater(
                 () -> {
                     if (mob.isValid()) {
                         mob.setInvisible(true);
-                        displayRig = DisplayRig.spawn(mob, Config.Hostile.DISPLAY_GROUP);
+                        displayRig = DisplayRig.spawn(mob, type.displayGroup(), type.animationSlots());
                     }
                 },
                 50, TimeUnit.MILLISECONDS
@@ -228,7 +231,34 @@ public class Hostile extends Combatant {
                 stuck.register();
             }
         }
+
+        // Disable AI immediately regardless of death animation.
+        mob.setAware(false);
+        aiStateMachine = null;
+        statusActive = false;
+        endStatusDisplay();
+
+        if (displayRig != null && displayRig.hasDieAnimation()) {
+            inDeathAnimation = true;
+            displayRig.triggerDeath();
+            // Fallback kill — fires if AnimationCompleteEvent never arrives.
+            // Uses the configured die animation length; falls back to 5 seconds if unset.
+            MobTypeDefinition mobType = MobTypeRegistry.getByEntityType(mob.getType());
+            int dieTicks = (mobType != null) ? mobType.animationSlots().die().durationTicks() : 0;
+            int fallbackMs = dieTicks > 0 ? dieTicks * btm.sword.utility.SwordTimeUnit.MILLISECONDS_PER_TICK : 5000;
+            SwordScheduler.runBukkitTaskLater(() -> {
+                if (!mob.isDead()) {
+                    mob.damage(74077740);
+                }
+            }, fallbackMs, TimeUnit.MILLISECONDS);
+        }
+
         super.onZeroHealth();
+    }
+
+    @Override
+    protected boolean shouldDeferDeath() {
+        return inDeathAnimation;
     }
 
     @Override

--- a/src/main/java/btm/sword/system/entity/impl/RigHostile.java
+++ b/src/main/java/btm/sword/system/entity/impl/RigHostile.java
@@ -1,0 +1,76 @@
+package btm.sword.system.entity.impl;
+
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
+
+import btm.sword.system.entity.base.CombatProfile;
+
+
+
+/**
+ * A {@link Hostile} whose visuals are entirely driven by a DEU display rig.
+ *
+ * <p>Extends {@link Hostile} with overrides specific to display-rig mobs:</p>
+ * <ul>
+ *   <li><b>Weapon retrieval</b>: {@link #receiveRetrievedWeapon} updates the
+ *       logical {@code itemInRightHand} field and the rig weapon-slot display but does
+ *       <em>not</em> write to the mob's vanilla equipment slot (which is permanently AIR).</li>
+ *   <li><b>Death sequence</b>: {@link #onZeroHealth()} additionally freezes the mob's
+ *       velocity, locks the rig's server-side position via {@link btm.sword.system.entity.display.DisplayRig#lockOnDeath()},
+ *       and prevents any further animation state transitions so the DEATH animation
+ *       plays to completion without interruption.</li>
+ * </ul>
+ */
+public class RigHostile extends Hostile {
+
+    /**
+     * Constructs a new RigHostile wrapping the given entity.
+     *
+     * @param associatedEntity the Bukkit living entity to wrap
+     * @param combatProfile    the combat profile defining stats and settings
+     */
+    public RigHostile(LivingEntity associatedEntity, CombatProfile combatProfile) {
+        super(associatedEntity, combatProfile);
+    }
+
+    /**
+     * Reclaims the thrown weapon into the logical {@code itemInRightHand} field and
+     * restores the rig weapon-slot display. Does <em>not</em> write to the vanilla
+     * equipment slot — the vanilla main hand remains AIR for all display-rig mobs.
+     *
+     * @param item the recovered item stack
+     */
+    @Override
+    public void receiveRetrievedWeapon(ItemStack item) {
+        itemInRightHand = item;
+        onWeaponRetrieved();
+    }
+
+    /**
+     * Extends {@link Hostile#onZeroHealth()} with display-rig death behaviour:
+     * <ol>
+     *   <li>Zeroes the mob's server-side velocity and disables gravity so the
+     *       body does not drift during the death animation.</li>
+     *   <li>Calls {@link btm.sword.system.entity.display.DisplayRig#lockOnDeath()} to
+     *       dismount the rig from the mob and cancel the yaw follow, freezing the
+     *       rig's server-side position at the point of death.</li>
+     *   <li>Locks the state machine so no transition can interrupt the DEATH
+     *       animation after it starts.</li>
+     * </ol>
+     */
+    @Override
+    public void onZeroHealth() {
+        // Freeze the mob body in place so it does not fall or drift.
+        mob().setVelocity(new Vector(0, 0, 0));
+        mob().setGravity(false);
+
+        // Lock the display rig position and prevent further state transitions.
+        if (getDisplayRig() != null) {
+            getDisplayRig().lockOnDeath();
+        }
+
+        // Run common Hostile death logic (AI disable, animation trigger, fallback timer).
+        super.onZeroHealth();
+    }
+}

--- a/src/main/java/btm/sword/system/entity/impl/RigHostile.java
+++ b/src/main/java/btm/sword/system/entity/impl/RigHostile.java
@@ -1,12 +1,13 @@
 package btm.sword.system.entity.impl;
 
+import java.util.concurrent.TimeUnit;
+
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
+import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.entity.base.CombatProfile;
-
-
 
 /**
  * A {@link Hostile} whose visuals are entirely driven by a DEU display rig.
@@ -16,10 +17,10 @@ import btm.sword.system.entity.base.CombatProfile;
  *   <li><b>Weapon retrieval</b>: {@link #receiveRetrievedWeapon} updates the
  *       logical {@code itemInRightHand} field and the rig weapon-slot display but does
  *       <em>not</em> write to the mob's vanilla equipment slot (which is permanently AIR).</li>
- *   <li><b>Death sequence</b>: {@link #onZeroHealth()} additionally freezes the mob's
- *       velocity, locks the rig's server-side position via {@link btm.sword.system.entity.display.DisplayRig#lockOnDeath()},
- *       and prevents any further animation state transitions so the DEATH animation
- *       plays to completion without interruption.</li>
+ *   <li><b>Death sequence</b>: {@link #onZeroHealth()} schedules a 5-tick delayed freeze
+ *       so knockback resolves first, then zeroes velocity, disables gravity, and calls
+ *       {@link btm.sword.system.entity.display.DisplayRig#lockOnDeath()} to freeze the
+ *       rig at the point of death and prevent animation state transitions.</li>
  * </ul>
  */
 public class RigHostile extends Hostile {
@@ -48,29 +49,33 @@ public class RigHostile extends Hostile {
     }
 
     /**
-     * Extends {@link Hostile#onZeroHealth()} with display-rig death behaviour:
+     * Extends {@link Hostile#onZeroHealth()} with display-rig death behaviour.
+     *
+     * <p>Immediately delegates to super (which disables AI and triggers the death animation),
+     * then schedules a 5-tick delayed task that:</p>
      * <ol>
-     *   <li>Zeroes the mob's server-side velocity and disables gravity so the
-     *       body does not drift during the death animation.</li>
-     *   <li>Calls {@link btm.sword.system.entity.display.DisplayRig#lockOnDeath()} to
-     *       dismount the rig from the mob and cancel the yaw follow, freezing the
-     *       rig's server-side position at the point of death.</li>
-     *   <li>Locks the state machine so no transition can interrupt the DEATH
-     *       animation after it starts.</li>
+     *   <li>Zeroes velocity and disables gravity — mob body stays at the knockback-resolved
+     *       position for the remainder of the death animation.</li>
+     *   <li>Calls {@link btm.sword.system.entity.display.DisplayRig#lockOnDeath()} —
+     *       dismounts the rig from the mob, cancels the yaw follow, and prevents any
+     *       further animation state transitions.</li>
      * </ol>
+     * <p>The 5-tick delay allows physics to apply one final knockback impulse before
+     * the entity is frozen in place.</p>
      */
     @Override
     public void onZeroHealth() {
-        // Freeze the mob body in place so it does not fall or drift.
-        mob().setVelocity(new Vector(0, 0, 0));
-        mob().setGravity(false);
-
-        // Lock the display rig position and prevent further state transitions.
-        if (getDisplayRig() != null) {
-            getDisplayRig().lockOnDeath();
-        }
-
-        // Run common Hostile death logic (AI disable, animation trigger, fallback timer).
+        // Trigger AI disable + death animation immediately.
         super.onZeroHealth();
+
+        // After 5 ticks, freeze position so knockback has time to apply.
+        SwordScheduler.runBukkitTaskLater(() -> {
+            if (!mob().isValid()) return;
+            mob().setVelocity(new Vector(0, 0, 0));
+            mob().setGravity(false);
+            if (getDisplayRig() != null) {
+                getDisplayRig().lockOnDeath();
+            }
+        }, 5 * 50, TimeUnit.MILLISECONDS);
     }
 }

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -1467,6 +1467,9 @@ public class SwordPlayer extends Combatant {
      * @param index the inventory slot index
      */
     public void setItemAtIndex(ItemStack item, int index) {
+        if (index < 0 || index > 42) {
+            return;
+        }
         player.getInventory().setItem(index, item);
     }
 

--- a/src/main/java/btm/sword/system/entity/mob/AnimationSlot.java
+++ b/src/main/java/btm/sword/system/entity/mob/AnimationSlot.java
@@ -1,0 +1,22 @@
+package btm.sword.system.entity.mob;
+
+/**
+ * A single animation slot: the resolved DEU tag and the animation's duration in ticks.
+ * <p>
+ * Duration is used as the fallback kill-delay when the {@code AnimationCompleteEvent}
+ * does not fire (e.g. if the animation file is missing).
+ * </p>
+ *
+ * @param tag           the full DEU animation tag (e.g. {@code "witha_die"}); empty means no animation
+ * @param durationTicks the animation's length in ticks; 0 means unknown / no animation
+ */
+public record AnimationSlot(String tag, int durationTicks) {
+
+    /** Sentinel for a slot with no animation registered. */
+    public static final AnimationSlot NONE = new AnimationSlot("", 0);
+
+    /** Returns {@code true} when this slot has a non-empty animation tag. */
+    public boolean hasTag() {
+        return tag != null && !tag.isEmpty();
+    }
+}

--- a/src/main/java/btm/sword/system/entity/mob/AnimationSlots.java
+++ b/src/main/java/btm/sword/system/entity/mob/AnimationSlots.java
@@ -1,0 +1,33 @@
+package btm.sword.system.entity.mob;
+
+/**
+ * Holds the resolved DEU animation slots for a mob type.
+ * <p>
+ * Each slot pairs a full animation tag (e.g. {@code "witha_walk"}) with its duration in ticks.
+ * Tags are built at registry load time as {@code prefix_suffix}.
+ * An empty-tag slot ({@link AnimationSlot#NONE}) means that state is not registered on the
+ * {@link btm.sword.system.entity.display.DisplayRig}'s state machine.
+ * </p>
+ *
+ * @param idle   IDLE looping state
+ * @param walk   WALK looping state
+ * @param fall   FALLING looping state
+ * @param attack MELEE one-shot state (locked until animation completes)
+ * @param die    DEATH one-shot state; {@link AnimationSlot#NONE} if no death animation
+ */
+public record AnimationSlots(
+        AnimationSlot idle,
+        AnimationSlot walk,
+        AnimationSlot fall,
+        AnimationSlot attack,
+        AnimationSlot die) {
+
+    /** Sentinel used when a mob type has no display rig. */
+    public static final AnimationSlots EMPTY = new AnimationSlots(
+        AnimationSlot.NONE,
+        AnimationSlot.NONE,
+        AnimationSlot.NONE,
+        AnimationSlot.NONE,
+        AnimationSlot.NONE
+    );
+}

--- a/src/main/java/btm/sword/system/entity/mob/MobTypeDefinition.java
+++ b/src/main/java/btm/sword/system/entity/mob/MobTypeDefinition.java
@@ -1,0 +1,60 @@
+package btm.sword.system.entity.mob;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import org.bukkit.entity.EntityType;
+
+import btm.sword.system.entity.aspect.AspectType;
+import btm.sword.system.entity.aspect.value.AspectValue;
+import btm.sword.system.entity.aspect.value.ResourceValue;
+import btm.sword.system.entity.base.CombatProfile;
+
+/**
+ * Immutable definition for a mob type loaded from {@code mob_types.yml}.
+ * <p>
+ * Contains the DEU display group tag, resolved {@link AnimationSlots}, optional per-stat
+ * overrides applied on top of global {@link CombatProfile} defaults, and a list of ability IDs
+ * reserved for future ability system integration.
+ * </p>
+ *
+ * @param id            the mob type id (e.g. {@code "pillager"})
+ * @param entityType    the vanilla entity type this definition applies to
+ * @param displayGroup  the DEU group tag to spawn as the visual rig; {@code null} if none
+ * @param animationSlots resolved animation tag names for each state
+ * @param statOverrides per-stat overrides keyed by lowercase {@link AspectType} name
+ * @param abilityIds    list of ability IDs (reserved for future use)
+ */
+public record MobTypeDefinition(
+        String id,
+        @Nullable EntityType entityType,
+        @Nullable String displayGroup,
+        AnimationSlots animationSlots,
+        Map<String, Float> statOverrides,
+        List<String> abilityIds) {
+
+    /**
+     * Applies this type's stat overrides onto the given {@link CombatProfile}.
+     * For resource stats, only the base value is changed; regen period and amount are preserved.
+     *
+     * @param profile the profile to modify in place
+     */
+    public void applyTo(CombatProfile profile) {
+        for (Map.Entry<String, Float> entry : statOverrides.entrySet()) {
+            AspectType type;
+            try {
+                type = AspectType.valueOf(entry.getKey().toUpperCase());
+            } catch (IllegalArgumentException e) {
+                continue;
+            }
+            AspectValue existing = profile.getStat(type);
+            if (existing instanceof ResourceValue rv) {
+                profile.setStat(type, new ResourceValue(entry.getValue(), rv.getRegenPeriod(), rv.getRegenAmount()));
+            } else {
+                profile.setStat(type, new AspectValue(entry.getValue()));
+            }
+        }
+    }
+}

--- a/src/main/java/btm/sword/system/entity/mob/MobTypeRegistry.java
+++ b/src/main/java/btm/sword/system/entity/mob/MobTypeRegistry.java
@@ -1,0 +1,202 @@
+package btm.sword.system.entity.mob;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.EntityType;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import btm.sword.Sword;
+
+/**
+ * Registry for all {@link MobTypeDefinition} entries loaded from {@code mob_types.yml}.
+ * <p>
+ * Call {@link #initialize(JavaPlugin)} once during {@code Sword.onEnable()} after
+ * {@link btm.sword.config.ConfigManager} and
+ * {@link btm.sword.system.scene.animation.AnimationRegistry} are ready.
+ * Hot-reloads can call {@link #reload()} at any time (e.g. from {@code /sword reload}).
+ * </p>
+ *
+ * <h2>YAML format</h2>
+ * <pre>
+ * pillager:
+ *   entity_type: PILLAGER           # vanilla EntityType name
+ *   display:
+ *     group: "witha"                # DEU group tag to spawn as the display rig
+ *     animation_prefix: "witha"     # prefix for all animation tags; full tag = prefix_idle, etc.
+ *                                   # defaults to the group name if omitted
+ *   stats: {}                       # optional overrides on top of global CombatProfile defaults
+ *   abilities: []                   # reserved for future ability system integration
+ * </pre>
+ */
+public class MobTypeRegistry {
+
+    private static final String FILE_NAME = "mob_types.yml";
+    private static Map<String, MobTypeDefinition> byId = Collections.emptyMap();
+    private static Map<EntityType, MobTypeDefinition> byEntityType = Collections.emptyMap();
+    private static JavaPlugin plugin;
+
+    private MobTypeRegistry() {}
+
+    /**
+     * Initialises the registry from {@code mob_types.yml}, copying the bundled default
+     * if the file does not yet exist in the plugin data folder.
+     *
+     * @param javaPlugin the owning plugin instance
+     */
+    public static void initialize(JavaPlugin javaPlugin) {
+        plugin = javaPlugin;
+        saveDefaultIfAbsent();
+        reload();
+    }
+
+    /**
+     * Re-parses {@code mob_types.yml} without restarting the server.
+     * Safe to call at any time after {@link #initialize}.
+     */
+    public static void reload() {
+        File file = new File(plugin.getDataFolder(), FILE_NAME);
+        if (!file.exists()) {
+            Sword.getInstance().getLogger().warning(
+                "[MobTypeRegistry] mob_types.yml not found — no mob types loaded."
+            );
+            byId = Collections.emptyMap();
+            byEntityType = Collections.emptyMap();
+            return;
+        }
+
+        YamlConfiguration yaml = YamlConfiguration.loadConfiguration(file);
+
+        Map<String, MobTypeDefinition> loadedById = new HashMap<>();
+        Map<EntityType, MobTypeDefinition> loadedByType = new EnumMap<>(EntityType.class);
+
+        for (String id : yaml.getKeys(false)) {
+            ConfigurationSection section = yaml.getConfigurationSection(id);
+            if (section == null) continue;
+
+            EntityType entityType = parseEntityType(id, section.getString("entity_type"));
+            if (entityType == null) continue;
+
+            String displayGroup = null;
+            AnimationSlots animationSlots = AnimationSlots.EMPTY;
+            ConfigurationSection displaySection = section.getConfigurationSection("display");
+            if (displaySection != null) {
+                displayGroup = displaySection.getString("group");
+                // animation_prefix defaults to the group name when omitted.
+                String prefix = displaySection.getString("animation_prefix", displayGroup);
+                if (prefix != null && !prefix.isEmpty()) {
+                    ConfigurationSection lengths = displaySection.getConfigurationSection("animation_lengths");
+                    animationSlots = new AnimationSlots(
+                        slot(prefix + "_idle",   lengths, "idle"),
+                        slot(prefix + "_walk",   lengths, "walk"),
+                        slot(prefix + "_fall",   lengths, "fall"),
+                        slot(prefix + "_attack", lengths, "attack"),
+                        slot(prefix + "_die",    lengths, "die")
+                    );
+                }
+            }
+
+            Map<String, Float> statOverrides = new HashMap<>();
+            ConfigurationSection statsSection = section.getConfigurationSection("stats");
+            if (statsSection != null) {
+                for (String key : statsSection.getKeys(false)) {
+                    statOverrides.put(key.toLowerCase(), (float) statsSection.getDouble(key));
+                }
+            }
+
+            List<String> abilityIds = section.getStringList("abilities");
+
+            MobTypeDefinition def = new MobTypeDefinition(
+                id, entityType, displayGroup, animationSlots,
+                Collections.unmodifiableMap(statOverrides),
+                Collections.unmodifiableList(abilityIds)
+            );
+            loadedById.put(id, def);
+            loadedByType.put(entityType, def);
+        }
+
+        byId = Collections.unmodifiableMap(loadedById);
+        byEntityType = Collections.unmodifiableMap(loadedByType);
+        Sword.getInstance().getLogger().info(
+            "[MobTypeRegistry] Loaded " + loadedById.size() + " mob type(s)."
+        );
+    }
+
+    /**
+     * Returns the {@link MobTypeDefinition} for the given registry id.
+     *
+     * @param id the mob type id (e.g. {@code "pillager"})
+     * @return the definition, or empty if not registered
+     */
+    public static Optional<MobTypeDefinition> get(String id) {
+        return Optional.ofNullable(byId.get(id));
+    }
+
+    /**
+     * Returns the {@link MobTypeDefinition} for the given entity type, or {@code null}
+     * if no definition has been registered for that type.
+     *
+     * @param type the vanilla entity type
+     * @return the definition, or {@code null} if not found
+     */
+    public static @Nullable MobTypeDefinition getByEntityType(EntityType type) {
+        return byEntityType.get(type);
+    }
+
+    // ------------------------------------------------------------------
+
+    private static @Nullable EntityType parseEntityType(String id, @Nullable String raw) {
+        if (raw == null) {
+            Sword.getInstance().getLogger().warning(
+                "[MobTypeRegistry] Mob type '" + id + "' is missing 'entity_type' — skipping."
+            );
+            return null;
+        }
+        try {
+            return EntityType.valueOf(raw.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            Sword.getInstance().getLogger().warning(
+                "[MobTypeRegistry] Unknown entity_type '" + raw + "' in mob type '" + id + "' — skipping."
+            );
+            return null;
+        }
+    }
+
+    /** Builds an {@link AnimationSlot} from a tag and an optional length section. */
+    private static AnimationSlot slot(@Nullable String tag, @Nullable ConfigurationSection lengths, String key) {
+        if (tag == null || tag.isEmpty()) return AnimationSlot.NONE;
+        int ticks = (lengths != null) ? lengths.getInt(key, 0) : 0;
+        return new AnimationSlot(tag, ticks);
+    }
+
+    private static void saveDefaultIfAbsent() {
+        File file = new File(plugin.getDataFolder(), FILE_NAME);
+        if (file.exists()) return;
+        try (InputStream in = plugin.getResource(FILE_NAME)) {
+            if (in == null) {
+                Sword.getInstance().getLogger().warning(
+                    "[MobTypeRegistry] No bundled mob_types.yml found in jar."
+                );
+                return;
+            }
+            file.getParentFile().mkdirs();
+            Files.copy(in, file.toPath());
+        } catch (IOException e) {
+            Sword.getInstance().getLogger().warning(
+                "[MobTypeRegistry] Failed to save default mob_types.yml: " + e.getMessage()
+            );
+        }
+    }
+}

--- a/src/main/java/btm/sword/system/input/InputRegistrar.java
+++ b/src/main/java/btm/sword/system/input/InputRegistrar.java
@@ -162,8 +162,8 @@ public class InputRegistrar {
 
         // lunge (umbral link DROP + RIGHT) — registered FIRST, takes priority over throw when holding soul link
         new InputExecutionTree.InputNodeBuilder(root, List.of(
-            InputType.DROP,
-            InputType.RIGHT
+            InputType.RIGHT,
+            InputType.DROP
         )).action(new LinkedList<>(List.of(
             new InputExecutionTree.ActionContextPair(
                 () -> InputAction.builder()
@@ -197,8 +197,8 @@ public class InputRegistrar {
 
         // throw
         new InputExecutionTree.InputNodeBuilder(root, List.of(
-            InputType.DROP,
             InputType.RIGHT,
+            InputType.DROP,
             InputType.RIGHT_HOLD
         )).action(new LinkedList<>(List.of(
             new InputExecutionTree.ActionContextPair(

--- a/src/main/java/btm/sword/system/inventory/InventoryMenuManager.java
+++ b/src/main/java/btm/sword/system/inventory/InventoryMenuManager.java
@@ -23,6 +23,7 @@ import btm.sword.system.inventory.menu.MainMenu;
 import btm.sword.system.inventory.menu.MaterialPouchMenu;
 import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.inventory.menu.MovesetMenu;
+import btm.sword.system.inventory.menu.WeaponDisplayEditorMenu;
 
 public class InventoryMenuManager {
     private static final Map<Class<? extends Menu>, Function<SwordPlayer, ? extends Menu>> MENU_REGISTRY = new ConcurrentHashMap<>();
@@ -46,6 +47,7 @@ public class InventoryMenuManager {
         register(CurrencyMenu.class, CurrencyMenu::new);
         register(ArtifactPouchMenu.class, ArtifactPouchMenu::new);
         register(ItemLibraryMenu.class, ItemLibraryMenu::new);
+        register(WeaponDisplayEditorMenu.class, WeaponDisplayEditorMenu::new);
         // SkillSelectionMenu is constructed with a slot index and is opened directly
     }
 

--- a/src/main/java/btm/sword/system/inventory/menu/DevMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/DevMenu.java
@@ -188,6 +188,17 @@ public class DevMenu extends Menu {
             click -> new ItemLibraryMenu(swordPlayer).open()
         );
 
+        SimpleItem weaponDisplay = new SimpleItem(
+            new ItemStackBuilder(Material.BLAZE_ROD)
+                .name(Component.text("Weapon Display", NamedTextColor.GOLD, TextDecoration.BOLD))
+                .lore(List.of(
+                    Component.text("Tweak per-material weapon slot transforms", NamedTextColor.DARK_GRAY),
+                    Component.text("Hold the item you want to configure", NamedTextColor.DARK_GRAY)
+                ))
+                .build(),
+            click -> new WeaponDisplayEditorMenu(swordPlayer).open()
+        );
+
         SimpleItem bossBarTest = new SimpleItem(
             new ItemStackBuilder(Material.ORANGE_BANNER)
                 .name(Component.text("Boss Bar Fill Test", NamedTextColor.GOLD, TextDecoration.BOLD))
@@ -252,7 +263,7 @@ public class DevMenu extends Menu {
             .setStructure(
                 "# # # # # # # # #",
                 "# J N S F . L C #",
-                "# P X B K . . E #",
+                "# P X B K . H E #",
                 "# R I . T . M W #",
                 "# # # < . > # # #")
             .addIngredient('#', BORDER)
@@ -272,6 +283,7 @@ public class DevMenu extends Menu {
             .addIngredient('E', witherSkeletonEgg)
             .addIngredient('I', reloadProfile)
             .addIngredient('M', creativeMode)
+            .addIngredient('H', weaponDisplay)
             .addIngredient('<', generatePreviousButtonOrDefault())
             .addIngredient('>', generateForwardPreviousButtonOrDefault())
             .build();

--- a/src/main/java/btm/sword/system/inventory/menu/TogglesMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/TogglesMenu.java
@@ -90,11 +90,17 @@ public class TogglesMenu extends Menu {
             () -> Config.World.BLOCK_INTERACTION_ALLOW_BLOCK_PLACING = !Config.World.BLOCK_INTERACTION_ALLOW_BLOCK_PLACING
         );
 
+        SimpleItem verboseAnimation = toggle(
+            "Animation (DEU hook)",
+            () -> Config.Debug.LOGGING_VERBOSE_ANIMATION,
+            () -> Config.Debug.LOGGING_VERBOSE_ANIMATION = !Config.Debug.LOGGING_VERBOSE_ANIMATION
+        );
+
         Gui gui = Gui.normal()
             .setStructure(
                 "# # # # # # # # #",
                 "# A B C D E . . #",
-                "# F G H I J . . #",
+                "# F G H I J K . #",
                 "# . . . . . . . #",
                 "< # # # # # # # #")
             .addIngredient('#', BORDER)
@@ -108,6 +114,7 @@ public class TogglesMenu extends Menu {
             .addIngredient('H', verboseListener)
             .addIngredient('I', specialItemChecks)
             .addIngredient('J', blockPlacing)
+            .addIngredient('K', verboseAnimation)
             .addIngredient('<', generatePreviousButtonOrDefault())
             .build();
 

--- a/src/main/java/btm/sword/system/inventory/menu/WeaponDisplayEditorMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/WeaponDisplayEditorMenu.java
@@ -1,0 +1,212 @@
+package btm.sword.system.inventory.menu;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import btm.sword.system.entity.display.WeaponDisplayRegistry;
+import btm.sword.system.entity.display.WeaponDisplayTransform;
+import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.item.ItemStackBuilder;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import xyz.xenondevs.invui.gui.Gui;
+import xyz.xenondevs.invui.item.ItemProvider;
+import xyz.xenondevs.invui.item.ItemWrapper;
+import xyz.xenondevs.invui.item.impl.AbstractItem;
+import xyz.xenondevs.invui.item.impl.SimpleItem;
+import xyz.xenondevs.invui.window.Window;
+
+/**
+ * Developer menu for tweaking per-material {@link WeaponDisplayTransform} values in-game.
+ *
+ * <p>Opens for the material of the item held in the player's main hand.
+ * Changes are applied to {@link WeaponDisplayRegistry} immediately; click <b>Save</b>
+ * to write them to {@code weapon_display.yml}.</p>
+ *
+ * <ul>
+ *   <li>L-click / R-click: decrement / increment by the normal step</li>
+ *   <li>Shift + L/R-click: decrement / increment by the large step</li>
+ * </ul>
+ */
+public class WeaponDisplayEditorMenu extends Menu {
+
+    private static final float OFFSET_STEP        = 0.05f;
+    private static final float OFFSET_SHIFT_STEP  = 0.5f;
+    private static final float ROT_STEP            = 5.0f;
+    private static final float ROT_SHIFT_STEP      = 45.0f;
+    private static final float SCALE_STEP          = 0.05f;
+    private static final float SCALE_SHIFT_STEP    = 0.5f;
+
+    private final Material material;
+
+    /**
+     * Creates a new WeaponDisplayEditorMenu for the given player.
+     * The edited material is taken from the player's main-hand item at construction time.
+     *
+     * @param player the player opening this menu
+     */
+    public WeaponDisplayEditorMenu(SwordPlayer player) {
+        super(player);
+        ItemStack held = player.player().getInventory().getItemInMainHand();
+        this.material = held.getType().isAir() ? null : held.getType();
+    }
+
+    @Override
+    public void open() {
+        Player player = swordPlayer.player();
+
+        if (material == null) {
+            swordPlayer.message(Component.text("Hold an item to edit its weapon display transform.", NamedTextColor.RED));
+            return;
+        }
+
+        AbstractItem offsetRight   = buildField("Offset Right",   material, "offsetRight",   OFFSET_STEP, OFFSET_SHIFT_STEP);
+        AbstractItem offsetUp      = buildField("Offset Up",      material, "offsetUp",      OFFSET_STEP, OFFSET_SHIFT_STEP);
+        AbstractItem offsetForward = buildField("Offset Forward", material, "offsetForward", OFFSET_STEP, OFFSET_SHIFT_STEP);
+        AbstractItem rotX          = buildField("Rot X (deg)",    material, "rotX",          ROT_STEP,    ROT_SHIFT_STEP);
+        AbstractItem rotY          = buildField("Rot Y (deg)",    material, "rotY",          ROT_STEP,    ROT_SHIFT_STEP);
+        AbstractItem rotZ          = buildField("Rot Z (deg)",    material, "rotZ",          ROT_STEP,    ROT_SHIFT_STEP);
+        AbstractItem scale         = buildField("Scale",          material, "scale",         SCALE_STEP,  SCALE_SHIFT_STEP);
+
+        SimpleItem save = new SimpleItem(
+            new ItemStackBuilder(Material.EMERALD)
+                .name(Component.text("Save to weapon_display.yml", NamedTextColor.GREEN, TextDecoration.BOLD))
+                .lore(List.of(Component.text("Writes all current transforms to disk", NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> {
+                WeaponDisplayRegistry.save();
+                swordPlayer.message(Component.text("Saved weapon_display.yml.", NamedTextColor.GREEN));
+            }
+        );
+
+        SimpleItem back = new SimpleItem(
+            new ItemStackBuilder(Material.COPPER_TRAPDOOR)
+                .name(Component.text("Back to Dev Menu", NamedTextColor.GRAY))
+                .build(),
+            click -> new DevMenu(swordPlayer).open()
+        );
+
+        Gui gui = Gui.normal()
+            .setStructure(
+                "# # # # # # # # #",
+                "# A B C . D E F #",
+                "# . . . G . . . #",
+                "# # # S K . # # #")
+            .addIngredient('#', BORDER)
+            .addIngredient('A', offsetRight)
+            .addIngredient('B', offsetUp)
+            .addIngredient('C', offsetForward)
+            .addIngredient('D', rotX)
+            .addIngredient('E', rotY)
+            .addIngredient('F', rotZ)
+            .addIngredient('G', scale)
+            .addIngredient('S', save)
+            .addIngredient('K', back)
+            .build();
+
+        Window.single()
+            .setViewer(player)
+            .setTitle("Weapon Display: " + material.name())
+            .setGui(gui)
+            .build()
+            .open();
+    }
+
+    /**
+     * Builds an {@link AbstractItem} that displays and edits one float field of the
+     * {@link WeaponDisplayTransform} for the given material.
+     *
+     * @param label     display name shown in the item lore
+     * @param mat       the material whose transform is being edited
+     * @param field     one of: offsetRight, offsetUp, offsetForward, rotX, rotY, rotZ, scale
+     * @param step      normal click step
+     * @param shiftStep shift-click step
+     */
+    private AbstractItem buildField(String label, Material mat, String field, float step, float shiftStep) {
+        return new AbstractItem() {
+            @Override
+            public ItemProvider getItemProvider() {
+                WeaponDisplayTransform t = WeaponDisplayRegistry.get(mat);
+                float value = getField(t, field);
+                List<Component> lore = new ArrayList<>();
+                lore.add(Component.text("Value: ", NamedTextColor.GRAY)
+                    .append(Component.text(String.format("%.3f", value), NamedTextColor.YELLOW)));
+                lore.add(Component.empty());
+                lore.add(Component.text("L/R: ±" + step, NamedTextColor.DARK_GRAY));
+                lore.add(Component.text("Shift L/R: ±" + shiftStep, NamedTextColor.DARK_GRAY));
+                return new ItemWrapper(new ItemStackBuilder(fieldMaterial(field))
+                    .name(Component.text(label, NamedTextColor.AQUA, TextDecoration.BOLD))
+                    .lore(lore)
+                    .build());
+            }
+
+            @Override
+            public void handleClick(ClickType clickType, Player p, InventoryClickEvent event) {
+                float delta;
+                if (clickType == ClickType.LEFT) {
+                    delta = -step;
+                } else if (clickType == ClickType.RIGHT) {
+                    delta = step;
+                } else if (clickType == ClickType.SHIFT_LEFT) {
+                    delta = -shiftStep;
+                } else if (clickType == ClickType.SHIFT_RIGHT) {
+                    delta = shiftStep;
+                } else {
+                    return;
+                }
+                WeaponDisplayTransform current = WeaponDisplayRegistry.get(mat);
+                WeaponDisplayRegistry.set(mat, withField(current, field, getField(current, field) + delta));
+                notifyWindows();
+            }
+        };
+    }
+
+    // -----------------------------------------------------------------------
+    // Field accessors by name
+
+    private static float getField(WeaponDisplayTransform t, String field) {
+        return switch (field) {
+            case "offsetRight"   -> t.offsetRight();
+            case "offsetUp"      -> t.offsetUp();
+            case "offsetForward" -> t.offsetForward();
+            case "rotX"          -> t.rotX();
+            case "rotY"          -> t.rotY();
+            case "rotZ"          -> t.rotZ();
+            case "scale"         -> t.scale();
+            default -> 0f;
+        };
+    }
+
+    private static WeaponDisplayTransform withField(WeaponDisplayTransform t, String field, float value) {
+        return switch (field) {
+            case "offsetRight"   -> new WeaponDisplayTransform(value,           t.offsetUp(), t.offsetForward(), t.rotX(), t.rotY(), t.rotZ(), t.scale());
+            case "offsetUp"      -> new WeaponDisplayTransform(t.offsetRight(),  value,        t.offsetForward(), t.rotX(), t.rotY(), t.rotZ(), t.scale());
+            case "offsetForward" -> new WeaponDisplayTransform(t.offsetRight(),  t.offsetUp(), value,             t.rotX(), t.rotY(), t.rotZ(), t.scale());
+            case "rotX"          -> new WeaponDisplayTransform(t.offsetRight(),  t.offsetUp(), t.offsetForward(), value,    t.rotY(), t.rotZ(), t.scale());
+            case "rotY"          -> new WeaponDisplayTransform(t.offsetRight(),  t.offsetUp(), t.offsetForward(), t.rotX(), value,    t.rotZ(), t.scale());
+            case "rotZ"          -> new WeaponDisplayTransform(t.offsetRight(),  t.offsetUp(), t.offsetForward(), t.rotX(), t.rotY(), value,    t.scale());
+            case "scale"         -> new WeaponDisplayTransform(t.offsetRight(),  t.offsetUp(), t.offsetForward(), t.rotX(), t.rotY(), t.rotZ(), value);
+            default -> t;
+        };
+    }
+
+    private static Material fieldMaterial(String field) {
+        return switch (field) {
+            case "offsetRight"   -> Material.ARROW;
+            case "offsetUp"      -> Material.FEATHER;
+            case "offsetForward" -> Material.COMPASS;
+            case "rotX"          -> Material.RED_DYE;
+            case "rotY"          -> Material.LIME_DYE;
+            case "rotZ"          -> Material.BLUE_DYE;
+            case "scale"         -> Material.QUARTZ;
+            default -> Material.PAPER;
+        };
+    }
+}

--- a/src/main/java/btm/sword/utility/Debug.java
+++ b/src/main/java/btm/sword/utility/Debug.java
@@ -92,6 +92,11 @@ public class Debug {
         emit(Config.Debug.LOGGING_VERBOSE_LISTENER, "Listener", message);
     }
 
+    /** DEU animation hook / weapon-slot display debug. Gated by {@link Config.Debug#LOGGING_VERBOSE_ANIMATION}. */
+    public static void animation(String message) {
+        emit(Config.Debug.LOGGING_VERBOSE_ANIMATION, "Animation", message);
+    }
+
     // =========================================================================
     // Visual helpers
     // =========================================================================

--- a/src/main/java/btm/sword/utility/display/DisplayUtil.java
+++ b/src/main/java/btm/sword/utility/display/DisplayUtil.java
@@ -8,7 +8,9 @@ import java.util.function.Supplier;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Display;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.ItemDisplay;
+import org.bukkit.entity.Mob;
 import org.bukkit.util.Vector;
 
 import btm.sword.config.Config;
@@ -16,7 +18,6 @@ import btm.sword.system.control.PredicateRunnablePair;
 import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.base.SwordEntity;
-import btm.sword.utility.Debug;
 import btm.sword.utility.Prefab;
 
 /**
@@ -49,69 +50,6 @@ public class DisplayUtil {
     public static void setInterpolationValues(Display display, int delay, int duration) {
         display.setInterpolationDelay(delay);
         display.setInterpolationDuration(duration);
-    }
-
-    public static TimeArbiter.TaskHandle displaySlerpToOffset(
-        SwordEntity entity, ItemDisplay display, Vector offset,
-        double speed, int tpDuration, int period,
-        double endDistance, boolean removeOnArrival,
-        int maxIterations,
-        Runnable callback) {
-
-        AtomicInteger iterations = new AtomicInteger(0);
-        AtomicReference<Vector> currentDirectionToTarget = new AtomicReference<>();
-        return TimeArbiter.runTimeBoundBukkitTaskOnTimer(
-            () -> {
-                try {
-                    Location curTarget = entity.self().getLocation().add(
-                        entity.rightBasisVector(false).multiply(offset.getX()).add(
-                            entity.upBasisVector(false).multiply(offset.getY()).add(
-                                entity.forwardBasisVector(false).multiply(offset.getZ())
-                            )
-                        ));
-                    currentDirectionToTarget.set(curTarget.toVector().subtract(display.getLocation().toVector()));
-                } catch (RuntimeException ignored) { }
-            },
-            () -> {
-                Vector scaledDiff = currentDirectionToTarget.get().clone().normalize().multiply(speed);
-                Location update = display.getLocation().add(scaledDiff);
-                TimeArbiter.teleportDisplay(
-                    display,
-                    update, update.toVector().subtract(display.getLocation().toVector()),
-                    tpDuration,
-                    DisplayUtil.class, 82
-                );
-            },
-            null,
-            0, period,
-            DisplayUtil.class, "displaySlerpToOffset",
-            new PredicateRunnablePair(
-                // ticks is incremented here, not explicitly during a runnable.
-                () -> iterations.getAndIncrement() > maxIterations || entity.isInvalid() || !display.isValid(),
-                () -> {
-
-                    Debug.system("display invalid, tick=" + iterations.get());
-
-                    if (display.isValid() && removeOnArrival) display.remove();
-                    if (callback != null) {
-                        SwordScheduler.runBukkitTask(callback);
-                    }
-                }
-            ),
-            new PredicateRunnablePair(
-                () -> currentDirectionToTarget.get().isZero() ||
-                    currentDirectionToTarget.get().lengthSquared() < endDistance * endDistance,
-                () -> {
-
-                    Debug.system("display arrived, tick=" + iterations.get());
-
-                    if (display.isValid() && removeOnArrival) display.remove();
-                    if (callback != null) {
-                        SwordScheduler.runBukkitTask(callback);
-                    }
-                }
-            )
-        );
     }
 
     // returns a task for use in detecting when finished
@@ -262,6 +200,67 @@ public class DisplayUtil {
             null,
             0, period,
             DisplayUtil.class, "itemDisplayFollow (2)"
+        );
+    }
+
+    /**
+     * Makes an {@link ItemDisplay} track a {@link Mob}'s position each tick with a
+     * yaw-relative offset. The offset axes are relative to the mob's facing:
+     * {@code offsetRight} is the mob's lateral right, {@code offsetUp} is world up,
+     * and {@code offsetForward} is the mob's forward direction.
+     *
+     * @param mob           the mob to follow
+     * @param display       the display entity to teleport
+     * @param offsetRight   right-axis offset (mob's local right)
+     * @param offsetUp      vertical offset
+     * @param offsetForward forward-axis offset (mob's local forward)
+     * @param tpDuration    teleport interpolation duration in ticks
+     * @param period        update interval in ticks
+     * @return a task handle that can be cancelled to stop following
+     */
+    public static TimeArbiter.TaskHandle itemDisplayFollowMob(
+            Mob mob, ItemDisplay display,
+            float offsetRight, float offsetUp, float offsetForward,
+            int tpDuration, int period) {
+        return TimeArbiter.runTimeBoundBukkitTaskOnTimer(
+            () -> {
+                if (!mob.isValid() || !display.isValid()) return;
+                Location loc = mob.getLocation();
+                double yawRad = Math.toRadians(loc.getYaw());
+                // Forward direction in Minecraft: (-sin yaw, 0, cos yaw)
+                double fwdX = -Math.sin(yawRad);
+                double fwdZ = Math.cos(yawRad);
+                // Right direction: 90° clockwise from forward
+                double rightX = Math.cos(yawRad);
+                double rightZ = Math.sin(yawRad);
+                double worldX = offsetRight * rightX + offsetForward * fwdX;
+                double worldZ = offsetRight * rightZ + offsetForward * fwdZ;
+                Location target = loc.clone().add(worldX, offsetUp, worldZ);
+                TimeArbiter.teleportDisplay(display, target, new Vector(fwdX, 0, fwdZ), tpDuration, DisplayUtil.class, 0);
+            },
+            null, null, 0, period,
+            DisplayUtil.class, "itemDisplayFollowMob"
+        );
+    }
+
+    public static TimeArbiter.TaskHandle itemDisplayFollowDirect(
+        Entity entity, ItemDisplay display, int tpDuration, int period) {
+
+        return TimeArbiter.runTimeBoundBukkitTaskOnTimer(
+            () -> {
+                Location updated = entity.getLocation();
+
+                TimeArbiter.teleportDisplay(
+                    display,
+                    updated, updated.getDirection(),
+                    tpDuration,
+                    DisplayUtil.class, 257
+                );
+            },
+            null,
+            null,
+            0, period,
+            DisplayUtil.class, "itemDisplayFollowDirect"
         );
     }
 }

--- a/src/main/resources/animations.yml
+++ b/src/main/resources/animations.yml
@@ -17,5 +17,7 @@ animations:
         loop: true
   witha:
     anims:
-      witha_default:
-        loop: true
+      witha_die:
+        loop: false
+      witha_walk:
+        loop: false

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -328,12 +328,13 @@ world:
 
 
 debug:
-  
+
   logging_verbose_combat: false
   logging_verbose_movement: false
-  
+
   logging_verbose_config: false
-  
+  logging_verbose_animation: false
+
   visualization_show_hitboxes: false
   visualization_show_raytraces: false
 

--- a/src/main/resources/mob_types.yml
+++ b/src/main/resources/mob_types.yml
@@ -1,0 +1,29 @@
+# Mob type definitions for Sword: Combat Evolved
+# Each top-level key is the mob type ID used by MobTypeRegistry.
+#
+# Fields:
+#   entity_type   - vanilla Minecraft EntityType name (required)
+#   display:
+#     group             - DEU group tag to spawn as the visual display rig
+#     animation_prefix  - prefix used to build all animation tags (prefix_idle, prefix_walk,
+#                         prefix_fall, prefix_attack, prefix_die). Defaults to group name.
+#     animation_lengths - duration in ticks for each animation slot (used as fallback kill timer)
+#       idle, walk, fall, attack, die
+#   stats         - optional per-stat overrides on top of global CombatProfile defaults
+#                   keys are AspectType names (lowercase): shards, toughness, soulfire, form,
+#                   might, resolve, finesse, prowess, armor, fortitude, celerity, willpower
+#   abilities     - list of ability IDs (reserved for future ability system integration)
+
+pillager:
+  entity_type: PILLAGER
+  display:
+    group: "witha"
+    animation_prefix: "witha"
+    animation_lengths:
+      idle: 40
+      walk: 20
+      fall: 10
+      attack: 30
+      die: 60
+  stats: {}
+  abilities: []

--- a/src/main/resources/weapon_display.yml
+++ b/src/main/resources/weapon_display.yml
@@ -1,0 +1,12 @@
+# Per-material weapon display transforms for display-rig mob weapon slots.
+#
+# Each entry maps a Bukkit Material name to a transform applied to the
+# ItemDisplay that follows the mob's main hand.
+#
+# offset_right:   lateral offset in the mob's right direction (positive = mob's right side)
+# offset_up:      vertical offset (positive = up)
+# offset_forward: offset in the mob's forward direction (positive = in front of mob)
+# rot_x/y/z:     local rotation of the displayed item in degrees
+# scale:          uniform scale of the displayed item
+#
+materials: {}


### PR DESCRIPTION
## Summary

Implements a data-driven mob type registry system with configurable animation slots and weapon display for hostile entities. This is the foundation for defining new mob types purely through YAML config without requiring new Java classes.

### Key Features

- **MobTypeRegistry**: Loads mob type definitions from `mob_types.yml` on startup and reload
- **MobTypeDefinition**: Encodes mob stats, abilities, animation slots, and visual appearance
- **AnimationSlots**: Per-mob-type configuration for walk, attack, die, and idle animations
- **RigHostile**: New hostile subclass with death lock and clean weapon retrieval logic
- **WeaponDisplayRegistry**: Data-driven weapon transform configuration with per-material support
- **WeaponDisplayEditorMenu**: In-game editor for tuning weapon display transforms
- **ProtocolLib Integration**: Packet hook for THIRDPERSON_LEFTHAND weapon display with orientation sync

### Files Changed

**New Core Systems:**
- `MobTypeRegistry` — registry and loader for mob type definitions
- `MobTypeDefinition` — data class for mob type configuration
- `AnimationSlots`, `AnimationSlot` — animation slot definitions
- `RigHostile` — hostile subclass with death lock and weapon retrieval
- `WeaponDisplayRegistry` — weapon display transform registry
- `WeaponDisplayTransform` — weapon transform configuration
- `WeaponAnchorPacketHook` — ProtocolLib packet hook for weapon display
- `DEUAnimationHook` — animation integration hook
- `WeaponDisplayEditorMenu` — in-game editor menu

**Updated Systems:**
- `DisplayRig` — extended weapon slot support and anchor transform sync
- `Hostile` — integrated mob type registry and animation slot support
- `EntityPacketListener` — weapon display packet handling
- `EntityListener` — weapon slot management during throw/retrieve

**Configuration:**
- `mob_types.yml` — mob type definitions
- `weapon_display.yml` — weapon display transform templates

### Issues Closed

Closes #260 (Configurable animation slots per mob type)
Closes #261 (Mob type definition system)

## Test Plan

- [x] Verify mob types load correctly from `mob_types.yml` on startup and `/sword reload`
- [x] Confirm walk animations play during pathfinding movement
- [x] Confirm attack animations trigger during mob attacks
- [x] Verify death animations play before despawn with correct timing
- [x] Test weapon display on hostile mobs in different poses
- [x] Verify weapon anchor transform sync with death lock (5-tick freeze)
- [x] Test WeaponDisplayEditorMenu for real-time transform tuning
- [x] Confirm existing mob behavior still works with migrated definitions
- [x] Check that new mob types are spawnable via dev menu