### PR TITLE
[Add] Dev data toggles — skip-load, skip-save, fresh-profile, reset-join

### DIFF
--- a/src/main/java/btm/sword/commands/SwordCommands.java
+++ b/src/main/java/btm/sword/commands/SwordCommands.java
@@ -3,6 +3,7 @@ package btm.sword.commands;
 import java.util.List;
 import java.util.Map;
 
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -12,6 +13,7 @@ import com.mojang.brigadier.arguments.DoubleArgumentType;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 
+import btm.sword.config.Config;
 import btm.sword.config.ConfigManager;
 import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.SwordEntityArbiter;
@@ -19,6 +21,8 @@ import btm.sword.system.entity.display.WeaponDisplayRegistry;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.entity.mob.MobTypeRegistry;
 import btm.sword.system.item.material.MaterialType;
+import btm.sword.system.playerdata.PlayerData;
+import btm.sword.system.playerdata.PlayerDataManager;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 import net.kyori.adventure.text.Component;
@@ -48,7 +52,10 @@ public final class SwordCommands {
                 .executes(ctx -> {
                     CommandSender sender = ctx.getSource().getSender();
                     sender.sendMessage(Component.text("Sword: Combat Evolved", NamedTextColor.GOLD));
-                    sender.sendMessage(Component.text("Usage: /sword reload", NamedTextColor.GRAY));
+                    sender.sendMessage(Component.text(
+                        "Usage: /sword reload | /sword dev <skipload|skipsave|freshprofile|resetjoin>",
+                        NamedTextColor.GRAY
+                    ));
                     return Command.SINGLE_SUCCESS;
                 })
                 .then(
@@ -59,6 +66,40 @@ public final class SwordCommands {
                 .then(
                     Commands.argument("global_time_scale", DoubleArgumentType.doubleArg(0, 2))
                         .executes(ctx -> handleSetGlobalTimeScale(ctx.getSource(), DoubleArgumentType.getDouble(ctx, "global_time_scale")))
+                )
+                .then(
+                    Commands.literal("dev")
+                        .requires(source -> source.getSender().hasPermission("sword.dev"))
+                        .then(
+                            Commands.literal("skipload")
+                                .executes(ctx -> handleDevSkipLoad(ctx.getSource()))
+                        )
+                        .then(
+                            Commands.literal("skipsave")
+                                .executes(ctx -> handleDevSkipSave(ctx.getSource()))
+                        )
+                        .then(
+                            Commands.literal("freshprofile")
+                                .executes(ctx -> handleDevFreshProfile(ctx.getSource(), null))
+                                .then(
+                                    Commands.argument("player", StringArgumentType.word())
+                                        .executes(ctx -> handleDevFreshProfile(
+                                            ctx.getSource(),
+                                            StringArgumentType.getString(ctx, "player")
+                                        ))
+                                )
+                        )
+                        .then(
+                            Commands.literal("resetjoin")
+                                .executes(ctx -> handleDevResetJoin(ctx.getSource(), null))
+                                .then(
+                                    Commands.argument("player", StringArgumentType.word())
+                                        .executes(ctx -> handleDevResetJoin(
+                                            ctx.getSource(),
+                                            StringArgumentType.getString(ctx, "player")
+                                        ))
+                                )
+                        )
                 )
                 .then(
                     Commands.literal("give")
@@ -231,6 +272,13 @@ public final class SwordCommands {
         return sb.toString();
     }
 
+    /**
+     * Handles {@code /sword [global_time_scale]}.
+     *
+     * @param source the command source
+     * @param value  the new time scale (0.0–2.0)
+     * @return command result status
+     */
     public static int handleSetGlobalTimeScale(CommandSourceStack source, double value) {
         CommandSender sender = source.getSender();
 
@@ -239,5 +287,136 @@ public final class SwordCommands {
             return Command.SINGLE_SUCCESS;
         }
         return 2;
+    }
+
+    /**
+     * Handles {@code /sword dev skipload}.
+     * Toggles {@link Config.Debug#SKIP_DATA_LOAD} and immediately persists the change to config.yaml.
+     * Console-compatible — no player entity required.
+     *
+     * @param source the command source
+     * @return command result status
+     */
+    private static int handleDevSkipLoad(CommandSourceStack source) {
+        CommandSender sender = source.getSender();
+        @SuppressWarnings("unchecked")
+        Config.ConfigEntry<Boolean> entry = (Config.ConfigEntry<Boolean>) Config.ENTRIES.stream()
+            .filter(e -> e.path.equals("debug.skip_data_load"))
+            .findFirst()
+            .orElseThrow();
+        boolean newValue = !Config.Debug.SKIP_DATA_LOAD;
+        ConfigManager.getInstance().setValue(entry, newValue);
+        ConfigManager.getInstance().saveConfig();
+        sender.sendMessage(Component.text(
+            "SKIP_DATA_LOAD -> " + newValue + " (saved to config.yaml).",
+            newValue ? NamedTextColor.YELLOW : NamedTextColor.GREEN
+        ));
+        return Command.SINGLE_SUCCESS;
+    }
+
+    /**
+     * Handles {@code /sword dev skipsave}.
+     * Toggles {@link Config.Debug#SKIP_DATA_SAVE} and immediately persists the change to config.yaml.
+     * Console-compatible — no player entity required.
+     *
+     * @param source the command source
+     * @return command result status
+     */
+    private static int handleDevSkipSave(CommandSourceStack source) {
+        CommandSender sender = source.getSender();
+        @SuppressWarnings("unchecked")
+        Config.ConfigEntry<Boolean> entry = (Config.ConfigEntry<Boolean>) Config.ENTRIES.stream()
+            .filter(e -> e.path.equals("debug.skip_data_save"))
+            .findFirst()
+            .orElseThrow();
+        boolean newValue = !Config.Debug.SKIP_DATA_SAVE;
+        ConfigManager.getInstance().setValue(entry, newValue);
+        ConfigManager.getInstance().saveConfig();
+        sender.sendMessage(Component.text(
+            "SKIP_DATA_SAVE -> " + newValue + " (saved to config.yaml).",
+            newValue ? NamedTextColor.YELLOW : NamedTextColor.GREEN
+        ));
+        return Command.SINGLE_SUCCESS;
+    }
+
+    /**
+     * Handles {@code /sword dev freshprofile [player]}.
+     * Replaces the target player's session data with a fresh {@link PlayerData} instance.
+     * If run from console without a target argument, an error is returned.
+     *
+     * @param source     the command source
+     * @param playerName the target player name, or {@code null} to use the sender
+     * @return command result status
+     */
+    private static int handleDevFreshProfile(CommandSourceStack source, String playerName) {
+        CommandSender sender = source.getSender();
+        Player target = resolvePlayer(sender, playerName);
+        if (target == null) return 2;
+
+        PlayerDataManager.resetToFresh(target.getUniqueId());
+        sender.sendMessage(Component.text(
+            "Reset " + target.getName() + "'s session data to a fresh profile.",
+            NamedTextColor.GREEN
+        ));
+        if (!target.equals(sender)) {
+            target.sendMessage(Component.text(
+                "Your session data has been reset to a fresh profile by an admin.",
+                NamedTextColor.YELLOW
+            ));
+        }
+        return Command.SINGLE_SUCCESS;
+    }
+
+    /**
+     * Handles {@code /sword dev resetjoin [player]}.
+     * Toggles the {@code joinSequenceCompleted} flag on the target player's {@link PlayerData}.
+     * If run from console without a target argument, an error is returned.
+     *
+     * @param source     the command source
+     * @param playerName the target player name, or {@code null} to use the sender
+     * @return command result status
+     */
+    private static int handleDevResetJoin(CommandSourceStack source, String playerName) {
+        CommandSender sender = source.getSender();
+        Player target = resolvePlayer(sender, playerName);
+        if (target == null) return 2;
+
+        PlayerData data = PlayerDataManager.getPlayerData(target.getUniqueId());
+        if (data == null) {
+            sender.sendMessage(Component.text("No PlayerData found for " + target.getName() + ".", NamedTextColor.RED));
+            return 2;
+        }
+        boolean newValue = !data.isJoinSequenceCompleted();
+        data.setJoinSequenceCompleted(newValue);
+        sender.sendMessage(Component.text(
+            target.getName() + "'s joinSequenceCompleted -> " + newValue + ".",
+            NamedTextColor.GREEN
+        ));
+        return Command.SINGLE_SUCCESS;
+    }
+
+    /**
+     * Resolves a target {@link Player} from the given name or falls back to the sender.
+     * Sends an error message and returns {@code null} if resolution fails.
+     *
+     * @param sender the command sender (used as fallback when {@code name} is null)
+     * @param name   the player name to look up, or {@code null} to use the sender
+     * @return the resolved online player, or {@code null} if not found
+     */
+    private static Player resolvePlayer(CommandSender sender, String name) {
+        if (name != null) {
+            Player found = Bukkit.getPlayer(name);
+            if (found == null) {
+                sender.sendMessage(Component.text("Player not found: " + name, NamedTextColor.RED));
+            }
+            return found;
+        }
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(Component.text(
+                "Console must specify a player: /sword dev <subcommand> <player>", NamedTextColor.RED
+            ));
+            return null;
+        }
+        return player;
     }
 }

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -2790,6 +2790,32 @@ public class Config {
             VISUALIZATION_SHOW_RAYTRACES, Boolean.class,
             v -> VISUALIZATION_SHOW_RAYTRACES = v,
             ConfigurationSection::getBoolean); }
+
+        /**
+         * When {@code true}, {@link btm.sword.system.playerdata.PlayerDataManager#register} skips
+         * the database load and always creates a fresh {@link btm.sword.system.playerdata.PlayerData},
+         * simulating a first-time join. Persisted to config.yaml.
+         * Toggle via the Dev Toggles menu or {@code /sword dev skipload}.
+         */
+        public static boolean SKIP_DATA_LOAD = false;
+        static { register(
+            "debug.skip_data_load",
+            SKIP_DATA_LOAD, Boolean.class,
+            v -> SKIP_DATA_LOAD = v,
+            ConfigurationSection::getBoolean); }
+
+        /**
+         * When {@code true}, all save paths in {@link btm.sword.system.playerdata.PlayerDataManager}
+         * ({@code saveAsync}, {@code flushAll}, {@code shutdown}) are no-ops — data is never written
+         * to the database. The store connection is still closed cleanly on shutdown.
+         * Persisted to config.yaml. Toggle via the Dev Toggles menu or {@code /sword dev skipsave}.
+         */
+        public static boolean SKIP_DATA_SAVE = false;
+        static { register(
+            "debug.skip_data_save",
+            SKIP_DATA_SAVE, Boolean.class,
+            v -> SKIP_DATA_SAVE = v,
+            ConfigurationSection::getBoolean); }
     }
     //endregion
 

--- a/src/main/java/btm/sword/system/inventory/menu/TogglesMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/TogglesMenu.java
@@ -1,10 +1,20 @@
 package btm.sword.system.inventory.menu;
 
+import java.util.List;
+
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 
 import btm.sword.config.Config;
+import btm.sword.config.ConfigManager;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.item.ItemStackBuilder;
+import btm.sword.system.playerdata.PlayerData;
+import btm.sword.system.playerdata.PlayerDataManager;
 import btm.sword.utility.Debug;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import xyz.xenondevs.invui.gui.Gui;
 import xyz.xenondevs.invui.item.impl.SimpleItem;
 import xyz.xenondevs.invui.window.Window;
@@ -12,7 +22,9 @@ import xyz.xenondevs.invui.window.Window;
 /**
  * Submenu of {@link DevMenu} listing all boolean debug and world toggles.
  * <p>
- * Toggles take effect immediately without a server restart and are not persisted across restarts.
+ * Most toggles take effect immediately without a server restart and are not persisted across
+ * restarts. Exceptions: "Skip Load" and "Skip Save" are written to config.yaml on toggle and
+ * survive server restarts.
  * </p>
  */
 public class TogglesMenu extends Menu {
@@ -96,12 +108,66 @@ public class TogglesMenu extends Menu {
             () -> Config.Debug.LOGGING_VERBOSE_ANIMATION = !Config.Debug.LOGGING_VERBOSE_ANIMATION
         );
 
+        @SuppressWarnings("unchecked")
+        Config.ConfigEntry<Boolean> skipLoadEntry = (Config.ConfigEntry<Boolean>) Config.ENTRIES.stream()
+            .filter(e -> e.path.equals("debug.skip_data_load"))
+            .findFirst()
+            .orElseThrow();
+
+        SimpleItem skipLoad = toggle(
+            "Skip Load (persisted)",
+            () -> Config.Debug.SKIP_DATA_LOAD,
+            () -> {
+                ConfigManager.getInstance().setValue(skipLoadEntry, !Config.Debug.SKIP_DATA_LOAD);
+                ConfigManager.getInstance().saveConfig();
+            }
+        );
+
+        @SuppressWarnings("unchecked")
+        Config.ConfigEntry<Boolean> skipSaveEntry = (Config.ConfigEntry<Boolean>) Config.ENTRIES.stream()
+            .filter(e -> e.path.equals("debug.skip_data_save"))
+            .findFirst()
+            .orElseThrow();
+
+        SimpleItem skipSave = toggle(
+            "Skip Save (persisted)",
+            () -> Config.Debug.SKIP_DATA_SAVE,
+            () -> {
+                ConfigManager.getInstance().setValue(skipSaveEntry, !Config.Debug.SKIP_DATA_SAVE);
+                ConfigManager.getInstance().saveConfig();
+            }
+        );
+
+        SimpleItem freshProfile = new SimpleItem(
+            new ItemStackBuilder(Material.RECOVERY_COMPASS)
+                .name(Component.text("Fresh Profile", NamedTextColor.AQUA, TextDecoration.BOLD))
+                .lore(List.of(Component.text("Replace your session data with a blank profile", NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> {
+                PlayerDataManager.resetToFresh(swordPlayer.getUniqueId());
+                swordPlayer.player().sendMessage(Component.text("Session data reset to fresh profile.", NamedTextColor.GREEN));
+                this.open();
+            }
+        );
+
+        SimpleItem resetJoin = toggle(
+            "Join Sequence Done",
+            () -> {
+                PlayerData pd = PlayerDataManager.getPlayerData(swordPlayer.getUniqueId());
+                return pd != null && pd.isJoinSequenceCompleted();
+            },
+            () -> {
+                PlayerData pd = PlayerDataManager.getPlayerData(swordPlayer.getUniqueId());
+                if (pd != null) pd.setJoinSequenceCompleted(!pd.isJoinSequenceCompleted());
+            }
+        );
+
         Gui gui = Gui.normal()
             .setStructure(
                 "# # # # # # # # #",
                 "# A B C D E . . #",
                 "# F G H I J K . #",
-                "# . . . . . . . #",
+                "# L M N O . . . #",
                 "< # # # # # # # #")
             .addIngredient('#', BORDER)
             .addIngredient('A', verboseDebug)
@@ -115,6 +181,10 @@ public class TogglesMenu extends Menu {
             .addIngredient('I', specialItemChecks)
             .addIngredient('J', blockPlacing)
             .addIngredient('K', verboseAnimation)
+            .addIngredient('L', skipLoad)
+            .addIngredient('M', skipSave)
+            .addIngredient('N', freshProfile)
+            .addIngredient('O', resetJoin)
             .addIngredient('<', generatePreviousButtonOrDefault())
             .build();
 

--- a/src/main/java/btm/sword/system/playerdata/PlayerDataManager.java
+++ b/src/main/java/btm/sword/system/playerdata/PlayerDataManager.java
@@ -12,6 +12,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.LivingEntity;
 
 import btm.sword.Sword;
+import btm.sword.config.Config;
 import btm.sword.system.playerdata.store.PlayerDataStore;
 import btm.sword.system.playerdata.store.SqlitePlayerDataStore;
 
@@ -62,22 +63,37 @@ public class PlayerDataManager {
     /**
      * Synchronously flushes all cached player data to disk and closes the store connection.
      * Called once on server shutdown.
+     * <p>
+     * If {@link Config.Debug#SKIP_DATA_SAVE} is {@code true}, the flush is skipped but the
+     * database connection is still closed cleanly.
+     * </p>
      */
     public static void shutdown() {
         if (store == null) return;
-        store.saveAll(cache.keySet(), cache);
+        if (!Config.Debug.SKIP_DATA_SAVE) {
+            store.saveAll(cache.keySet(), cache);
+        }
         store.close();
     }
 
     /**
      * Registers a player, loading their data from the database if it exists
      * or creating a fresh default record for first-time players.
+     * <p>
+     * If {@link Config.Debug#SKIP_DATA_LOAD} is {@code true}, the database load is skipped
+     * entirely and a fresh {@link PlayerData} is always created, simulating a first-time join.
+     * </p>
      *
      * @param entity the player entity to register
      */
     public static void register(LivingEntity entity) {
         UUID uuid = entity.getUniqueId();
         if (cache.containsKey(uuid)) return;
+
+        if (Config.Debug.SKIP_DATA_LOAD) {
+            cache.put(uuid, new PlayerData(uuid));
+            return;
+        }
 
         PlayerData loaded = store != null ? store.load(uuid) : null;
         cache.put(uuid, loaded != null ? loaded : new PlayerData(uuid));
@@ -96,10 +112,14 @@ public class PlayerDataManager {
     /**
      * Asynchronously saves a single player's data to the database.
      * Call this when a player quits so their data is persisted promptly.
+     * <p>
+     * This method is a no-op when {@link Config.Debug#SKIP_DATA_SAVE} is {@code true}.
+     * </p>
      *
      * @param uuid the player's unique ID
      */
     public static void saveAsync(UUID uuid) {
+        if (Config.Debug.SKIP_DATA_SAVE) return;
         PlayerData data = cache.get(uuid);
         if (data == null || store == null) return;
         Sword.getScheduler().submit(() -> store.save(uuid, data));
@@ -116,12 +136,32 @@ public class PlayerDataManager {
         cache.remove(uuid);
     }
 
+    /**
+     * Replaces the cached {@link PlayerData} for the given UUID with a completely fresh instance,
+     * as if the player had never joined before. Session-only — no database interaction.
+     * <p>
+     * Useful for testing the first-join sequence without clearing the database. The change takes
+     * effect immediately; the player's next action will reflect the fresh data.
+     * </p>
+     *
+     * @param uuid the UUID of the online player whose session data should be reset
+     */
+    public static void resetToFresh(UUID uuid) {
+        cache.put(uuid, new PlayerData(uuid));
+    }
+
     // =========================================================================
     // Internal helpers
     // =========================================================================
 
-    /** Async flush of all currently cached players — called by the periodic scheduler. */
-    private static void flushAll() {
+    /**
+     * Async flush of all currently cached players — called by the periodic scheduler.
+     * <p>
+     * This method is a no-op when {@link Config.Debug#SKIP_DATA_SAVE} is {@code true}.
+     * </p>
+     */
+    public static void flushAll() {
+        if (Config.Debug.SKIP_DATA_SAVE) return;
         if (store == null || cache.isEmpty()) return;
         Collection<UUID> snapshot = cache.keySet();
         store.saveAll(snapshot, cache);

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -338,6 +338,9 @@ debug:
   visualization_show_hitboxes: false
   visualization_show_raytraces: false
 
+  skip_data_load: false
+  skip_data_save: false
+
 
 grab:
   

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -20,3 +20,6 @@ permissions:
   sword.reload:
     description: Allows reloading configuration
     default: op
+  sword.dev:
+    description: Allows use of /sword dev subcommands (data toggles, fresh profile)
+    default: op


### PR DESCRIPTION
## Summary
- Adds two persisted debug flags (`SKIP_DATA_LOAD`, `SKIP_DATA_SAVE`) that survive server restarts via config.yaml — skip DB load on join to simulate first-time players, or mute all saves to freely test without polluting the database
- Adds `PlayerDataManager.resetToFresh(UUID)` for session-only in-memory profile reset
- Wires all four tools into the Dev Toggles menu and `/sword dev` subcommands (console-compatible for the persistent toggles)

## Changes
- `Config.java` + `config.yaml`: `debug.skip_data_load` and `debug.skip_data_save` flags
- `PlayerDataManager`: guards on `register`, `saveAsync`, `flushAll`, `shutdown`; new `resetToFresh`; `flushAll` promoted to public
- `TogglesMenu`: Skip Load (persisted), Skip Save (persisted), Fresh Profile (one-shot), Join Sequence Done toggle
- `SwordCommands`: `/sword dev skipload|skipsave|freshprofile [player]|resetjoin [player]`
- `paper-plugin.yml`: `sword.dev` permission node (default: op)

## Test plan
- [x] Join server → data loads normally
- [x] `/sword dev skipload` → toggle on → rejoin → fresh profile, no DB load, persists after restart
- [x] `/sword dev skipsave` → toggle on → quit → restart → no data written
- [x] Dev menu → Toggles → Skip Load/Skip Save reflect state, toggle, persist
- [x] Dev menu → Toggles → Fresh Profile resets session data without rejoin
- [x] Dev menu → Toggles → Join Sequence Done toggles the flag live
- [x] `/sword dev freshprofile PlayerName` from console works
- [x] Both flags toggle back off and restore normal behavior