### PR TITLE
[Feat] Ability pickup refund, depleted slot interactions, and chargeable ability system

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,18 @@ tasks {
         // Your plugin's jar (or shadowJar if present) will be used automatically.
         minecraftVersion("1.21.8")
 
+        // Auto-download required dependency plugins on first run.
+        // Jars are cached in run/plugins/ and only re-downloaded when missing.
+        // If a download fails, verify the release tag at the linked repo — tag format varies by project.
+        downloadPlugins {
+            // https://github.com/PZDonny/DisplayEntityUtils/releases — tag format: "3.4.3" (no v prefix)
+            github("PZDonny", "DisplayEntityUtils", "3.4.3", "displayentityutils-3.4.3.jar")
+            // https://github.com/retrooper/packetevents/releases — tag format: "v2.11.2"
+            github("retrooper", "packetevents", "v2.11.2", "packetevents-spigot-2.11.2.jar")
+            // https://github.com/dmulloy2/ProtocolLib/releases — tag format: "5.4.0" (no v prefix)
+            github("dmulloy2", "ProtocolLib", "5.4.0", "ProtocolLib.jar")
+        }
+
         // IMPORTANT: Auto-accept Minecraft EULA for development/testing
         // By using this runServer task, you agree to Minecraft's EULA: https://aka.ms/MinecraftEULA
         // This is standard practice for plugin development environments

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -2605,7 +2605,7 @@ public class Config {
         ); }
 
         /** Delay for flat dash height boost in milliseconds. */
-        public static int FLAT_DASH_HEIGHT_BOOST_DELAY_MS = 100;
+        public static int FLAT_DASH_HEIGHT_BOOST_DELAY_MS = 75;
         static { register(
             "movement.flat_dash_height_boost_delay_ms",
             FLAT_DASH_HEIGHT_BOOST_DELAY_MS, Integer.class,

--- a/src/main/java/btm/sword/system/action/movement/Dash.java
+++ b/src/main/java/btm/sword/system/action/movement/Dash.java
@@ -18,6 +18,7 @@ import btm.sword.system.control.PredicateRunnablePair;
 import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.impl.Combatant;
+import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.entity.umbral.UmbralBlade;
 import btm.sword.system.entity.umbral.statemachine.state.LodgedState;
 import btm.sword.system.entity.umbral.statemachine.state.WaitingState;
@@ -96,6 +97,13 @@ public class Dash {
                 }
             }
         }
+        // Holding an ability item — only pick up matching ability projectiles
+        else if (executor instanceof SwordPlayer sp && !sp.notHoldingAbilityItem()) {
+            targetedDisplay = raycastForAbilityProjectile();
+            if (targetedDisplay != null) {
+                dashType = flatDash ? DashType.FLAT_TO_ITEM : DashType.NORMAL_TO_ITEM;
+            }
+        }
 
         if (dashType == DashType.NOTHING || (targetedDisplay != null && isDashToItemImpeded())) {
             if (flatDash) {
@@ -167,6 +175,27 @@ public class Dash {
         );
 
         if (itemDisplay != null) Debug.movement("Normal Item Targeted.. itemDisplay=" + itemDisplay.getName());
+
+        return itemDisplay;
+    }
+
+    /**
+     * Raycasts for ability projectiles only (items tagged with {@code ABILITY_ID_KEY}).
+     * Used when the executor is holding an ability item and can only pick up matching projectiles.
+     */
+    public ItemDisplay raycastForAbilityProjectile() {
+        ItemDisplay itemDisplay = (ItemDisplay) HitboxUtil.ray(
+            executor.eyeLoc(),
+            executor.dir(),
+            MAX_STRAIGHT_DASH_DISTANCE.get(),
+            NORMAL_ITEM_RAY_WIDTH.get(),
+            entity -> entity instanceof ItemDisplay id &&
+                !entity.isDead() &&
+                InteractiveItemArbiter.checkIfInteractive(id) &&
+                InteractiveItemArbiter.isAbilityProjectile(id)
+        );
+
+        if (itemDisplay != null) Debug.movement("Ability Projectile Targeted.. itemDisplay=" + itemDisplay.getName());
 
         return itemDisplay;
     }

--- a/src/main/java/btm/sword/system/action/movement/Dash.java
+++ b/src/main/java/btm/sword/system/action/movement/Dash.java
@@ -26,6 +26,7 @@ import btm.sword.utility.Prefab;
 import btm.sword.utility.display.ParticleWrapper;
 import btm.sword.utility.entity.EntityUtil;
 import btm.sword.utility.entity.HitboxUtil;
+import btm.sword.utility.math.VectorUtil;
 import btm.sword.utility.sound.SoundUtil;
 import btm.sword.utility.sound.SwordSoundType;
 
@@ -40,6 +41,7 @@ public class Dash {
     private DashType dashType;
     private double dashPower;
     private boolean holdingLink;
+    private boolean itemRetrieved;
 
     private static final Supplier<Double> MAX_STRAIGHT_DASH_DISTANCE = () -> Config.Movement.DASH_MAX_DISTANCE;
     private static final Supplier<Double> NORMAL_ITEM_RAY_WIDTH = () -> Config.Movement.DASH_RAY_HITBOX_RADIUS;
@@ -64,6 +66,7 @@ public class Dash {
     }
 
     public void execute() {
+        itemRetrieved = false;
         dashType = DashType.NOTHING;
         onGround = EntityUtil.isOnGround(ex);
         holdingLink = executor.holdingSoulLink();
@@ -225,16 +228,27 @@ public class Dash {
 
         boolean umbralHeightBoost = !holdingLink || targetedBlade.inState(WaitingState.class) || targetedBlade.inState(LodgedState.class);
 
+        final Vector exDir = executor.dir();
+
         if (umbralHeightBoost &&
             heightDiff <= Config.Movement.DASH_FLAT_HEIGHT_UPPER &&
             heightDiff > Config.Movement.DASH_FLAT_HEIGHT_LOWER) {
-            executor.setVelocity(executor.dir()
-                .add(Config.Direction.UP().multiply(Config.Movement.DASH_FLAT_ITEM_DASH_UPWARD_SCALER)));
+
+            Vector dashVelocity = exDir.add(
+                Config.Direction.UP().multiply(Config.Movement.DASH_FLAT_ITEM_DASH_UPWARD_SCALER)
+            );
+            executor.setVelocity(dashVelocity);
         }
-        SwordScheduler.runBukkitTaskLater(() ->
-                executor.setVelocity(executor.dir().multiply(Math.log(distanceToItem * Config.Movement.DASH_FLAT_ITEM_DASH_DISTANCE_SCALER))),
-            !umbralHeightBoost ? 0 : Config.Movement.FLAT_DASH_HEIGHT_BOOST_DELAY_MS, TimeUnit.MILLISECONDS
-        );
+
+        final Vector toItem = calcVectorToItem().normalize();
+        if (VectorUtil.isBroken(toItem)) return;
+
+        if (!itemRetrieved && distanceToItem > 3) { // TODO: COnfig
+            SwordScheduler.runBukkitTaskLater(() -> // Velocity applied after the initial height boost
+                    executor.setVelocity(toItem.multiply(Math.log(distanceToItem * Config.Movement.DASH_FLAT_ITEM_DASH_DISTANCE_SCALER))),
+                !umbralHeightBoost ? 0 : Config.Movement.FLAT_DASH_HEIGHT_BOOST_DELAY_MS, TimeUnit.MILLISECONDS
+            );
+        }
     }
 
     private void scheduleCheckForItemPickup() {
@@ -263,6 +277,7 @@ public class Dash {
         SoundUtil.playSound(ex, SwordSoundType.ENTITY_ENDER_DRAGON_FLAP, Config.Movement.DASH_FLAP_SOUND_VOLUME, Config.Movement.DASH_FLAP_SOUND_PITCH);
         SoundUtil.playSound(ex, SwordSoundType.ENTITY_PLAYER_ATTACK_SWEEP, Config.Movement.DASH_SWEEP_SOUND_VOLUME, Config.Movement.DASH_SWEEP_SOUND_PITCH);
         executor.setVelocity(calcPostRetrievalVector());
+        itemRetrieved = true;
         InteractiveItemArbiter.onGrab(targetedDisplay, executor); // here is where the display is taken care of
     }
 

--- a/src/main/java/btm/sword/system/action/skill/AbilityType.java
+++ b/src/main/java/btm/sword/system/action/skill/AbilityType.java
@@ -1,0 +1,20 @@
+package btm.sword.system.action.skill;
+
+/**
+ * Classifies the physical and interaction behavior of an ability.
+ *
+ * <ul>
+ *   <li>{@link #ACTIVATABLE} — Press to activate; has a cooldown; never consumed.</li>
+ *   <li>{@link #THROWABLE} — Aimed-throw on hold; the physical item is consumed on each throw.</li>
+ *   <li>{@link #CONSUMABLE} — One-shot activation; the physical item is consumed on use.</li>
+ *   <li>{@link #PASSIVE} — Always active while the slot is equipped; no activation required.</li>
+ *   <li>{@link #QUEST} — Fully usable ability <em>and</em> surrenderable as a quest turn-in.</li>
+ * </ul>
+ */
+public enum AbilityType {
+    ACTIVATABLE,
+    THROWABLE,
+    CONSUMABLE,
+    PASSIVE,
+    QUEST
+}

--- a/src/main/java/btm/sword/system/action/skill/AbilityType.java
+++ b/src/main/java/btm/sword/system/action/skill/AbilityType.java
@@ -5,6 +5,7 @@ package btm.sword.system.action.skill;
  *
  * <ul>
  *   <li>{@link #ACTIVATABLE} — Press to activate; has a cooldown; never consumed.</li>
+ *   <li>{@link #CHARGEABLE} — Hold right-click to charge; release to fire a scaled projectile.</li>
  *   <li>{@link #THROWABLE} — Aimed-throw on hold; the physical item is consumed on each throw.</li>
  *   <li>{@link #CONSUMABLE} — One-shot activation; the physical item is consumed on use.</li>
  *   <li>{@link #PASSIVE} — Always active while the slot is equipped; no activation required.</li>
@@ -13,6 +14,7 @@ package btm.sword.system.action.skill;
  */
 public enum AbilityType {
     ACTIVATABLE,
+    CHARGEABLE,
     THROWABLE,
     CONSUMABLE,
     PASSIVE,

--- a/src/main/java/btm/sword/system/action/skill/AbilityUseType.java
+++ b/src/main/java/btm/sword/system/action/skill/AbilityUseType.java
@@ -1,0 +1,22 @@
+package btm.sword.system.action.skill;
+
+/**
+ * Describes how an ability's uses are consumed when activated.
+ *
+ * <ul>
+ *   <li>{@link #STACK} — each use decrements the item's stack count; depleted at zero.</li>
+ *   <li>{@link #DURABILITY} — each use damages the item's durability bar; depleted when broken.</li>
+ *   <li>{@link #COOLDOWN} — the item is never consumed; activation only triggers a cooldown.</li>
+ * </ul>
+ */
+public enum AbilityUseType {
+
+    /** Item stack count decrements each use; depleted at zero. */
+    STACK,
+
+    /** Single item whose durability bar decreases; depleted when broken. */
+    DURABILITY,
+
+    /** Never consumed — activation only triggers a cooldown. */
+    COOLDOWN
+}

--- a/src/main/java/btm/sword/system/action/skill/README.md
+++ b/src/main/java/btm/sword/system/action/skill/README.md
@@ -1,0 +1,281 @@
+# Skill & Ability System
+
+## Overview
+
+The skill system manages the player's equipped abilities — combat skills tied to the UmbralBlade, throwable and consumable active abilities, and passive modifiers. It covers four concerns:
+
+1. **Skill identity and registration** — what skills exist (`SkillId`, `SkillIds`, `SkillRegistry`)
+2. **Skill behavior contracts** — what a skill does and how it activates (`Skill`, `ActiveSkill`, `AbilitySkill`, and their subclasses)
+3. **Per-player state** — which skills a player has unlocked and equipped (`PlayerSkillContainer`, `SkillSlot`)
+4. **Input resolution** — bridging equipped skills into the `InputExecutionTree` (`SkillSlotActionFactory`)
+
+Skills live in the player's `CombatProfile` via `PlayerSkillContainer`. The `InputRegistrar` reads the container through `SkillSlotActionFactory` to wire each slot dynamically into the trie-based input system at skill-node resolution time.
+
+---
+
+## Class Hierarchy
+
+```
+Skill (interface)
+│   id(), type(), icon(), name(), description()
+│
+├── ActiveSkill (abstract)
+│   │   execute(Combatant), calculateCooldown(Combatant), canPerform(Combatant)
+│   │   requiresHold() → false by default
+│   │   getCachedInputAction() / setCachedInputAction() — cooldown cache
+│   │
+│   ├── ShadowSlashSkill          — UMBRAL slot; stub execute (placeholder)
+│   ├── VoidLungeSkill            — UMBRAL slot; blinks behind targeted entity, reclaims blade
+│   │
+│   └── AbilitySkill (interface, also extends Skill)
+│       │   abilityType(), buildWorldItem(), consumesOnUse(), requiresPhysicalItemToUse()
+│       │   useTypes(), maxUses(), maxDurability(), cooldownTicks(), isWeapon()
+│       │
+│       ├── ActivatableAbility (abstract extends ActiveSkill implements AbilitySkill)
+│       │   │   Press to activate; cooldown only; item never consumed
+│       │   │
+│       │   ├── ConsumableAbility (abstract)
+│       │   │       One-shot activation; item consumed on use; STACK use type by default
+│       │   │
+│       │   ├── ThrowableAbility (abstract)
+│       │   │   │   Hold-activated throw; item consumed per throw; STACK use type by default
+│       │   │   │   requiresHold() → true
+│       │   │   │
+│       │   │   └── KnifeThrowAbility  — ACTIVE slot; STACK + COOLDOWN; isWeapon = true
+│       │   │
+│       │   └── QuestAbility (abstract)
+│       │           Activatable like normal but also surrenderable as a quest turn-in
+│       │           onSurrender(Combatant) — item removal handled externally by AbilitySurrenderUtil
+│       │
+│       └── PassiveAbilitySkill (abstract extends PassiveSkill implements AbilitySkill)
+│               Always active while equipped; never consumed
+│
+├── PassiveSkill (abstract)
+│       Default AMETHYST_SHARD icon; no activation logic (passive effect only)
+│
+└── ConsumableActive (abstract extends ActiveSkill)
+        Stub; intended for active skills that track uses/repair (no concrete implementations yet)
+```
+
+### Key distinction: `ActiveSkill` vs `AbilitySkill`
+
+- `ActiveSkill` — any skill that has an executable `execute()` method and a cooldown. Covers both UmbralBlade skills (slot-bound, no physical item) and ability skills (physical world item).
+- `AbilitySkill` — a marker interface that adds the world-item contract (`buildWorldItem()`, consumption rules, use-type tracking). **Not all `ActiveSkill`s are `AbilitySkill`s.** UmbralBlade skills like `ShadowSlashSkill` and `VoidLungeSkill` extend `ActiveSkill` directly — they have no physical item.
+
+---
+
+## Enums
+
+### `SkillType`
+
+```
+UMBRAL   — Tied to the UmbralBlade; equipped in UMBRAL_1/2/3 slots
+ACTIVE   — Physical-item-backed ability; equipped in ACTIVE_1/2 slots
+PASSIVE  — Always-on modifier; equipped in PASSIVE_CORE/1/2/3 slots
+```
+
+### `AbilityType`
+
+Classifies the interaction pattern of an `AbilitySkill`:
+
+| Value | Meaning |
+|---|---|
+| `ACTIVATABLE` | Press to activate; cooldown only; item never consumed |
+| `THROWABLE` | Held right-click to throw; physical item consumed per throw |
+| `CONSUMABLE` | One-shot activation; physical item consumed on use |
+| `PASSIVE` | Always active while equipped; no input required |
+| `QUEST` | Activatable + surrenderable as a quest turn-in |
+
+**Important: `AbilityType` is currently never consumed by any system.** Every concrete `AbilitySkill` subclass declares it via `abilityType()`, but no caller ever reads the return value — no switch statements, no serialization, no UI dispatch. The type information is structurally encoded in the class hierarchy instead (e.g., `instanceof ThrowableAbility`). `AbilityType` is either planned for future serialization/UI use or is genuinely dead code.
+
+### `AbilityUseType`
+
+Controls how an ability slot's resource is depleted. Multiple types may be combined on a single ability (they are non-exclusive):
+
+| Value | Effect |
+|---|---|
+| `STACK` | Each activation decrements item stack count; slot depletes at zero |
+| `DURABILITY` | Each activation degrades the item's durability bar; slot depletes when broken |
+| `COOLDOWN` | Applies a Minecraft item-cooldown overlay; never depletes the slot |
+
+`AbilitySlotManager` (in `item/special/`) is the actual executor of use-type logic — it reads `useTypes()`, `maxUses()`, `maxDurability()`, and `cooldownTicks()` from the ability and applies them to the player's hotbar item each time `consumeUse()` is called.
+
+---
+
+## `SkillId` and `SkillIds`
+
+`SkillId` is a thin record wrapper over a Bukkit `NamespacedKey`. It provides:
+- `SkillId.of(namespace, value)` — primary factory
+- `SkillId.parse(serialized)` — for deserialization from `"namespace:value"` strings
+- `asString()` — returns `"namespace:value"` for storage
+
+`SkillIds` is a non-instantiable constants class holding every registered skill ID:
+
+```
+sword:none                       — sentinel for an empty slot
+sword:locked                     — sentinel for a locked (unavailable) slot
+sword:umbral_blade.shadow_slash  — UmbralBlade skill slot 1
+sword:umbral_blade.void_lunge    — UmbralBlade skill slot 2
+sword:active.knife_throw         — Active ability slot
+sword:passive.bleed_mastery      — Passive skill (registered as ID only; no impl yet)
+```
+
+`SkillIds.getAll()` returns the full `ALL` list. **When adding a new skill, you must add its `SkillId` constant here AND add it to `ALL`.** The class has two reminder comments for this; missing the `ALL` entry will cause the skill to never appear in player skill pools.
+
+---
+
+## `SkillRegistry`
+
+A static `HashMap<SkillId, Skill>` populated via a `static {}` block. No Bukkit API is needed at registration time, so initialization is safe at class-load.
+
+```java
+// Registration
+register(new VoidLungeSkill());
+register(new ShadowSlashSkill());
+register(new KnifeThrowAbility());
+
+// Lookup
+Skill skill = SkillRegistry.get(SkillIds.VOID_LUNGE);
+```
+
+`get()` returns `null` for unregistered IDs — callers must null-check. Note that `SkillIds.NONE` and `SkillIds.LOCKED` are never registered; they are sentinel values only and will always return `null` from `get()`.
+
+---
+
+## `SkillSlot` and `PlayerSkillContainer`
+
+### `SkillSlot`
+
+Nine slots partitioned by type:
+
+| Slot | Type |
+|---|---|
+| `UMBRAL_1`, `UMBRAL_2`, `UMBRAL_3` | `UMBRAL` |
+| `ACTIVE_1`, `ACTIVE_2` | `ACTIVE` |
+| `PASSIVE_CORE`, `PASSIVE_1`, `PASSIVE_2`, `PASSIVE_3` | `PASSIVE` |
+
+`SkillSlotRules.canEquip(skill, slot)` enforces type compatibility — a skill can only be equipped in a slot whose type matches `skill.type()`.
+
+### `PlayerSkillContainer`
+
+Owned by `CombatProfile`, which is owned by each `SwordPlayer`. Tracks two things:
+
+1. **Available skills** — skills the player has unlocked, stored as `EnumMap<SkillType, Set<SkillId>>`. Populated from `PlayerDataStore` on login; new players get all skills from `SkillIds.getAll()` (the no-arg constructor for testing).
+2. **Equipped skills** — `EnumMap<SkillSlot, SkillId>` mapping each slot to an equipped skill (or `NONE`/`LOCKED`).
+
+Key behaviors:
+- `equip(slot, id)` — puts the skill in the slot; if the same skill was already in another slot, that other slot is cleared to `NONE`. Skills cannot be equipped in two slots simultaneously.
+- `unlock(slot)` — transitions a slot from `LOCKED` to `NONE` (unlocks it for equipping).
+- `freeSkillIds(type)` — returns skills of the given type that are available but not currently equipped in any slot. Used by the skill selection menu to populate options.
+- `allAvailableSkillIds()` — flat list of every unlocked skill; used by the persistence layer on save.
+
+---
+
+## `SkillSlotActionFactory`
+
+Bridges `PlayerSkillContainer` into the `InputExecutionTree`. Called by `InputRegistrar` when building the trie node for each skill slot.
+
+```java
+// tap-activated skill (UMBRAL or non-throwable ACTIVE)
+InputAction action = SkillSlotActionFactory.create(player, SkillSlot.UMBRAL_1);
+
+// hold-activated skill (ACTIVE with requiresHold() == true)
+InputAction action = SkillSlotActionFactory.create(player, SkillSlot.ACTIVE_1, true);
+```
+
+Behavior:
+- Returns `null` if no skill is equipped, if the equipped skill is not an `ActiveSkill`, or if the hold-variant flag mismatches `skill.requiresHold()`. A `null` return makes the input branch silently inert.
+- Caches the built `InputAction` on the `ActiveSkill` instance via `getCachedInputAction()` / `setCachedInputAction()`. This preserves the cooldown state (`timeLastExecuted`) across dynamic re-resolves, since skill-slot trie nodes re-invoke the supplier on every step rather than holding a static reference.
+- Hardcodes two skill-specific overrides for `VoidLungeSkill` — cast duration (250 ms) and soulfire cost (40). This coupling is a known smell: the factory contains skill-specific knowledge that belongs on the skill itself.
+
+---
+
+## History System
+
+`PlayerAbilityHistory` is a session-scoped, chronologically-ordered log of ability events per player. It tracks two event types via `AbilityHistoryAction`:
+- `USED` — a consumable or throwable ability's physical item was consumed
+- `SURRENDERED` — a quest ability was surrendered as a turn-in
+
+`AbilityHistoryEntry` records: the skill ID, the display name at event time (captured as plain text via `PlainTextComponentSerializer`), the action type, and an epoch-millisecond timestamp.
+
+The history is loaded from the database on login and saved on quit via `AbilityHistoryRepository`. Item removal and `recordSurrender()` are triggered externally by `AbilitySurrenderUtil` (not in this package).
+
+---
+
+## How to Add a New Skill
+
+### 1. Choose the right base class
+
+| Goal | Extend |
+|---|---|
+| UmbralBlade-slot skill (no physical item) | `ActiveSkill` |
+| Press-to-activate item ability | `ActivatableAbility` |
+| Throw-on-hold item ability | `ThrowableAbility` |
+| One-shot consumable item ability | `ConsumableAbility` |
+| Quest turn-in item ability | `QuestAbility` |
+| Always-on passive item ability | `PassiveAbilitySkill` |
+
+### 2. Implement required methods
+
+For `ActiveSkill`-based skills:
+- `id()` — return your `SkillIds` constant
+- `type()` — return `SkillType.UMBRAL`, `ACTIVE`, or `PASSIVE`
+- `execute(Combatant)` — the effect
+- `calculateCooldown(Combatant)` — cooldown in milliseconds
+- `canPerform(Combatant)` — pre-cast guard
+- `icon()` — menu display item
+- `name()` — Adventure `Component`
+- `description()` — list of `Component`s
+
+For `AbilitySkill`-based skills, also implement:
+- `buildWorldItem()` — build the base `ItemStack`, then call `AbilityItemBuilder.tag(item, id())` to stamp the PDC identity key
+- Override `useTypes()`, `maxUses()`, `maxDurability()`, `cooldownTicks()`, and `isWeapon()` as needed
+
+For `ThrowableAbility`, `execute()` should call `ThrowAction.throwDirect(combatant, projectile, scale, velocity)`.
+
+### 3. Register the skill ID
+
+In `SkillIds.java`:
+```java
+public static final SkillId MY_SKILL = SkillId.of("sword", "active.my_skill");
+```
+
+Then add it to the `ALL` list — **both steps are required.**
+
+### 4. Register the skill implementation
+
+In `SkillRegistry.java`, inside the `static {}` block:
+```java
+register(new MySkillImpl());
+```
+
+### 5. Wire to input (optional — UMBRAL and ACTIVE slots only)
+
+If your skill goes in a slot that is already handled by `InputRegistrar`, no additional wiring is needed. `SkillSlotActionFactory.create()` resolves it at runtime from `PlayerSkillContainer`.
+
+If your skill requires a hold-activated input path, ensure `requiresHold()` returns `true`. The factory will then only return a non-null action on the `holdVariant = true` code path in `InputRegistrar`.
+
+---
+
+## Interactions with Other Systems
+
+| System | Interaction |
+|---|---|
+| `InputExecutionTree` | `SkillSlotActionFactory` produces `InputAction` instances consumed by the trie at skill-slot nodes |
+| `CombatProfile` | Owns `PlayerSkillContainer`; retrieved via `player.getCombatProfile().getPlayerSkillContainer()` |
+| `AbilitySlotManager` | Reads `AbilitySkill` methods (`useTypes`, `buildWorldItem`, etc.) to manage hotbar slot items |
+| `PlayerDataStore` / `SqlitePlayerDataStore` | Persists and restores `PlayerSkillContainer` state (equipped + available skill IDs) |
+| `AbilityHistoryRepository` | Persists and loads `PlayerAbilityHistory` entries |
+| `SkillSelectionMenu` / `CharacterMenu` | Read `PlayerSkillContainer` to display and modify equipped skills |
+| `UmbralBlade` / `UmbralStateMachine` | UmbralBlade skills trigger blade FSM transitions indirectly via `UmbralBladeAction` calls |
+
+---
+
+## Known Issues and Limitations
+
+- **`AbilityType` is never consumed.** All five base classes declare it but no caller reads the value. It is safe to ignore for now but represents either dead code or unfinished infrastructure.
+- **`ConsumableActive` is a stub.** It extends `ActiveSkill` with no added behavior and has no concrete implementations.
+- **`SkillIds.BLEED_MASTERY` has no implementation.** The ID is declared and included in `ALL` but no class is registered in `SkillRegistry`. `SkillRegistry.get(SkillIds.BLEED_MASTERY)` returns `null`.
+- **`SkillSlotActionFactory` hardcodes `VoidLungeSkill` specifics.** Cast duration and soulfire cost are set conditionally by `instanceof` check. New skills with non-default cast durations or soulfire costs must add another branch here until the factory is refactored.
+- **`SkillSlotActionFactory.create()` silently returns `null` on hold/tap mismatch.** A misconfigured input tree registration (e.g., registering a tap node for a throwable skill) produces no error — the node just never fires.
+- **`ShadowSlashSkill.name()` returns `null`.** The `execute()` body is a debug message. This is a placeholder; the skill is not yet implemented.

--- a/src/main/java/btm/sword/system/action/skill/SkillIds.java
+++ b/src/main/java/btm/sword/system/action/skill/SkillIds.java
@@ -36,6 +36,9 @@ public final class SkillIds {
     public static final SkillId KNIFE_THROW =
         SkillId.of("sword", "active.knife_throw");
 
+    public static final SkillId ICE_SPELL =
+        SkillId.of("sword", "active.ice_spell");
+
 
     /* =========================
        Passive Skills
@@ -66,6 +69,7 @@ public final class SkillIds {
         SHADOW_SLASH,
         VOID_LUNGE,
         KNIFE_THROW,
+        ICE_SPELL,
         BLEED_MASTERY,
         TEST_ALPHA,
         TEST_BETA,

--- a/src/main/java/btm/sword/system/action/skill/SkillIds.java
+++ b/src/main/java/btm/sword/system/action/skill/SkillIds.java
@@ -45,6 +45,20 @@ public final class SkillIds {
         SkillId.of("sword", "passive.bleed_mastery");
 
 
+    /* =========================
+       Test Stubs (TODO: remove once real found abilities replace these)
+       ========================= */
+
+    public static final SkillId TEST_ALPHA =
+        SkillId.of("sword", "active.test_alpha");
+
+    public static final SkillId TEST_BETA =
+        SkillId.of("sword", "active.test_beta");
+
+    public static final SkillId TEST_GAMMA =
+        SkillId.of("sword", "active.test_gamma");
+
+
     // Remember to add new skills to this list!
     private static final List<SkillId> ALL = List.of(
         NONE,
@@ -52,7 +66,10 @@ public final class SkillIds {
         SHADOW_SLASH,
         VOID_LUNGE,
         KNIFE_THROW,
-        BLEED_MASTERY
+        BLEED_MASTERY,
+        TEST_ALPHA,
+        TEST_BETA,
+        TEST_GAMMA
     );
 
     public static List<SkillId> getAll() {

--- a/src/main/java/btm/sword/system/action/skill/SkillRegistry.java
+++ b/src/main/java/btm/sword/system/action/skill/SkillRegistry.java
@@ -2,6 +2,7 @@ package btm.sword.system.action.skill;
 
 import java.util.HashMap;
 
+import btm.sword.system.action.skill.type.impl.active.IceSpellAbility;
 import btm.sword.system.action.skill.type.impl.active.KnifeThrowAbility;
 import btm.sword.system.action.skill.type.impl.active.TestAlphaAbility;
 import btm.sword.system.action.skill.type.impl.active.TestBetaAbility;
@@ -17,6 +18,7 @@ public class SkillRegistry {
         register(new VoidLungeSkill());
         register(new ShadowSlashSkill());
         register(new KnifeThrowAbility());
+        register(new IceSpellAbility());
         // TODO: remove once real found abilities replace test stubs
         register(new TestAlphaAbility());
         register(new TestBetaAbility());

--- a/src/main/java/btm/sword/system/action/skill/SkillRegistry.java
+++ b/src/main/java/btm/sword/system/action/skill/SkillRegistry.java
@@ -2,6 +2,10 @@ package btm.sword.system.action.skill;
 
 import java.util.HashMap;
 
+import btm.sword.system.action.skill.type.impl.active.KnifeThrowAbility;
+import btm.sword.system.action.skill.type.impl.active.TestAlphaAbility;
+import btm.sword.system.action.skill.type.impl.active.TestBetaAbility;
+import btm.sword.system.action.skill.type.impl.active.TestGammaAbility;
 import btm.sword.system.action.skill.type.impl.umbral.ShadowSlashSkill;
 import btm.sword.system.action.skill.type.impl.umbral.VoidLungeSkill;
 
@@ -12,6 +16,11 @@ public class SkillRegistry {
     static {
         register(new VoidLungeSkill());
         register(new ShadowSlashSkill());
+        register(new KnifeThrowAbility());
+        // TODO: remove once real found abilities replace test stubs
+        register(new TestAlphaAbility());
+        register(new TestBetaAbility());
+        register(new TestGammaAbility());
     }
 
     private static void register(Skill skill) {

--- a/src/main/java/btm/sword/system/action/skill/container/PlayerSkillContainer.java
+++ b/src/main/java/btm/sword/system/action/skill/container/PlayerSkillContainer.java
@@ -2,6 +2,7 @@ package btm.sword.system.action.skill.container;
 
 import java.util.Collection;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -17,11 +18,42 @@ import btm.sword.system.action.skill.SkillType;
 public final class PlayerSkillContainer {
 
     private final EnumMap<SkillType, Set<SkillId>> availableSkillsMap = new EnumMap<>(SkillType.class);
+
+    /**
+     * Tracks the availability state of every skill the player has ever discovered.
+     * A skill is only shown in menus if it appears in this map. Its state governs
+     * whether it can be equipped ({@link SkillAvailability#AVAILABLE}) or only viewed
+     * ({@link SkillAvailability#DEPLETED}, {@link SkillAvailability#RELINQUISHED}).
+     */
+    private final Map<SkillId, SkillAvailability> availabilityMap = new HashMap<>();
+
     private final EnumMap<SkillSlot, SkillId> equipped;
+    private final Map<SkillSlot, SkillSlotState> slotStates = new EnumMap<>(SkillSlot.class);
 
     public PlayerSkillContainer(Collection<SkillId> availableSkills, EnumMap<SkillSlot, SkillId> equipped) {
         initializeSkillMap();
         addAvailableSkills(availableSkills);
+        this.equipped = equipped;
+    }
+
+    /**
+     * Constructs a container from persisted data that includes per-skill availability states.
+     * Used exclusively by the persistence layer.
+     *
+     * @param skillAvailabilities the persisted map of skill IDs to their saved availability state
+     * @param equipped            the persisted equipped-slot map
+     */
+    public PlayerSkillContainer(Map<SkillId, SkillAvailability> skillAvailabilities,
+            EnumMap<SkillSlot, SkillId> equipped) {
+        initializeSkillMap();
+        for (Map.Entry<SkillId, SkillAvailability> entry : skillAvailabilities.entrySet()) {
+            SkillId id = entry.getKey();
+            if (id.equals(SkillIds.NONE) || id.equals(SkillIds.LOCKED)) continue;
+            Skill skill = SkillRegistry.get(id);
+            if (skill == null) continue;
+            availabilityMap.put(id, entry.getValue());
+            availableSkillsMap.get(skill.type()).add(id);
+        }
         this.equipped = equipped;
     }
 
@@ -50,15 +82,58 @@ public final class PlayerSkillContainer {
 
     public void addAvailableSkills(Collection<SkillId> skillIds) {
         for (SkillId id : skillIds) {
-            if (id.equals(SkillIds.NONE) || id.equals(SkillIds.LOCKED)) {
-                continue;
-            }
-            Skill skill = SkillRegistry.get(id);
-            if (skill == null) {
-                continue;
-            }
-            availableSkillsMap.get(skill.type()).add(id);
+            discover(id);
         }
+    }
+
+    /**
+     * Adds a skill to this player's discovered pool as {@link SkillAvailability#AVAILABLE}.
+     * If the skill has already been discovered, its existing state is not changed.
+     *
+     * @param id the skill to discover; NONE and LOCKED are silently ignored
+     */
+    public void discover(SkillId id) {
+        if (id.equals(SkillIds.NONE) || id.equals(SkillIds.LOCKED)) return;
+        Skill skill = SkillRegistry.get(id);
+        if (skill == null) return;
+        if (availabilityMap.containsKey(id)) return;
+        availabilityMap.put(id, SkillAvailability.AVAILABLE);
+        availableSkillsMap.get(skill.type()).add(id);
+    }
+
+    /**
+     * Updates the availability state of an already-discovered skill.
+     * Has no effect if the skill has not been discovered yet.
+     *
+     * @param id           the skill whose state to update
+     * @param availability the new state
+     */
+    public void setAvailability(SkillId id, SkillAvailability availability) {
+        if (availabilityMap.containsKey(id)) {
+            availabilityMap.put(id, availability);
+        }
+    }
+
+    /**
+     * Returns the current availability state of a skill, or {@code null} if it
+     * has not been discovered by this player yet.
+     *
+     * @param id the skill to query
+     * @return the availability state, or {@code null}
+     */
+    public SkillAvailability getAvailability(SkillId id) {
+        return availabilityMap.get(id);
+    }
+
+    /**
+     * Returns {@code true} if the skill has been discovered and is currently
+     * {@link SkillAvailability#AVAILABLE} (i.e. can be equipped).
+     *
+     * @param id the skill to check
+     * @return {@code true} if equippable
+     */
+    public boolean isEquippable(SkillId id) {
+        return availabilityMap.get(id) == SkillAvailability.AVAILABLE;
     }
 
     public void unlock(SkillSlot slot) {
@@ -69,12 +144,7 @@ public final class PlayerSkillContainer {
     }
 
     public boolean isAvailable(SkillId id) {
-        for (Map.Entry<SkillType, Set<SkillId>> entry : availableSkillsMap.entrySet()) {
-            if (entry.getValue().contains(id)) {
-                return true;
-            }
-        }
-        return false;
+        return availabilityMap.get(id) == SkillAvailability.AVAILABLE;
     }
 
     public SkillId getEquipped(SkillSlot slot) {
@@ -86,12 +156,11 @@ public final class PlayerSkillContainer {
      * Avoid calling with None as that will generate redundant work. Instead call {@link #unequip(SkillSlot)}
      *
      * @param slot the slot to equip the id to
-     * @param id the id to be equipped
+     * @param id the id to be equipped; must be {@link SkillAvailability#AVAILABLE}
      */
     public void equip(SkillSlot slot, SkillId id) {
-        if (equipped.get(slot).equals(SkillIds.LOCKED)) {
-            return;
-        }
+        if (equipped.get(slot).equals(SkillIds.LOCKED)) return;
+        if (!isEquippable(id)) return;
 
         equipped.put(slot, id);
 
@@ -113,10 +182,70 @@ public final class PlayerSkillContainer {
         equipped.put(slot, SkillIds.NONE);
     }
 
+    /**
+     * Returns discovered skills of the given type that are {@link SkillAvailability#AVAILABLE}
+     * and not currently equipped in any slot. These are the skills the player can select from
+     * in the equip menu.
+     *
+     * @param type the skill type to filter by
+     * @return equippable, unequipped skills of that type
+     */
     public List<SkillId> freeSkillIds(SkillType type) {
         Set<SkillId> allSkillsOfType = new HashSet<>(availableSkillsMap.get(type));
         allSkillsOfType.removeAll(equipped.values());
-        return allSkillsOfType.stream().toList();
+        return allSkillsOfType.stream()
+            .filter(id -> availabilityMap.get(id) == SkillAvailability.AVAILABLE)
+            .toList();
+    }
+
+    /**
+     * Returns discovered skills of the given type that are {@link SkillAvailability#DEPLETED}
+     * or {@link SkillAvailability#RELINQUISHED} and not currently equipped. These are shown in
+     * the menu as locked — visible but not selectable.
+     *
+     * @param type the skill type to filter by
+     * @return discovered but locked skills of that type
+     */
+    public List<SkillId> lockedSkillIds(SkillType type) {
+        Set<SkillId> allSkillsOfType = new HashSet<>(availableSkillsMap.get(type));
+        allSkillsOfType.removeAll(equipped.values());
+        return allSkillsOfType.stream()
+            .filter(id -> {
+                SkillAvailability a = availabilityMap.get(id);
+                return a == SkillAvailability.DEPLETED || a == SkillAvailability.RELINQUISHED;
+            })
+            .toList();
+    }
+
+    /**
+     * Returns the persisted resource state for the given slot, or {@link SkillSlotState#EMPTY}
+     * if no state has been recorded yet.
+     *
+     * @param slot the ability slot to query
+     * @return the current slot state; never {@code null}
+     */
+    public SkillSlotState getSlotState(SkillSlot slot) {
+        return slotStates.getOrDefault(slot, SkillSlotState.EMPTY);
+    }
+
+    /**
+     * Stores the resource state for the given slot.
+     *
+     * @param slot  the ability slot to update
+     * @param state the new state; must not be {@code null}
+     */
+    public void setSlotState(SkillSlot slot, SkillSlotState state) {
+        slotStates.put(slot, state);
+    }
+
+    /**
+     * Returns all slot states for persistence.
+     * Only slots with explicitly recorded state are included (EMPTY slots are omitted).
+     *
+     * @return an unmodifiable copy of the slot-state map
+     */
+    public Map<SkillSlot, SkillSlotState> allSlotStates() {
+        return Map.copyOf(slotStates);
     }
 
     public Map<SkillSlot, SkillId> equippedView() {
@@ -124,14 +253,12 @@ public final class PlayerSkillContainer {
     }
 
     /**
-     * Returns all unlocked skill IDs across every skill type as a flat list.
-     * Used by the persistence layer to save the player's available skill pool.
+     * Returns all discovered skills and their current availability states.
+     * Used by the persistence layer to save the full discovered pool with states.
      *
-     * @return an unmodifiable flat list of all available (unlocked) skill IDs
+     * @return an unmodifiable view of the availability map
      */
-    public List<SkillId> allAvailableSkillIds() {
-        return availableSkillsMap.values().stream()
-            .flatMap(Set::stream)
-            .toList();
+    public Map<SkillId, SkillAvailability> allDiscoveredSkillAvailabilities() {
+        return Map.copyOf(availabilityMap);
     }
 }

--- a/src/main/java/btm/sword/system/action/skill/container/SkillAvailability.java
+++ b/src/main/java/btm/sword/system/action/skill/container/SkillAvailability.java
@@ -1,0 +1,21 @@
+package btm.sword.system.action.skill.container;
+
+/**
+ * Tracks whether a discovered skill can be equipped by the player.
+ *
+ * <p>A skill enters a player's discovered pool the first time they encounter it.
+ * Once discovered, its availability state governs whether it can be placed in a
+ * {@link SkillSlot}:
+ * <ul>
+ *   <li>{@link #AVAILABLE} — discovered and equippable.</li>
+ *   <li>{@link #DEPLETED} — all uses have been spent; visible in the menu but
+ *       cannot be re-equipped until restored.</li>
+ *   <li>{@link #RELINQUISHED} — a quest item that was given away permanently;
+ *       visible as a record but permanently locked.</li>
+ * </ul>
+ */
+public enum SkillAvailability {
+    AVAILABLE,
+    DEPLETED,
+    RELINQUISHED
+}

--- a/src/main/java/btm/sword/system/action/skill/container/SkillSlot.java
+++ b/src/main/java/btm/sword/system/action/skill/container/SkillSlot.java
@@ -4,26 +4,33 @@ import btm.sword.system.action.skill.SkillType;
 
 public enum SkillSlot {
 
-    UMBRAL_1(SkillType.UMBRAL),
-    UMBRAL_2(SkillType.UMBRAL),
-    UMBRAL_3(SkillType.UMBRAL),
+    UMBRAL_1(SkillType.UMBRAL,   "Umbral I — Swap · L · L"),
+    UMBRAL_2(SkillType.UMBRAL,   "Umbral II — Swap · L · R"),
+    UMBRAL_3(SkillType.UMBRAL,   "Umbral III — Swap · L · Swap"),
 
-    ACTIVE_1(SkillType.ACTIVE),
-    ACTIVE_2(SkillType.ACTIVE),
+    ACTIVE_1(SkillType.ACTIVE,   "Active I — Slot 1"),
+    ACTIVE_2(SkillType.ACTIVE,   "Active II — Slot 2"),
 
-    PASSIVE_CORE(SkillType.PASSIVE),
+    PASSIVE_CORE(SkillType.PASSIVE, "Core Passive"),
 
-    PASSIVE_1(SkillType.PASSIVE),
-    PASSIVE_2(SkillType.PASSIVE),
-    PASSIVE_3(SkillType.PASSIVE);
+    PASSIVE_1(SkillType.PASSIVE, "Passive I"),
+    PASSIVE_2(SkillType.PASSIVE, "Passive II"),
+    PASSIVE_3(SkillType.PASSIVE, "Passive III");
 
     private final SkillType type;
+    private final String title;
 
-    SkillSlot(SkillType type) {
+    SkillSlot(SkillType type, String title) {
         this.type = type;
+        this.title = title;
     }
 
     public SkillType type() {
         return type;
+    }
+
+    /** Menu title for this slot, including its input binding where applicable. */
+    public String title() {
+        return title;
     }
 }

--- a/src/main/java/btm/sword/system/action/skill/container/SkillSlotState.java
+++ b/src/main/java/btm/sword/system/action/skill/container/SkillSlotState.java
@@ -1,0 +1,17 @@
+package btm.sword.system.action.skill.container;
+
+/**
+ * Persisted per-slot resource state for an equipped ability.
+ *
+ * <p>{@code -1} for uses/durability means "not tracked" (ability has no STACK/DURABILITY use type).
+ * {@code cooldownExpiresAt} is epoch-millis; {@code 0} means no active cooldown.</p>
+ *
+ * @param remainingUses       remaining stack-use count, or {@code -1} if not tracked
+ * @param remainingDurability remaining durability, or {@code -1} if not tracked
+ * @param cooldownExpiresAt   epoch-millis when the cooldown expires; {@code 0} if no active cooldown
+ */
+public record SkillSlotState(int remainingUses, int remainingDurability, long cooldownExpiresAt) {
+
+    /** Sentinel — no tracking active for any dimension. */
+    public static final SkillSlotState EMPTY = new SkillSlotState(-1, -1, 0L);
+}

--- a/src/main/java/btm/sword/system/action/skill/history/AbilityHistoryAction.java
+++ b/src/main/java/btm/sword/system/action/skill/history/AbilityHistoryAction.java
@@ -1,0 +1,11 @@
+package btm.sword.system.action.skill.history;
+
+/**
+ * The action that produced an entry in the player's ability history log.
+ */
+public enum AbilityHistoryAction {
+    /** The ability's physical item was consumed on use. */
+    USED,
+    /** The ability was surrendered as a quest turn-in. */
+    SURRENDERED
+}

--- a/src/main/java/btm/sword/system/action/skill/history/AbilityHistoryEntry.java
+++ b/src/main/java/btm/sword/system/action/skill/history/AbilityHistoryEntry.java
@@ -1,0 +1,19 @@
+package btm.sword.system.action.skill.history;
+
+import btm.sword.system.action.skill.SkillId;
+
+/**
+ * An immutable record of a single ability event in a player's history.
+ *
+ * @param id          the ability's stable {@link SkillId}
+ * @param displayName the human-readable name captured at the time of the event
+ * @param action      whether the ability was {@link AbilityHistoryAction#USED} or
+ *                    {@link AbilityHistoryAction#SURRENDERED}
+ * @param timestamp   epoch-millis when the event occurred
+ */
+public record AbilityHistoryEntry(
+    SkillId id,
+    String displayName,
+    AbilityHistoryAction action,
+    long timestamp
+) {}

--- a/src/main/java/btm/sword/system/action/skill/history/PlayerAbilityHistory.java
+++ b/src/main/java/btm/sword/system/action/skill/history/PlayerAbilityHistory.java
@@ -1,0 +1,92 @@
+package btm.sword.system.action.skill.history;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import btm.sword.system.action.skill.Skill;
+import btm.sword.system.action.skill.SkillId;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+
+/**
+ * Session-scoped log of ability events (uses and surrenders) for a single player.
+ *
+ * <p>Entries are appended chronologically and never reordered.
+ * The full list is loaded from the database on login and saved on quit.
+ */
+public class PlayerAbilityHistory {
+
+    private final List<AbilityHistoryEntry> entries;
+
+    /** Constructs an empty history for a first-time player. */
+    public PlayerAbilityHistory() {
+        this.entries = new ArrayList<>();
+    }
+
+    /**
+     * Constructs a history pre-populated from persisted data.
+     *
+     * @param entries the restored entry list (mutable copy is made internally)
+     */
+    public PlayerAbilityHistory(List<AbilityHistoryEntry> entries) {
+        this.entries = new ArrayList<>(entries);
+    }
+
+    /**
+     * Records that a consumable or throwable ability was used (item consumed).
+     *
+     * @param skill the ability that was used
+     */
+    public void recordUse(Skill skill) {
+        entries.add(new AbilityHistoryEntry(
+            skill.id(),
+            PlainTextComponentSerializer.plainText().serialize(skill.name()),
+            AbilityHistoryAction.USED,
+            System.currentTimeMillis()
+        ));
+    }
+
+    /**
+     * Records that a quest ability was surrendered.
+     *
+     * @param skill the ability that was surrendered
+     */
+    public void recordSurrender(Skill skill) {
+        entries.add(new AbilityHistoryEntry(
+            skill.id(),
+            PlainTextComponentSerializer.plainText().serialize(skill.name()),
+            AbilityHistoryAction.SURRENDERED,
+            System.currentTimeMillis()
+        ));
+    }
+
+    /**
+     * Records an entry directly — used by the persistence layer on load.
+     *
+     * @param entry the pre-built entry to add
+     */
+    public void addEntry(AbilityHistoryEntry entry) {
+        entries.add(entry);
+    }
+
+    /**
+     * Returns an unmodifiable view of all history entries, oldest-first.
+     *
+     * @return the full history
+     */
+    public List<AbilityHistoryEntry> entries() {
+        return Collections.unmodifiableList(entries);
+    }
+
+    /**
+     * Filters entries to only those matching the given ability id.
+     *
+     * @param id the ability to filter by
+     * @return a new list of matching entries
+     */
+    public List<AbilityHistoryEntry> entriesFor(SkillId id) {
+        return entries.stream()
+            .filter(e -> e.id().equals(id))
+            .toList();
+    }
+}

--- a/src/main/java/btm/sword/system/action/skill/type/AbilitySkill.java
+++ b/src/main/java/btm/sword/system/action/skill/type/AbilitySkill.java
@@ -1,0 +1,119 @@
+package btm.sword.system.action.skill.type;
+
+import java.util.Set;
+
+import org.bukkit.inventory.ItemStack;
+
+import btm.sword.system.action.skill.AbilityType;
+import btm.sword.system.action.skill.AbilityUseType;
+import btm.sword.system.action.skill.Skill;
+
+/**
+ * Marker interface for abilities — skills that exist as physical world items.
+ *
+ * <p>Abilities extend the base {@link Skill} contract with:
+ * <ol>
+ *   <li>A world item ({@link #buildWorldItem()}) that represents the ability as a droppable,
+ *       findable, equippable {@link ItemStack} tagged with the ability's {@link #id()}.</li>
+ *   <li>Physical-item consumption rules ({@link #consumesOnUse()} /
+ *       {@link #requiresPhysicalItemToUse()}) that govern whether the item is spent
+ *       from the player's inventory when the ability fires.</li>
+ *   <li>A {@link #useType()} that controls how hotbar-slot uses are tracked
+ *       (stack count, durability bar, or cooldown-only).</li>
+ * </ol>
+ *
+ * <p>Implementations should extend one of the concrete base classes:
+ * {@link ActivatableAbility}, {@link ThrowableAbility}, {@link ConsumableAbility},
+ * {@link PassiveAbilitySkill}, or {@link QuestAbility}.
+ */
+public interface AbilitySkill extends Skill {
+
+    /** @return the ability classification governing activation and consumption behavior */
+    AbilityType abilityType();
+
+    /**
+     * Builds the physical {@link ItemStack} that represents this ability in the world.
+     * The returned item is tagged with the {@code ability_id} PDC key so it can be
+     * identified and matched against this ability's {@link #id()}.
+     *
+     * @return a new, tagged world item for this ability
+     */
+    ItemStack buildWorldItem();
+
+    /**
+     * Whether using this ability removes one physical item from the player's inventory.
+     * True for {@link AbilityType#CONSUMABLE} and {@link AbilityType#THROWABLE}.
+     *
+     * @return {@code true} if the item is consumed on activation
+     */
+    boolean consumesOnUse();
+
+    /**
+     * Whether a physical ability item must be present in the player's inventory
+     * before this ability can be activated. Equal to {@link #consumesOnUse()} in
+     * the base design — separated for clarity and potential future divergence.
+     *
+     * @return {@code true} if inventory presence is required to cast
+     */
+    boolean requiresPhysicalItemToUse();
+
+    /**
+     * Returns the set of active resource-tracking mechanisms for this ability's hotbar slot.
+     * Multiple types may be combined — they are non-exclusive:
+     * <ul>
+     *   <li>{@link AbilityUseType#STACK} — each activation decrements the slot's use count;
+     *       the slot becomes {@code DEPLETED} when the count reaches zero.</li>
+     *   <li>{@link AbilityUseType#DURABILITY} — each activation degrades the item's durability bar;
+     *       the slot becomes {@code DEPLETED} when durability reaches zero.</li>
+     *   <li>{@link AbilityUseType#COOLDOWN} — applies a Minecraft item-cooldown overlay after each
+     *       activation; the slot is never depleted by this mechanism alone.</li>
+     * </ul>
+     * An empty set means no slot-level resource tracking (the ability can always be used).
+     *
+     * @return the set of active use types; never {@code null}
+     */
+    default Set<AbilityUseType> useTypes() {
+        return Set.of();
+    }
+
+    /**
+     * For abilities with {@link AbilityUseType#STACK}, the number of uses in a fresh stack.
+     * Ignored if {@code STACK} is not in {@link #useTypes()}. Default is {@code 1}.
+     *
+     * @return the maximum use count
+     */
+    default int maxUses() {
+        return 1;
+    }
+
+    /**
+     * For abilities with {@link AbilityUseType#DURABILITY}, the maximum durability value.
+     * Ignored if {@code DURABILITY} is not in {@link #useTypes()}. Default is {@code 1}.
+     *
+     * @return the maximum durability
+     */
+    default int maxDurability() {
+        return 1;
+    }
+
+    /**
+     * For abilities with {@link AbilityUseType#COOLDOWN}, the cooldown duration in ticks
+     * applied as a Minecraft item-cooldown overlay after each activation.
+     * Ignored if {@code COOLDOWN} is not in {@link #useTypes()}. Default is {@code 0}.
+     *
+     * @return cooldown duration in ticks
+     */
+    default int cooldownTicks() {
+        return 0;
+    }
+
+    /**
+     * Whether this ability doubles as a weak melee weapon when the player
+     * presses LEFT while holding the ability item. Default is {@code false}.
+     *
+     * @return {@code true} if the ability item can deal weak basic attacks
+     */
+    default boolean isWeapon() {
+        return false;
+    }
+}

--- a/src/main/java/btm/sword/system/action/skill/type/ActivatableAbility.java
+++ b/src/main/java/btm/sword/system/action/skill/type/ActivatableAbility.java
@@ -1,0 +1,28 @@
+package btm.sword.system.action.skill.type;
+
+import btm.sword.system.action.skill.AbilityType;
+
+/**
+ * An ability that is pressed to activate, has a cooldown, and is never consumed.
+ *
+ * <p>The physical world item grants access to this ability when picked up, but is not
+ * removed from inventory on use. Extend this class and implement {@link #execute},
+ * {@link #calculateCooldown}, {@link #canPerform}, and {@link #buildWorldItem}.
+ */
+public abstract class ActivatableAbility extends ActiveSkill implements AbilitySkill {
+
+    @Override
+    public AbilityType abilityType() {
+        return AbilityType.ACTIVATABLE;
+    }
+
+    @Override
+    public boolean consumesOnUse() {
+        return false;
+    }
+
+    @Override
+    public boolean requiresPhysicalItemToUse() {
+        return false;
+    }
+}

--- a/src/main/java/btm/sword/system/action/skill/type/ConsumableAbility.java
+++ b/src/main/java/btm/sword/system/action/skill/type/ConsumableAbility.java
@@ -1,0 +1,38 @@
+package btm.sword.system.action.skill.type;
+
+import java.util.Set;
+
+import btm.sword.system.action.skill.AbilityType;
+import btm.sword.system.action.skill.AbilityUseType;
+
+/**
+ * A one-shot ability that consumes its physical item on activation.
+ *
+ * <p>The player must have the physical ability item in their inventory to cast.
+ * After casting, one item is removed. To use the ability again they must find
+ * another item. Extend this class and implement {@link #execute},
+ * {@link #calculateCooldown}, {@link #canPerform}, and {@link #buildWorldItem}.
+ */
+public abstract class ConsumableAbility extends ActivatableAbility {
+
+    @Override
+    public AbilityType abilityType() {
+        return AbilityType.CONSUMABLE;
+    }
+
+    @Override
+    public boolean consumesOnUse() {
+        return true;
+    }
+
+    @Override
+    public boolean requiresPhysicalItemToUse() {
+        return true;
+    }
+
+    /** Consumable abilities default to stack-based consumption. */
+    @Override
+    public Set<AbilityUseType> useTypes() {
+        return Set.of(AbilityUseType.STACK);
+    }
+}

--- a/src/main/java/btm/sword/system/action/skill/type/PassiveAbilitySkill.java
+++ b/src/main/java/btm/sword/system/action/skill/type/PassiveAbilitySkill.java
@@ -1,0 +1,28 @@
+package btm.sword.system.action.skill.type;
+
+import btm.sword.system.action.skill.AbilityType;
+
+/**
+ * An ability that is always active while equipped in a passive slot.
+ *
+ * <p>No activation input is needed. The physical world item grants the passive effect
+ * when picked up and equipped — it is never consumed on use. Extend this class and
+ * implement {@link #buildWorldItem}.
+ */
+public abstract class PassiveAbilitySkill extends PassiveSkill implements AbilitySkill {
+
+    @Override
+    public AbilityType abilityType() {
+        return AbilityType.PASSIVE;
+    }
+
+    @Override
+    public boolean consumesOnUse() {
+        return false;
+    }
+
+    @Override
+    public boolean requiresPhysicalItemToUse() {
+        return false;
+    }
+}

--- a/src/main/java/btm/sword/system/action/skill/type/QuestAbility.java
+++ b/src/main/java/btm/sword/system/action/skill/type/QuestAbility.java
@@ -1,0 +1,38 @@
+package btm.sword.system.action.skill.type;
+
+import btm.sword.system.action.skill.AbilityType;
+import btm.sword.system.entity.impl.Combatant;
+
+/**
+ * An ability that doubles as a quest turn-in item.
+ *
+ * <p>While held, the player can activate it like a normal {@link ActivatableAbility}.
+ * The physical item is not consumed on use. However, it can be <em>surrendered</em>
+ * via {@link #onSurrender(Combatant)}, which permanently removes it from the player's
+ * possession and records it in their ability history.
+ *
+ * <p>This creates genuine stakes: surrendering completes the quest but forfeits the
+ * ability's power forever.
+ *
+ * <p>Extend this class and implement {@link #execute}, {@link #calculateCooldown},
+ * {@link #canPerform}, {@link #buildWorldItem}, and {@link #onSurrender}.
+ */
+public abstract class QuestAbility extends ActivatableAbility {
+
+    @Override
+    public AbilityType abilityType() {
+        return AbilityType.QUEST;
+    }
+
+    /**
+     * Called when the player surrenders this quest item to complete a quest.
+     * Implement any quest-specific side effects here (e.g., advancing quest state,
+     * spawning a reward, sending a message).
+     *
+     * <p>The physical item removal and history logging are handled externally by
+     * {@code AbilitySurrenderUtil} — do not remove the item inside this method.
+     *
+     * @param combatant the player surrendering the item
+     */
+    public abstract void onSurrender(Combatant combatant);
+}

--- a/src/main/java/btm/sword/system/action/skill/type/ThrowableAbility.java
+++ b/src/main/java/btm/sword/system/action/skill/type/ThrowableAbility.java
@@ -1,0 +1,43 @@
+package btm.sword.system.action.skill.type;
+
+import java.util.Set;
+
+import btm.sword.system.action.skill.AbilityType;
+import btm.sword.system.action.skill.AbilityUseType;
+
+/**
+ * An ability that is thrown on a held right-click.
+ *
+ * <p>Each throw consumes one physical ability item from the player's inventory.
+ * The player must have at least one such item to throw. Extend this class and implement
+ * {@link #execute}, {@link #calculateCooldown}, {@link #canPerform}, and {@link #buildWorldItem}.
+ */
+public abstract class ThrowableAbility extends ActivatableAbility {
+
+    @Override
+    public AbilityType abilityType() {
+        return AbilityType.THROWABLE;
+    }
+
+    /** Throwable abilities are always activated via hold, not tap. */
+    @Override
+    public boolean requiresHold() {
+        return true;
+    }
+
+    @Override
+    public boolean consumesOnUse() {
+        return true;
+    }
+
+    @Override
+    public boolean requiresPhysicalItemToUse() {
+        return true;
+    }
+
+    /** Throwable abilities default to stack-based consumption. */
+    @Override
+    public Set<AbilityUseType> useTypes() {
+        return Set.of(AbilityUseType.STACK);
+    }
+}

--- a/src/main/java/btm/sword/system/action/skill/type/impl/active/IceSpellAbility.java
+++ b/src/main/java/btm/sword/system/action/skill/type/impl/active/IceSpellAbility.java
@@ -10,10 +10,10 @@ import org.joml.AxisAngle4f;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
-import btm.sword.system.action.skill.type.impl.charge.ChargeSession;
 import btm.sword.system.action.skill.SkillId;
 import btm.sword.system.action.skill.SkillIds;
 import btm.sword.system.action.skill.SkillType;
+import btm.sword.system.action.skill.type.impl.charge.ChargeSession;
 import btm.sword.system.action.skill.type.impl.charge.ChargeableAbility;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.item.ItemStackBuilder;

--- a/src/main/java/btm/sword/system/action/skill/type/impl/active/IceSpellAbility.java
+++ b/src/main/java/btm/sword/system/action/skill/type/impl/active/IceSpellAbility.java
@@ -1,0 +1,169 @@
+package btm.sword.system.action.skill.type.impl.active;
+
+import java.util.List;
+
+import org.bukkit.Material;
+import org.bukkit.entity.ItemDisplay;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Transformation;
+import org.joml.AxisAngle4f;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+
+import btm.sword.system.action.skill.type.impl.charge.ChargeSession;
+import btm.sword.system.action.skill.SkillId;
+import btm.sword.system.action.skill.SkillIds;
+import btm.sword.system.action.skill.SkillType;
+import btm.sword.system.action.skill.type.impl.charge.ChargeableAbility;
+import btm.sword.system.entity.impl.Combatant;
+import btm.sword.system.item.ItemStackBuilder;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+/**
+ * A chargeable ice spell that launches a block of ice.
+ *
+ * <p>While charging, the display scales from {@code 0.25} to {@code 3.0},
+ * rotates continuously, and bobs up and down with a sine wave.
+ * The player may release once the scale reaches {@code 0.5}.</p>
+ */
+public class IceSpellAbility extends ChargeableAbility {
+
+    private static final Component NAME = Component.text("Ice Bolt", NamedTextColor.AQUA);
+
+    // ── Charge parameters ──────────────────────────────────────────────
+
+    private static final float MIN_SCALE = 0.25f;
+    private static final float MAX_SCALE = 3.0f;
+    private static final float MIN_RELEASE_SCALE = 0.5f;
+    private static final int CHARGE_TIME_MS = 3000;
+    private static final double VELOCITY = 1.8;
+
+    // ── Visual animation constants ─────────────────────────────────────
+
+    /** Rotation speed in radians per millisecond. */
+    private static final float ROTATION_SPEED = 0.003f;
+
+    /** Sine wave amplitude (blocks) for the vertical bob. */
+    private static final float BOB_AMPLITUDE = 0.15f;
+
+    /** Sine wave period in milliseconds. */
+    private static final float BOB_PERIOD_MS = 800f;
+
+    // ── Session data keys ──────────────────────────────────────────────
+
+    private static final String KEY_SCALE = "scale";
+
+    // ── Skill identity ─────────────────────────────────────────────────
+
+    @Override
+    public Component name() {
+        return NAME;
+    }
+
+    @Override
+    public SkillId id() {
+        return SkillIds.ICE_SPELL;
+    }
+
+    @Override
+    public SkillType type() {
+        return SkillType.ACTIVE;
+    }
+
+    @Override
+    public ItemStack icon() {
+        return ItemStackBuilder.of(Material.BLUE_ICE)
+            .name(NAME)
+            .hideAll()
+            .build();
+    }
+
+    @Override
+    public List<Component> description() {
+        return List.of(
+            Component.text("Hold right-click to charge a block of ice.", NamedTextColor.GRAY),
+            Component.text("Release to hurl it at your target.", NamedTextColor.DARK_GRAY)
+        );
+    }
+
+    @Override
+    public ItemStack buildWorldItem() {
+        return ItemStackBuilder.of(Material.BLUE_ICE)
+            .name(NAME)
+            .lore(description())
+            .hideAll()
+            .build();
+    }
+
+    // ── Ability parameters ─────────────────────────────────────────────
+
+    @Override
+    public int maxUses() {
+        return 5;
+    }
+
+    @Override
+    public int cooldownTicks() {
+        return 20;
+    }
+
+    @Override
+    public double projectileVelocity() {
+        return VELOCITY;
+    }
+
+    // ── Charge behavior ────────────────────────────────────────────────
+
+    @Override
+    public void onChargeTick(ChargeSession session, long elapsedMs) {
+        ItemDisplay display = session.getDisplay();
+
+        // Scale grows linearly from MIN to MAX over CHARGE_TIME_MS
+        float progress = Math.min(1.0f, (float) elapsedMs / CHARGE_TIME_MS);
+        float scale = MIN_SCALE + (MAX_SCALE - MIN_SCALE) * progress;
+        session.setFloat(KEY_SCALE, scale);
+
+        // Continuous Y-axis rotation
+        float angle = (elapsedMs * ROTATION_SPEED) % ((float) Math.PI * 2);
+        Quaternionf rotation = new Quaternionf(new AxisAngle4f(angle, 0f, 1f, 0f));
+
+        // Sine-wave vertical bob
+        float bob = BOB_AMPLITUDE * (float) Math.sin(2.0 * Math.PI * elapsedMs / BOB_PERIOD_MS);
+
+        display.setTransformation(new Transformation(
+            new Vector3f(0f, bob, 0f),
+            rotation,
+            new Vector3f(scale, scale, scale),
+            new Quaternionf()
+        ));
+    }
+
+    @Override
+    public boolean canRelease(ChargeSession session) {
+        return session.getFloat(KEY_SCALE, 0f) >= MIN_RELEASE_SCALE;
+    }
+
+    @Override
+    public float releaseDisplayScale(ChargeSession session) {
+        return session.getFloat(KEY_SCALE, 1.0f);
+    }
+
+    // ── ActiveSkill contract ───────────────────────────────────────────
+
+    @Override
+    public void execute(Combatant combatant) {
+        // Charge release is handled by ChargeAction.releaseCharge — execute() is not
+        // called directly for chargeables. No-op here for safety.
+    }
+
+    @Override
+    public int calculateCooldown(Combatant combatant) {
+        return 500;
+    }
+
+    @Override
+    public boolean canPerform(Combatant combatant) {
+        return combatant.canPerformAction();
+    }
+}

--- a/src/main/java/btm/sword/system/action/skill/type/impl/active/KnifeThrowAbility.java
+++ b/src/main/java/btm/sword/system/action/skill/type/impl/active/KnifeThrowAbility.java
@@ -10,10 +10,9 @@ import btm.sword.system.action.skill.AbilityUseType;
 import btm.sword.system.action.skill.SkillId;
 import btm.sword.system.action.skill.SkillIds;
 import btm.sword.system.action.skill.SkillType;
-import btm.sword.system.action.skill.type.ThrowableAbility;
+import btm.sword.system.action.skill.type.ActivatableAbility;
 import btm.sword.system.action.throwing.ThrowAction;
 import btm.sword.system.entity.impl.Combatant;
-import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.item.AbilityItemBuilder;
 import btm.sword.system.item.ItemStackBuilder;
 import net.kyori.adventure.text.Component;
@@ -29,7 +28,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
  * <p>The projectile is a diamond sword thrown at half scale for a compact visual.
  * The throw fires immediately on activation without any aim-windup animation.</p>
  */
-public class KnifeThrowAbility extends ThrowableAbility {
+public class KnifeThrowAbility extends ActivatableAbility {
 
     private static final Component NAME = Component.text("Throwing Knife");
 
@@ -56,7 +55,7 @@ public class KnifeThrowAbility extends ThrowableAbility {
 
     @Override
     public ItemStack icon() {
-        return ItemStackBuilder.of(Material.IRON_NUGGET)
+        return ItemStackBuilder.of(Material.DIAMOND_SWORD)
             .name(Component.text("Throwing Knife", NamedTextColor.WHITE))
             .hideAll()
             .build();
@@ -72,12 +71,17 @@ public class KnifeThrowAbility extends ThrowableAbility {
 
     @Override
     public ItemStack buildWorldItem() {
-        ItemStack item = ItemStackBuilder.of(Material.IRON_NUGGET)
+        ItemStack item = ItemStackBuilder.of(Material.DIAMOND_SWORD)
             .name(Component.text("Throwing Knife", NamedTextColor.WHITE))
             .lore(description())
             .hideAll()
             .build();
         return AbilityItemBuilder.tag(item, id());
+    }
+
+    @Override
+    public boolean consumesOnUse() {
+        return true;
     }
 
     /** Stack count and cooldown both apply — non-exclusive. */
@@ -107,6 +111,7 @@ public class KnifeThrowAbility extends ThrowableAbility {
             .name(Component.text("Throwing Knife"))
             .hideAll()
             .build();
+        AbilityItemBuilder.tag(projectile, id());
         ThrowAction.throwDirect(combatant, projectile, PROJECTILE_SCALE, PROJECTILE_VELOCITY);
     }
 
@@ -117,10 +122,6 @@ public class KnifeThrowAbility extends ThrowableAbility {
 
     @Override
     public boolean canPerform(Combatant combatant) {
-        if (!combatant.canPerformAction()) return false;
-        if (combatant instanceof SwordPlayer sp) {
-            return !sp.isAttemptingThrow();
-        }
-        return true;
+        return combatant.canPerformAction();
     }
 }

--- a/src/main/java/btm/sword/system/action/skill/type/impl/active/KnifeThrowAbility.java
+++ b/src/main/java/btm/sword/system/action/skill/type/impl/active/KnifeThrowAbility.java
@@ -1,0 +1,126 @@
+package btm.sword.system.action.skill.type.impl.active;
+
+import java.util.List;
+import java.util.Set;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import btm.sword.system.action.skill.AbilityUseType;
+import btm.sword.system.action.skill.SkillId;
+import btm.sword.system.action.skill.SkillIds;
+import btm.sword.system.action.skill.SkillType;
+import btm.sword.system.action.skill.type.ThrowableAbility;
+import btm.sword.system.action.throwing.ThrowAction;
+import btm.sword.system.entity.impl.Combatant;
+import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.item.AbilityItemBuilder;
+import btm.sword.system.item.ItemStackBuilder;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+/**
+ * A throwing knife ability that consumes one knife per throw and applies a short cooldown.
+ *
+ * <p>Uses both {@link AbilityUseType#STACK} and {@link AbilityUseType#COOLDOWN} — each throw
+ * decrements the slot's use count, and a brief cooldown overlay prevents rapid re-casting.
+ * When all uses are exhausted the slot becomes DEPLETED.</p>
+ *
+ * <p>The projectile is a diamond sword thrown at half scale for a compact visual.
+ * The throw fires immediately on activation without any aim-windup animation.</p>
+ */
+public class KnifeThrowAbility extends ThrowableAbility {
+
+    private static final Component NAME = Component.text("Throwing Knife");
+
+    /** Projectile scale relative to a normal thrown sword. */
+    private static final float PROJECTILE_SCALE = 0.5f;
+
+    /** Initial velocity magnitude passed to the physics simulation. */
+    private static final double PROJECTILE_VELOCITY = 2.0;
+
+    @Override
+    public Component name() {
+        return NAME;
+    }
+
+    @Override
+    public SkillId id() {
+        return SkillIds.KNIFE_THROW;
+    }
+
+    @Override
+    public SkillType type() {
+        return SkillType.ACTIVE;
+    }
+
+    @Override
+    public ItemStack icon() {
+        return ItemStackBuilder.of(Material.IRON_NUGGET)
+            .name(Component.text("Throwing Knife", NamedTextColor.WHITE))
+            .hideAll()
+            .build();
+    }
+
+    @Override
+    public List<Component> description() {
+        return List.of(
+            Component.text("Hurl a knife at your target.", NamedTextColor.GRAY),
+            Component.text("Can also be used as a weak melee weapon.", NamedTextColor.DARK_GRAY)
+        );
+    }
+
+    @Override
+    public ItemStack buildWorldItem() {
+        ItemStack item = ItemStackBuilder.of(Material.IRON_NUGGET)
+            .name(Component.text("Throwing Knife", NamedTextColor.WHITE))
+            .lore(description())
+            .hideAll()
+            .build();
+        return AbilityItemBuilder.tag(item, id());
+    }
+
+    /** Stack count and cooldown both apply — non-exclusive. */
+    @Override
+    public Set<AbilityUseType> useTypes() {
+        return Set.of(AbilityUseType.STACK, AbilityUseType.COOLDOWN);
+    }
+
+    @Override
+    public int maxUses() {
+        return 3;
+    }
+
+    @Override
+    public int cooldownTicks() {
+        return 10;
+    }
+
+    @Override
+    public boolean isWeapon() {
+        return true;
+    }
+
+    @Override
+    public void execute(Combatant combatant) {
+        ItemStack projectile = ItemStackBuilder.of(Material.DIAMOND_SWORD)
+            .name(Component.text("Throwing Knife"))
+            .hideAll()
+            .build();
+        ThrowAction.throwDirect(combatant, projectile, PROJECTILE_SCALE, PROJECTILE_VELOCITY);
+    }
+
+    @Override
+    public int calculateCooldown(Combatant combatant) {
+        return 200;
+    }
+
+    @Override
+    public boolean canPerform(Combatant combatant) {
+        if (!combatant.canPerformAction()) return false;
+        if (combatant instanceof SwordPlayer sp) {
+            return !sp.isAttemptingThrow();
+        }
+        return true;
+    }
+}

--- a/src/main/java/btm/sword/system/action/skill/type/impl/active/TestAlphaAbility.java
+++ b/src/main/java/btm/sword/system/action/skill/type/impl/active/TestAlphaAbility.java
@@ -1,0 +1,81 @@
+package btm.sword.system.action.skill.type.impl.active;
+
+import java.util.List;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import btm.sword.system.action.skill.SkillId;
+import btm.sword.system.action.skill.SkillIds;
+import btm.sword.system.action.skill.SkillType;
+import btm.sword.system.action.skill.type.ActivatableAbility;
+import btm.sword.system.entity.impl.Combatant;
+import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.item.AbilityItemBuilder;
+import btm.sword.system.item.ItemStackBuilder;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+/**
+ * No-op test ability Alpha. Used to verify the ability slot, equip/unequip, and
+ * availability systems end-to-end.
+ *
+ * <p>TODO: remove once real found abilities replace test stubs.</p>
+ */
+public class TestAlphaAbility extends ActivatableAbility {
+
+    @Override
+    public Component name() {
+        return Component.text("Test Alpha");
+    }
+
+    @Override
+    public SkillId id() {
+        return SkillIds.TEST_ALPHA;
+    }
+
+    @Override
+    public SkillType type() {
+        return SkillType.ACTIVE;
+    }
+
+    @Override
+    public ItemStack icon() {
+        return ItemStackBuilder.of(Material.GREEN_STAINED_GLASS_PANE)
+            .name(Component.text("Test Alpha", NamedTextColor.GREEN))
+            .hideAll()
+            .build();
+    }
+
+    @Override
+    public List<Component> description() {
+        return List.of(Component.text("A no-op test ability.", NamedTextColor.GRAY));
+    }
+
+    @Override
+    public ItemStack buildWorldItem() {
+        ItemStack item = ItemStackBuilder.of(Material.GREEN_STAINED_GLASS_PANE)
+            .name(Component.text("Test Alpha", NamedTextColor.GREEN))
+            .lore(description())
+            .hideAll()
+            .build();
+        return AbilityItemBuilder.tag(item, id());
+    }
+
+    @Override
+    public void execute(Combatant combatant) {
+        if (combatant instanceof SwordPlayer sp) {
+            sp.player().sendMessage(Component.text("[Test] Alpha fired!", NamedTextColor.GREEN));
+        }
+    }
+
+    @Override
+    public int calculateCooldown(Combatant combatant) {
+        return 0;
+    }
+
+    @Override
+    public boolean canPerform(Combatant combatant) {
+        return true;
+    }
+}

--- a/src/main/java/btm/sword/system/action/skill/type/impl/active/TestBetaAbility.java
+++ b/src/main/java/btm/sword/system/action/skill/type/impl/active/TestBetaAbility.java
@@ -1,0 +1,81 @@
+package btm.sword.system.action.skill.type.impl.active;
+
+import java.util.List;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import btm.sword.system.action.skill.SkillId;
+import btm.sword.system.action.skill.SkillIds;
+import btm.sword.system.action.skill.SkillType;
+import btm.sword.system.action.skill.type.ActivatableAbility;
+import btm.sword.system.entity.impl.Combatant;
+import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.item.AbilityItemBuilder;
+import btm.sword.system.item.ItemStackBuilder;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+/**
+ * No-op test ability Beta. Used to verify the ability slot, equip/unequip, and
+ * availability systems end-to-end.
+ *
+ * <p>TODO: remove once real found abilities replace test stubs.</p>
+ */
+public class TestBetaAbility extends ActivatableAbility {
+
+    @Override
+    public Component name() {
+        return Component.text("Test Beta");
+    }
+
+    @Override
+    public SkillId id() {
+        return SkillIds.TEST_BETA;
+    }
+
+    @Override
+    public SkillType type() {
+        return SkillType.ACTIVE;
+    }
+
+    @Override
+    public ItemStack icon() {
+        return ItemStackBuilder.of(Material.YELLOW_STAINED_GLASS_PANE)
+            .name(Component.text("Test Beta", NamedTextColor.YELLOW))
+            .hideAll()
+            .build();
+    }
+
+    @Override
+    public List<Component> description() {
+        return List.of(Component.text("A no-op test ability.", NamedTextColor.GRAY));
+    }
+
+    @Override
+    public ItemStack buildWorldItem() {
+        ItemStack item = ItemStackBuilder.of(Material.YELLOW_STAINED_GLASS_PANE)
+            .name(Component.text("Test Beta", NamedTextColor.YELLOW))
+            .lore(description())
+            .hideAll()
+            .build();
+        return AbilityItemBuilder.tag(item, id());
+    }
+
+    @Override
+    public void execute(Combatant combatant) {
+        if (combatant instanceof SwordPlayer sp) {
+            sp.player().sendMessage(Component.text("[Test] Beta fired!", NamedTextColor.YELLOW));
+        }
+    }
+
+    @Override
+    public int calculateCooldown(Combatant combatant) {
+        return 0;
+    }
+
+    @Override
+    public boolean canPerform(Combatant combatant) {
+        return true;
+    }
+}

--- a/src/main/java/btm/sword/system/action/skill/type/impl/active/TestGammaAbility.java
+++ b/src/main/java/btm/sword/system/action/skill/type/impl/active/TestGammaAbility.java
@@ -1,0 +1,81 @@
+package btm.sword.system.action.skill.type.impl.active;
+
+import java.util.List;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import btm.sword.system.action.skill.SkillId;
+import btm.sword.system.action.skill.SkillIds;
+import btm.sword.system.action.skill.SkillType;
+import btm.sword.system.action.skill.type.ActivatableAbility;
+import btm.sword.system.entity.impl.Combatant;
+import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.item.AbilityItemBuilder;
+import btm.sword.system.item.ItemStackBuilder;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+/**
+ * No-op test ability Gamma. Used to verify the ability slot, equip/unequip, and
+ * availability systems end-to-end.
+ *
+ * <p>TODO: remove once real found abilities replace test stubs.</p>
+ */
+public class TestGammaAbility extends ActivatableAbility {
+
+    @Override
+    public Component name() {
+        return Component.text("Test Gamma");
+    }
+
+    @Override
+    public SkillId id() {
+        return SkillIds.TEST_GAMMA;
+    }
+
+    @Override
+    public SkillType type() {
+        return SkillType.ACTIVE;
+    }
+
+    @Override
+    public ItemStack icon() {
+        return ItemStackBuilder.of(Material.RED_STAINED_GLASS_PANE)
+            .name(Component.text("Test Gamma", NamedTextColor.RED))
+            .hideAll()
+            .build();
+    }
+
+    @Override
+    public List<Component> description() {
+        return List.of(Component.text("A no-op test ability.", NamedTextColor.GRAY));
+    }
+
+    @Override
+    public ItemStack buildWorldItem() {
+        ItemStack item = ItemStackBuilder.of(Material.RED_STAINED_GLASS_PANE)
+            .name(Component.text("Test Gamma", NamedTextColor.RED))
+            .lore(description())
+            .hideAll()
+            .build();
+        return AbilityItemBuilder.tag(item, id());
+    }
+
+    @Override
+    public void execute(Combatant combatant) {
+        if (combatant instanceof SwordPlayer sp) {
+            sp.player().sendMessage(Component.text("[Test] Gamma fired!", NamedTextColor.RED));
+        }
+    }
+
+    @Override
+    public int calculateCooldown(Combatant combatant) {
+        return 0;
+    }
+
+    @Override
+    public boolean canPerform(Combatant combatant) {
+        return true;
+    }
+}

--- a/src/main/java/btm/sword/system/action/skill/type/impl/charge/ChargeAction.java
+++ b/src/main/java/btm/sword/system/action/skill/type/impl/charge/ChargeAction.java
@@ -1,0 +1,191 @@
+package btm.sword.system.action.skill.type.impl.charge;
+
+import btm.sword.system.action.skill.Skill;
+import btm.sword.system.action.skill.SkillId;
+import btm.sword.system.action.skill.SkillRegistry;
+import btm.sword.system.control.PredicateRunnablePair;
+import btm.sword.system.control.TimeArbiter;
+
+import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.ItemDisplay;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
+
+import btm.sword.Sword;
+import btm.sword.system.action.skill.container.SkillSlot;
+import btm.sword.system.action.throwing.ThrowAction;
+import btm.sword.system.entity.impl.Combatant;
+import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.item.AbilityItemBuilder;
+import btm.sword.system.item.SwordItemType;
+import btm.sword.utility.Debug;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Static utility that manages the charge lifecycle for {@link ChargeableAbility} skills.
+ *
+ * <p>Flow:
+ * <ol>
+ *   <li>{@link #startCharge(Combatant)} — spawns an {@link ItemDisplay}, starts tick loop.</li>
+ *   <li>{@link #releaseCharge(Combatant)} — fires the projectile via
+ *       {@link ThrowAction#throwDirect}.</li>
+ *   <li>{@link #cancelCharge(Combatant)} — disposes the display without firing.</li>
+ * </ol>
+ *
+ * <p>All visual behavior (scaling, rotation, particles) is delegated to
+ * {@link ChargeableAbility#onChargeTick(ChargeSession, long)}.</p>
+ */
+public final class ChargeAction {
+
+    /** Distance in front of the player's eye to hold the charging display. */
+    private static final double HOLD_DISTANCE = 4.5;
+
+    private ChargeAction() { }
+
+    /**
+     * Begins charging the equipped chargeable ability. Resolves the ability from the held slot,
+     * spawns a display entity, and starts the per-tick loop.
+     *
+     * @param executor the combatant starting the charge (must be a {@link SwordPlayer})
+     */
+    public static void startCharge(Combatant executor) {
+        if (!(executor instanceof SwordPlayer sp)) return;
+
+        ChargeableAbility chargeable = resolveChargeable(sp);
+        if (chargeable == null) return;
+
+        int heldSlot = sp.player().getInventory().getHeldItemSlot();
+
+        // Cancel any existing charge
+        cancelCharge(executor);
+
+        // Spawn display in front of the player
+        Location spawnLoc = sp.self().getEyeLocation()
+            .add(sp.self().getEyeLocation().getDirection().multiply(HOLD_DISTANCE));
+        ItemDisplay display = (ItemDisplay) spawnLoc.getWorld()
+            .spawnEntity(spawnLoc, EntityType.ITEM_DISPLAY);
+        display.setItemStack(chargeable.buildWorldItem());
+
+        ChargeSession session = new ChargeSession(chargeable, display, heldSlot);
+        sp.setActiveCharge(session);
+
+        Debug.debug("Charge started: " + chargeable.id().asString());
+
+        AtomicInteger it = new AtomicInteger(0);
+        // Per-tick loop: follow player + delegate visuals to ability
+        session.setTickTask(
+            TimeArbiter.runTimeBoundBukkitTaskOnTimer(
+                null,
+                () -> {
+                    // Follow the player's eye direction
+                    Location eyeLoc = sp.self().getEyeLocation();
+                    Vector dir = eyeLoc.getDirection().multiply(HOLD_DISTANCE);
+                    TimeArbiter.teleportDisplay(display, eyeLoc, dir, 3, ChargeAction.class, 83);
+
+                    // Delegate all visual behavior to the ability
+                    long elapsed = System.currentTimeMillis() - session.getStartTimeMs();
+                    chargeable.onChargeTick(session, elapsed);
+                },
+                null,
+                0,50,
+                ChargeAction.class, "startCharge",
+                new PredicateRunnablePair(
+                    () -> sp.isDead() || display.isDead() ||
+                        sp.getActiveCharge() != session ||
+                        (it.incrementAndGet() > 3 && !sp.player().isBlocking()),
+                    () -> {
+                        if (it.get() > 6) releaseCharge(sp);
+                        else cancelCharge(sp);
+                    }
+                )
+            )
+
+        );
+    }
+
+    /**
+     * Releases the charge, firing the projectile at the ability's release scale.
+     * If the ability says the charge can't be released yet, cancels instead.
+     *
+     * @param executor the combatant releasing the charge
+     */
+    public static void releaseCharge(Combatant executor) {
+        if (!(executor instanceof SwordPlayer sp)) return;
+
+        ChargeSession session = sp.getActiveCharge();
+        if (session == null) return;
+
+        ChargeableAbility ability = session.getAbility();
+
+        if (!ability.canRelease(session)) {
+            Debug.debug("Charge cancelled — ability says not ready");
+            cancelCharge(executor);
+            return;
+        }
+
+        Debug.debug("Charge released");
+
+        // Build the projectile item and tag it
+        ItemStack projectile = ability.buildWorldItem();
+        AbilityItemBuilder.tag(projectile, ability.id());
+
+        float releaseScale = ability.releaseDisplayScale(session);
+        int slotIndex = session.getSlotIndex();
+
+        // Clean up the charge display
+        session.dispose();
+        sp.setActiveCharge(null);
+
+        // Fire via throwDirect with the ability's release scale
+        ThrowAction.throwDirect(executor, projectile, releaseScale, ability.projectileVelocity());
+
+        // Consume a use from the ability slot
+        sp.getAbilitySlotManager().consumeUse(slotIndex);
+    }
+
+    /**
+     * Cancels an active charge without firing.
+     *
+     * @param executor the combatant whose charge to cancel
+     */
+    public static void cancelCharge(Combatant executor) {
+        if (!(executor instanceof SwordPlayer sp)) return;
+
+        ChargeSession session = sp.getActiveCharge();
+        if (session == null) return;
+
+        session.dispose();
+        sp.setActiveCharge(null);
+    }
+
+    /**
+     * Returns {@code true} if the given player is holding a chargeable ability item
+     * in the currently selected hotbar slot.
+     *
+     * @param sp the player to check
+     * @return {@code true} if the held ability is chargeable
+     */
+    public static boolean isHoldingChargeable(SwordPlayer sp) {
+        return resolveChargeable(sp) != null;
+    }
+
+    /**
+     * Resolves the {@link ChargeableAbility} from the player's currently held slot,
+     * or {@code null} if not holding one.
+     */
+    private static ChargeableAbility resolveChargeable(SwordPlayer sp) {
+        int heldSlot = sp.player().getInventory().getHeldItemSlot();
+        SwordItemType itemType = sp.getAbilitySlotManager().getActiveTypeForHeldSlot(heldSlot);
+        if (itemType == null) return null;
+
+        SkillSlot slot = itemType == SwordItemType.ACTIVE_1 ? SkillSlot.ACTIVE_1 : SkillSlot.ACTIVE_2;
+        SkillId equippedId = sp.getCombatProfile().getPlayerSkillContainer().getEquipped(slot);
+        if (equippedId == null) return null;
+
+        Skill skill = SkillRegistry.get(equippedId);
+        return skill instanceof ChargeableAbility c ? c : null;
+    }
+}

--- a/src/main/java/btm/sword/system/action/skill/type/impl/charge/ChargeAction.java
+++ b/src/main/java/btm/sword/system/action/skill/type/impl/charge/ChargeAction.java
@@ -1,28 +1,25 @@
 package btm.sword.system.action.skill.type.impl.charge;
 
-import btm.sword.system.action.skill.Skill;
-import btm.sword.system.action.skill.SkillId;
-import btm.sword.system.action.skill.SkillRegistry;
-import btm.sword.system.control.PredicateRunnablePair;
-import btm.sword.system.control.TimeArbiter;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.ItemDisplay;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
-import btm.sword.Sword;
+import btm.sword.system.action.skill.Skill;
+import btm.sword.system.action.skill.SkillId;
+import btm.sword.system.action.skill.SkillRegistry;
 import btm.sword.system.action.skill.container.SkillSlot;
 import btm.sword.system.action.throwing.ThrowAction;
+import btm.sword.system.control.PredicateRunnablePair;
+import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.item.AbilityItemBuilder;
 import btm.sword.system.item.SwordItemType;
 import btm.sword.utility.Debug;
-
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Static utility that manages the charge lifecycle for {@link ChargeableAbility} skills.

--- a/src/main/java/btm/sword/system/action/skill/type/impl/charge/ChargeSession.java
+++ b/src/main/java/btm/sword/system/action/skill/type/impl/charge/ChargeSession.java
@@ -1,0 +1,86 @@
+package btm.sword.system.action.skill.type.impl.charge;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import btm.sword.system.control.TimeArbiter;
+
+import org.bukkit.entity.ItemDisplay;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Holds the runtime state of an active ability charge.
+ *
+ * <p>Created by {@link ChargeAction#startCharge} when the player begins charging,
+ * and disposed by {@link ChargeAction#releaseCharge} or {@link ChargeAction#cancelCharge}.</p>
+ *
+ * <p>Abilities store their own per-tick state (current scale, rotation, etc.) in the
+ * generic {@link #data} map.</p>
+ */
+@Getter
+@Setter
+public class ChargeSession {
+
+    private final ChargeableAbility ability;
+    private final ItemDisplay display;
+    private final int slotIndex;
+    private final long startTimeMs;
+    private TimeArbiter.TaskHandle tickTask;
+
+    /**
+     * Generic data map for ability-specific state (e.g. current scale, rotation angle).
+     * Avoids the need for session subclasses.
+     */
+    private final Map<String, Object> data = new HashMap<>();
+
+    /**
+     * Creates a new charge session.
+     *
+     * @param ability   the chargeable ability being charged
+     * @param display   the display entity
+     * @param slotIndex the hotbar slot index (1 or 2)
+     */
+    public ChargeSession(ChargeableAbility ability, ItemDisplay display, int slotIndex) {
+        this.ability = ability;
+        this.display = display;
+        this.slotIndex = slotIndex;
+        this.startTimeMs = System.currentTimeMillis();
+    }
+
+    /**
+     * Convenience getter for a float value from the data map.
+     *
+     * @param key          the data key
+     * @param defaultValue the value to return if the key is absent
+     * @return the stored float or the default
+     */
+    public float getFloat(String key, float defaultValue) {
+        Object v = data.get(key);
+        return v instanceof Number n ? n.floatValue() : defaultValue;
+    }
+
+    /**
+     * Convenience setter for a float value in the data map.
+     *
+     * @param key   the data key
+     * @param value the value to store
+     */
+    public void setFloat(String key, float value) {
+        data.put(key, value);
+    }
+
+    /**
+     * Cancels the tick task and removes the display entity.
+     */
+    public void dispose() {
+        if (tickTask != null) {
+            tickTask.cancel();
+            tickTask = null;
+        }
+        if (display != null && !display.isDead()) {
+            display.remove();
+        }
+    }
+}

--- a/src/main/java/btm/sword/system/action/skill/type/impl/charge/ChargeSession.java
+++ b/src/main/java/btm/sword/system/action/skill/type/impl/charge/ChargeSession.java
@@ -3,10 +3,9 @@ package btm.sword.system.action.skill.type.impl.charge;
 import java.util.HashMap;
 import java.util.Map;
 
-import btm.sword.system.control.TimeArbiter;
-
 import org.bukkit.entity.ItemDisplay;
 
+import btm.sword.system.control.TimeArbiter;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/src/main/java/btm/sword/system/action/skill/type/impl/charge/ChargeableAbility.java
+++ b/src/main/java/btm/sword/system/action/skill/type/impl/charge/ChargeableAbility.java
@@ -2,11 +2,11 @@ package btm.sword.system.action.skill.type.impl.charge;
 
 import java.util.Set;
 
-import btm.sword.system.action.skill.type.ActivatableAbility;
 import org.bukkit.entity.ItemDisplay;
 
 import btm.sword.system.action.skill.AbilityType;
 import btm.sword.system.action.skill.AbilityUseType;
+import btm.sword.system.action.skill.type.ActivatableAbility;
 
 /**
  * An ability that charges while the player holds right-click, then fires on release.

--- a/src/main/java/btm/sword/system/action/skill/type/impl/charge/ChargeableAbility.java
+++ b/src/main/java/btm/sword/system/action/skill/type/impl/charge/ChargeableAbility.java
@@ -1,0 +1,83 @@
+package btm.sword.system.action.skill.type.impl.charge;
+
+import java.util.Set;
+
+import btm.sword.system.action.skill.type.ActivatableAbility;
+import org.bukkit.entity.ItemDisplay;
+
+import btm.sword.system.action.skill.AbilityType;
+import btm.sword.system.action.skill.AbilityUseType;
+
+/**
+ * An ability that charges while the player holds right-click, then fires on release.
+ *
+ * <p>The charge spawns an {@link ItemDisplay} in front of the player. Each tick,
+ * {@link #onChargeTick(ChargeSession, long)} is called so the ability can apply its own
+ * visual effects (scaling, rotation, particles, etc.). The player may release once
+ * {@link ChargeSession#canRelease()} returns {@code true}.</p>
+ *
+ * <p>Chargeable abilities use the input execution tree ({@code RIGHT} to start charging,
+ * {@code RIGHT_HOLD} to release) rather than the simple left-click path used by
+ * {@link ActivatableAbility}.</p>
+ */
+public abstract class ChargeableAbility extends ActivatableAbility {
+
+    @Override
+    public AbilityType abilityType() {
+        return AbilityType.CHARGEABLE;
+    }
+
+    /** Chargeable abilities are always activated via hold, not tap. */
+    @Override
+    public boolean requiresHold() {
+        return true;
+    }
+
+    @Override
+    public boolean consumesOnUse() {
+        return true;
+    }
+
+    /** Chargeable abilities default to stack-based consumption. */
+    @Override
+    public Set<AbilityUseType> useTypes() {
+        return Set.of(AbilityUseType.STACK, AbilityUseType.COOLDOWN);
+    }
+
+    /**
+     * Called every tick while the charge is active.
+     * Implementations apply visual effects (scale, rotation, particles, etc.)
+     * to the session's display entity.
+     *
+     * @param session   the active charge session
+     * @param elapsedMs milliseconds since the charge started
+     */
+    public abstract void onChargeTick(ChargeSession session, long elapsedMs);
+
+    /**
+     * Whether the charge can be released at this moment. Called when the player
+     * releases right-click. If {@code false}, the charge is cancelled instead.
+     *
+     * @param session the active charge session
+     * @return {@code true} if the charge is ready to fire
+     */
+    public abstract boolean canRelease(ChargeSession session);
+
+    /**
+     * The velocity magnitude of the projectile when released.
+     *
+     * @return projectile speed
+     */
+    public abstract double projectileVelocity();
+
+    /**
+     * The display scale to use for the thrown projectile.
+     * Defaults to {@code 1.0f}; override to use the charge session's tracked scale.
+     *
+     * @param session the charge session at time of release
+     * @return the scale for the thrown ThrownItem display
+     */
+    public float releaseDisplayScale(ChargeSession session) {
+        return 1.0f;
+    }
+}

--- a/src/main/java/btm/sword/system/action/throwing/InteractiveItemArbiter.java
+++ b/src/main/java/btm/sword/system/action/throwing/InteractiveItemArbiter.java
@@ -10,9 +10,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.util.Vector;
 
-import btm.sword.system.action.skill.SkillId;
-import btm.sword.system.action.skill.container.PlayerSkillContainer;
-import btm.sword.system.action.skill.container.SkillSlot;
 import btm.sword.system.action.throwing.types.DroppedItem;
 import btm.sword.system.action.throwing.types.ThrownItem;
 import btm.sword.system.entity.base.SwordEntity;
@@ -20,7 +17,6 @@ import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.entity.umbral.UmbralBlade;
 import btm.sword.system.item.KeyRegistry;
-import btm.sword.system.item.special.AbilitySlotManager;
 import btm.sword.utility.Prefab;
 import btm.sword.utility.display.ParticleWrapper;
 
@@ -61,6 +57,21 @@ public class InteractiveItemArbiter {
 
     public static boolean isUmbralBlade(ItemDisplay id) {
         return INTERACTIVE_ITEMS.get(id) instanceof UmbralBlade;
+    }
+
+    /**
+     * Returns {@code true} if the given display is a tracked interactive item whose
+     * {@link ItemStack} carries the {@link KeyRegistry#ABILITY_ID_KEY} tag — i.e. a
+     * projectile spawned by an ability (e.g. a thrown knife).
+     *
+     * @param id the display to test
+     * @return {@code true} if the item is an ability-spawned projectile
+     */
+    public static boolean isAbilityProjectile(ItemDisplay id) {
+        InteractiveItem item = INTERACTIVE_ITEMS.get(id);
+        if (item == null) return false;
+        ItemStack stack = item.getItemStack();
+        return stack != null && !stack.isEmpty() && KeyRegistry.hasKey(stack, KeyRegistry.ABILITY_ID_KEY);
     }
 
     public static boolean isImpaling(SwordEntity self, ItemDisplay targeted) {
@@ -148,16 +159,7 @@ public class InteractiveItemArbiter {
      * @param abilityId  the {@link SkillId#asString()} value stamped on the projectile
      */
     private static void refundAbilityUse(SwordPlayer sp, String abilityId) {
-        PlayerSkillContainer container = sp.getCombatProfile().getPlayerSkillContainer();
-        SkillId eq1 = container.getEquipped(SkillSlot.ACTIVE_1);
-        if (eq1 != null && eq1.asString().equals(abilityId)) {
-            sp.getAbilitySlotManager().addUse(AbilitySlotManager.SLOT_1);
-            return;
-        }
-        SkillId eq2 = container.getEquipped(SkillSlot.ACTIVE_2);
-        if (eq2 != null && eq2.asString().equals(abilityId)) {
-            sp.getAbilitySlotManager().addUse(AbilitySlotManager.SLOT_2);
-        }
+        sp.getAbilitySlotManager().refundByAbilityId(abilityId);
     }
 
     /**

--- a/src/main/java/btm/sword/system/action/throwing/InteractiveItemArbiter.java
+++ b/src/main/java/btm/sword/system/action/throwing/InteractiveItemArbiter.java
@@ -7,13 +7,20 @@ import org.bukkit.Particle;
 import org.bukkit.block.Block;
 import org.bukkit.entity.ItemDisplay;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.util.Vector;
 
+import btm.sword.system.action.skill.SkillId;
+import btm.sword.system.action.skill.container.PlayerSkillContainer;
+import btm.sword.system.action.skill.container.SkillSlot;
 import btm.sword.system.action.throwing.types.DroppedItem;
 import btm.sword.system.action.throwing.types.ThrownItem;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.impl.Combatant;
+import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.entity.umbral.UmbralBlade;
+import btm.sword.system.item.KeyRegistry;
+import btm.sword.system.item.special.AbilitySlotManager;
 import btm.sword.utility.Prefab;
 import btm.sword.utility.display.ParticleWrapper;
 
@@ -105,6 +112,17 @@ public class InteractiveItemArbiter {
         ItemStack item = interactiveItem.getItemStack();
         if (item == null) return;
         if (!item.isEmpty()) {
+            // Ability projectile pickup — refund a use to the thrower instead of giving the visual item
+            if (interactiveItem instanceof ThrownItem thrownItem
+                    && thrownItem.getThrower() instanceof SwordPlayer sp
+                    && KeyRegistry.hasKey(item, KeyRegistry.ABILITY_ID_KEY)) {
+                String abilityId = KeyRegistry.getKeyField(item, KeyRegistry.ABILITY_ID_KEY, PersistentDataType.STRING);
+                refundAbilityUse(sp, abilityId);
+                interactiveItem.dispose();
+                Prefab.Particles.GRAB_CLOUD.display(display.getLocation());
+                return;
+            }
+
             interactiveItem.dispose();
             executor.giveItem(item);
             Location displayLoc = display.getLocation();
@@ -119,6 +137,26 @@ public class InteractiveItemArbiter {
             }
             Prefab.Particles.GRAB_CLOUD.display(display.getLocation());
             interactiveItem.dispose();
+        }
+    }
+
+    /**
+     * Refunds one stack use of the named ability to the given player, if they have it equipped
+     * in an active slot. Used when an ability projectile (e.g. a thrown knife) is picked up.
+     *
+     * @param sp         the player who originally threw the projectile
+     * @param abilityId  the {@link SkillId#asString()} value stamped on the projectile
+     */
+    private static void refundAbilityUse(SwordPlayer sp, String abilityId) {
+        PlayerSkillContainer container = sp.getCombatProfile().getPlayerSkillContainer();
+        SkillId eq1 = container.getEquipped(SkillSlot.ACTIVE_1);
+        if (eq1 != null && eq1.asString().equals(abilityId)) {
+            sp.getAbilitySlotManager().addUse(AbilitySlotManager.SLOT_1);
+            return;
+        }
+        SkillId eq2 = container.getEquipped(SkillSlot.ACTIVE_2);
+        if (eq2 != null && eq2.asString().equals(abilityId)) {
+            sp.getAbilitySlotManager().addUse(AbilitySlotManager.SLOT_2);
         }
     }
 

--- a/src/main/java/btm/sword/system/action/throwing/ThrowAction.java
+++ b/src/main/java/btm/sword/system/action/throwing/ThrowAction.java
@@ -106,6 +106,55 @@ public class ThrowAction extends SwordAction {
     }
 
     /**
+     * Throws an item directly without the {@link #throwReady} aim-and-hold windup.
+     * <p>
+     * The display entity is spawned on the next server tick; once it exists the
+     * {@link ThrownItem} is immediately released at the given velocity — {@code onReady()}
+     * is never called. This is suitable for instant-release throws (e.g. knife throws)
+     * where no aim window or slowness effect is desired.
+     * <p>
+     * {@code displayScale} is applied to the item's transform in
+     * {@link ThrownItem#determineOrientation()} via
+     * {@link btm.sword.system.action.throwing.types.VisualProjectile#displayScale}.
+     * Pass {@code 1.0f} for normal size.
+     *
+     * @param executor     the combatant performing the throw
+     * @param item         the item to throw
+     * @param displayScale uniform scale applied to the display transform (e.g. {@code 0.5f} for half size)
+     * @param velocity     the initial velocity magnitude passed to {@link ThrownItem#onRelease(double)}
+     */
+    public static void throwDirect(Combatant executor, ItemStack item, float displayScale, double velocity) {
+        executor.setAttemptingThrow(true);
+        executor.setThrowCancelled(false);
+        executor.setThrowSuccessful(false);
+        if (executor instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.THROWING);
+
+        ThrownItem thrownItem = new ThrownItem(executor, display -> display.setItemStack(item), 1);
+        thrownItem.setItemStack(item);
+        thrownItem.setDisplayScale(displayScale);
+        executor.setThrownItem(thrownItem);
+
+        new BukkitRunnable() {
+            int misses = 0;
+            @Override
+            public void run() {
+                if (misses > 20) {
+                    cancel();
+                    return;
+                }
+                if (thrownItem.getDisplay() == null) {
+                    misses++;
+                } else {
+                    executor.setThrowSuccessful(true);
+                    if (executor instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.NORMAL);
+                    thrownItem.onRelease(velocity);
+                    cancel();
+                }
+            }
+        }.runTaskTimer(Sword.getInstance(), 0L, 1L);
+    }
+
+    /**
      * Cancels a throw action before it is released.
      * <p>
      * This restores the executor’s held item states to what they were prior to

--- a/src/main/java/btm/sword/system/action/throwing/ThrowAction.java
+++ b/src/main/java/btm/sword/system/action/throwing/ThrowAction.java
@@ -145,6 +145,7 @@ public class ThrowAction extends SwordAction {
                 if (thrownItem.getDisplay() == null) {
                     misses++;
                 } else {
+                    executor.setAttemptingThrow(false);
                     executor.setThrowSuccessful(true);
                     if (executor instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.NORMAL);
                     thrownItem.onRelease(velocity);

--- a/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
@@ -36,6 +36,7 @@ import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.input.ActivationContext;
 import btm.sword.system.item.ItemUsageManager;
+import btm.sword.system.item.KeyRegistry;
 import btm.sword.utility.Debug;
 import btm.sword.utility.Prefab;
 import btm.sword.utility.display.DisplayUtil;
@@ -252,11 +253,21 @@ public class ThrownItem extends VisualProjectile {
     }
 
     /**
-     * Returns the item to the thrower's inventory when caught.
+     * Returns the item to the thrower when caught.
+     * Ability projectiles (tagged with {@link KeyRegistry#ABILITY_ID_KEY}) refund one
+     * slot use instead of placing the raw visual item into the thrower's inventory.
      */
     @Override
     protected void onCatch() {
-        thrower.giveItem(display.getItemStack());
+        ItemStack caughtItem = display.getItemStack();
+        if (caughtItem != null && KeyRegistry.hasKey(caughtItem, KeyRegistry.ABILITY_ID_KEY)
+                && thrower instanceof SwordPlayer sp) {
+            String abilityId = KeyRegistry.getKeyField(caughtItem, KeyRegistry.ABILITY_ID_KEY,
+                org.bukkit.persistence.PersistentDataType.STRING);
+            sp.getAbilitySlotManager().refundByAbilityId(abilityId);
+        } else {
+            thrower.giveItem(caughtItem);
+        }
         dispose();
     }
 

--- a/src/main/java/btm/sword/system/action/throwing/types/VisualProjectile.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/VisualProjectile.java
@@ -83,6 +83,13 @@ public class VisualProjectile extends SimulatedDisplay {
     protected Vector launchDirection;
 
     /**
+     * Uniform scale applied to the item display transform in {@link #determineOrientation()}.
+     * Defaults to {@code 1.0}. Set before launch (e.g. in {@link ThrowAction#throwDirect}) to
+     * adjust the visual size of the thrown item.
+     */
+    protected float displayScale = 1.0f;
+
+    /**
      * Scales the time parameter fed to {@link #positionFunction}.
      * Negative value means no scaling (raw tick count is used).
      */
@@ -471,28 +478,29 @@ public class VisualProjectile extends SimulatedDisplay {
             display.setTransformation(new Transformation(
                 base.add(new Vector3f()),
                 new Quaternionf().rotateY((float) Math.PI / 2).rotateZ((float) Math.PI / 2),
-                new Vector3f(1, 1, 1),
+                new Vector3f(displayScale, displayScale, displayScale),
                 new Quaternionf()
             ));
         } else if (name.endsWith("AXE") || name.endsWith("_HOE") || name.endsWith("_SHOVEL")) {
+            float axeScale = 1.5f * displayScale;
             display.setTransformation(new Transformation(
                 base.add(new Vector3f()),
                 new Quaternionf().rotateY((float) -Math.PI / 2).rotateZ((float) Math.PI / 4),
-                new Vector3f(1.5f, 1.5f, 1.5f),
+                new Vector3f(axeScale, axeScale, axeScale),
                 new Quaternionf()
             ));
         } else if (display.getItemStack().getType() == Material.SHIELD) {
             display.setTransformation(new Transformation(
                 base.add(new Vector3f(0, 0, 0)),
                 new Quaternionf().rotateY((float) (Math.PI / 1.01f) * 0),
-                new Vector3f(1, 1, 1),
+                new Vector3f(displayScale, displayScale, displayScale),
                 new Quaternionf()
             ));
         } else {
             display.setTransformation(new Transformation(
                 base.add(new Vector3f()),
                 new Quaternionf().rotateZ((float) Math.PI / 8),
-                new Vector3f(1, 1, 1),
+                new Vector3f(displayScale, displayScale, displayScale),
                 new Quaternionf()
             ));
         }

--- a/src/main/java/btm/sword/system/action/utility/GrabAction.java
+++ b/src/main/java/btm/sword/system/action/utility/GrabAction.java
@@ -50,6 +50,10 @@ public class GrabAction extends SwordAction {
         double baseGrabRange = Config.Grab.BASE_RANGE;
         double baseGrabThickness = Config.Grab.BASE_THICKNESS;
 
+        if (executor instanceof SwordPlayer sp) {
+            sp.resetTree(); // TODO: find out why this is necessary and why the tree doesn't reset on its own...
+        }
+
         long duration = (long) executor.calcValueAdditive(AspectType.MIGHT, 100L, baseDuration,
             Config.Grab.DURATION_SCALING);
         double range = executor.calcValueAdditive(AspectType.WILLPOWER, 4.5, baseGrabRange,
@@ -60,12 +64,16 @@ public class GrabAction extends SwordAction {
         LivingEntity ex = executor.self();
         Location o = ex.getEyeLocation();
 
-        if (executor.getItemStackInHand(true).isEmpty() || executor.holdingSoulLink()) {
+        boolean holdingAbility = executor instanceof SwordPlayer sp2 && !sp2.notHoldingAbilityItem();
+
+        if (executor.getItemStackInHand(true).isEmpty() || executor.holdingSoulLink() || holdingAbility) {
             Entity grabbedItem = HitboxUtil.ray(o, o.getDirection(), range, grabThickness,
                 entity -> entity.getType() == EntityType.ITEM_DISPLAY &&
                     !entity.isDead() &&
                     entity instanceof ItemDisplay id &&
-                    InteractiveItemArbiter.checkIfInteractive(id));
+                    InteractiveItemArbiter.checkIfInteractive(id) &&
+                    // When holding an ability item, only target ability projectiles
+                    (!holdingAbility || InteractiveItemArbiter.isAbilityProjectile(id)));
 
             if (executor.holdingSoulLink() &&
                 grabbedItem instanceof ItemDisplay display &&

--- a/src/main/java/btm/sword/system/control/TimeArbiter.java
+++ b/src/main/java/btm/sword/system/control/TimeArbiter.java
@@ -98,8 +98,8 @@ public class TimeArbiter {
             else if (timeScale < 0.6) potionStrength = 3;
             else if (timeScale < 0.8) potionStrength = 2;
             else potionStrength = 1;
-            PotionEffect slowness = new PotionEffect(PotionEffectType.SLOWNESS, 99999999, potionStrength);
-            PotionEffect slowFall = new PotionEffect(PotionEffectType.SLOW_FALLING, 99999999, potionStrength);
+            PotionEffect slowness = new PotionEffect(PotionEffectType.SLOWNESS, PotionEffect.INFINITE_DURATION, potionStrength);
+            PotionEffect slowFall = new PotionEffect(PotionEffectType.SLOW_FALLING, PotionEffect.INFINITE_DURATION, potionStrength);
             application = swordEntity -> {
                 swordEntity.self().clearActivePotionEffects();
                 swordEntity.self().addPotionEffect(slowness);
@@ -112,7 +112,7 @@ public class TimeArbiter {
             else if (timeScale < 1.6) potionStrength = 3;
             else if (timeScale < 1.8) potionStrength = 4;
             else potionStrength = 5;
-            PotionEffect speed = new PotionEffect(PotionEffectType.SPEED, 99999999, potionStrength);
+            PotionEffect speed = new PotionEffect(PotionEffectType.SPEED, PotionEffect.INFINITE_DURATION, potionStrength);
             application = swordEntity -> {
                 swordEntity.self().clearActivePotionEffects();
                 swordEntity.self().addPotionEffect(speed);
@@ -296,6 +296,7 @@ public class TimeArbiter {
             conditionalCallbacks, delayMs, periodMs, callingClass, callingMethod);
     }
 
+    @SuppressWarnings("all")
     public static TaskHandle runFixedIterationTaskTimer(@Nullable Runnable precheckRunnable,
                                                         @Nullable Runnable postcheckRunnable,
                                                         int delayMs,
@@ -346,8 +347,6 @@ public class TimeArbiter {
     }
 
     public static void teleportDisplay(Display display, Location destination, @Nullable Vector direction, int teleportDuration, Class<?> clazz, int lineNum) {
-//        Sword.getInstance().getLogger().info("Teleporting Display From: Class " + clazz + " line: " + lineNum);
-        // ^ Debug purposes. Will need to remove unused params later
         DisplayUtil.setSmoothTeleportDuration(display,
             teleportDuration == 0 ? 0 : Math.max(1, (int) (teleportDuration * GLOBAL_TELEPORT_DURATION_SCALING))
         );

--- a/src/main/java/btm/sword/system/entity/base/CombatProfile.java
+++ b/src/main/java/btm/sword/system/entity/base/CombatProfile.java
@@ -127,7 +127,7 @@ public class CombatProfile {
 
         this.maxAirDodges = btm.sword.config.Config.Entity.COMBAT_PROFILE_MAX_AIR_DODGES;
 
-        playerSkillContainer = new PlayerSkillContainer(); // Related to #166
+        playerSkillContainer = new PlayerSkillContainer(); // TODO: Related to #166
     }
 
     /**

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -487,7 +487,7 @@ public class SwordPlayer extends Combatant {
             activationContext = ActivationContext.NORMAL;
         }
 
-        if (handleAbilityInput(input, player.getInventory().getHeldItemSlot())) {
+        if (handleAbilityInput(input)) {
             resetTree();
             return;
         }
@@ -565,21 +565,32 @@ public class SwordPlayer extends Combatant {
         }
     }
 
-    private boolean handleAbilityInput(InputType input, int heldItemSlot) {
-        SwordItemType itemType = SwordItemType.fromString(getItemStackInHand(true));
-        if (itemType != SwordItemType.ACTIVE_1 && itemType != SwordItemType.ACTIVE_2) return false;
+    public boolean isAbilityItem(ItemStack item) {
+        SwordItemType itemType = SwordItemType.fromString(item);
+        Debug.combat("ItemType="+itemType);
+        return itemType == SwordItemType.ACTIVE_1 || itemType == SwordItemType.ACTIVE_2;
+    }
+
+    public boolean isAbilityItem(SwordItemType itemType) {
+        return itemType == SwordItemType.ACTIVE_1 || itemType == SwordItemType.ACTIVE_2;
+    }
+
+    private boolean handleAbilityInput(InputType input) {
+        int heldSlot = player.getInventory().getHeldItemSlot();
+        SwordItemType itemType = abilitySlotManager.getActiveTypeForHeldSlot(heldSlot);
+        if (itemType == null) return false;
 
         // Only LEFT (tap) and RIGHT_HOLD (charge/throw) trigger abilities
         if (input != InputType.LEFT && input != InputType.RIGHT_HOLD) return false;
         boolean holdVariant = input == InputType.RIGHT_HOLD;
 
         SkillSlot slot = itemType == SwordItemType.ACTIVE_1 ? SkillSlot.ACTIVE_1 : SkillSlot.ACTIVE_2;
-        int slotIndex = itemType == SwordItemType.ACTIVE_1 ? AbilitySlotManager.SLOT_1 : AbilitySlotManager.SLOT_2;
+        int slotIndex = heldSlot; // heldSlot is already the hotbar index (1 or 2)
 
         InputAction action = SkillSlotActionFactory.create(this, slot, holdVariant);
         if (action == null) return false;
 
-        if (!abilitySlotManager.isEquipped(slotIndex)) return true;
+        // slotEnabled already guarantees EQUIPPED — isEquipped check not needed
 
         SkillId equippedId = getCombatProfile().getPlayerSkillContainer().getEquipped(slot);
         Skill skill = SkillRegistry.get(equippedId);
@@ -1099,6 +1110,10 @@ public class SwordPlayer extends Combatant {
             (isPerformedDropAction() && KeyRegistry.hasKey(getLastHeldItemBeforeDrop(), KeyRegistry.SOUL_LINK_KEY));
     }
 
+    public boolean notHoldingAbilityItem() {
+        return abilitySlotManager.getActiveTypeForHeldSlot(player.getInventory().getHeldItemSlot()) == null;
+    }
+
     public boolean normalActState() {
         return activationContext == ActivationContext.NORMAL;
     }
@@ -1110,6 +1125,10 @@ public class SwordPlayer extends Combatant {
 
     public boolean throwingNonUmbralState() {
         return (throwingState() || nonUmbralState());
+    }
+
+    public boolean canBeginThrow() {
+        return nonUmbralState() && notHoldingAbilityItem();
     }
 
     public boolean nonUmbralState() {

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -10,9 +10,6 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
-import btm.sword.system.action.skill.type.impl.charge.ChargeAction;
-import btm.sword.system.action.skill.type.impl.charge.ChargeSession;
-
 import org.bukkit.Color;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -52,6 +49,8 @@ import btm.sword.system.action.skill.container.SkillSlot;
 import btm.sword.system.action.skill.container.SkillSlotActionFactory;
 import btm.sword.system.action.skill.container.SkillSlotState;
 import btm.sword.system.action.skill.type.ActiveSkill;
+import btm.sword.system.action.skill.type.impl.charge.ChargeAction;
+import btm.sword.system.action.skill.type.impl.charge.ChargeSession;
 import btm.sword.system.action.throwing.ThrowAction;
 import btm.sword.system.action.throwing.types.DroppedItem;
 import btm.sword.system.control.PredicateRunnablePair;

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -1,6 +1,7 @@
 package btm.sword.system.entity.impl;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +40,15 @@ import com.destroystokyo.paper.profile.PlayerProfile;
 import btm.sword.config.Config;
 import btm.sword.system.action.BlockAction;
 import btm.sword.system.action.UmbralBladeAction;
+import btm.sword.system.action.skill.Skill;
+import btm.sword.system.action.skill.SkillId;
+import btm.sword.system.action.skill.SkillIds;
+import btm.sword.system.action.skill.SkillRegistry;
+import btm.sword.system.action.skill.container.PlayerSkillContainer;
+import btm.sword.system.action.skill.container.SkillSlot;
+import btm.sword.system.action.skill.container.SkillSlotActionFactory;
+import btm.sword.system.action.skill.container.SkillSlotState;
+import btm.sword.system.action.skill.type.ActiveSkill;
 import btm.sword.system.action.throwing.ThrowAction;
 import btm.sword.system.action.throwing.types.DroppedItem;
 import btm.sword.system.control.PredicateRunnablePair;
@@ -65,10 +75,12 @@ import btm.sword.system.item.ItemStackBuilder;
 import btm.sword.system.item.KeyRegistry;
 import btm.sword.system.item.StorageCategory;
 import btm.sword.system.item.SwordItemType;
+import btm.sword.system.item.special.AbilitySlotManager;
 import btm.sword.system.item.special.NonMovableItem;
 import btm.sword.system.item.special.SlotAnchoredItem;
 import btm.sword.system.playerdata.PlayerData;
 import btm.sword.system.playerdata.PlayerStorage;
+import btm.sword.system.scene.animation.CutsceneInputHandler;
 import btm.sword.utility.Debug;
 import btm.sword.utility.Prefab;
 import btm.sword.utility.SwordTimeUnit;
@@ -107,6 +119,8 @@ public class SwordPlayer extends Combatant {
     private SlotAnchoredItem questStorageButton;
     private final SlotAnchoredItem shieldItem;
     private final SlotAnchoredItem chestplateItem;
+    @Getter
+    private final AbilitySlotManager abilitySlotManager;
 
     /** Economy storage for materials, credits, and auto-pickup preferences. Loaded from and saved to the database. */
     private PlayerStorage playerStorage;
@@ -292,6 +306,15 @@ public class SwordPlayer extends Combatant {
             Material.NETHERITE_CHESTPLATE
         );
 
+        abilitySlotManager = new AbilitySlotManager(this);
+        abilitySlotManager.initialize();
+
+        // TODO: remove once test abilities are replaced with real found items
+        PlayerSkillContainer skillContainer = getCombatProfile().getPlayerSkillContainer();
+        skillContainer.discover(SkillIds.TEST_ALPHA);
+        skillContainer.discover(SkillIds.TEST_BETA);
+        skillContainer.discover(SkillIds.TEST_GAMMA);
+
         updateManagedItems();
 
         inputExecutionTree = new InputExecutionTree(this);
@@ -456,12 +479,17 @@ public class SwordPlayer extends Combatant {
         if (ItemClassifier.isBlocked(getItemStackInHand(true))) return;
 
         if (activationContext == ActivationContext.CUTSCENE) {
-            btm.sword.system.scene.animation.CutsceneInputHandler.handle(this, input);
+            CutsceneInputHandler.handle(this, input);
             return;
         }
 
         if (activationContext.equals(ActivationContext.CHANNELING)) {
             activationContext = ActivationContext.NORMAL;
+        }
+
+        if (handleAbilityInput(input, player.getInventory().getHeldItemSlot())) {
+            resetTree();
+            return;
         }
 
         if (throwingState()) {
@@ -535,6 +563,40 @@ public class SwordPlayer extends Combatant {
         if (internalAction != null) {
             internalAction.accept(this);
         }
+    }
+
+    private boolean handleAbilityInput(InputType input, int heldItemSlot) {
+        SwordItemType itemType = SwordItemType.fromString(getItemStackInHand(true));
+        if (itemType != SwordItemType.ACTIVE_1 && itemType != SwordItemType.ACTIVE_2) return false;
+
+        // Only LEFT (tap) and RIGHT_HOLD (charge/throw) trigger abilities
+        if (input != InputType.LEFT && input != InputType.RIGHT_HOLD) return false;
+        boolean holdVariant = input == InputType.RIGHT_HOLD;
+
+        SkillSlot slot = itemType == SwordItemType.ACTIVE_1 ? SkillSlot.ACTIVE_1 : SkillSlot.ACTIVE_2;
+        int slotIndex = itemType == SwordItemType.ACTIVE_1 ? AbilitySlotManager.SLOT_1 : AbilitySlotManager.SLOT_2;
+
+        InputAction action = SkillSlotActionFactory.create(this, slot, holdVariant);
+        if (action == null) return false;
+
+        if (!abilitySlotManager.isEquipped(slotIndex)) return true;
+
+        SkillId equippedId = getCombatProfile().getPlayerSkillContainer().getEquipped(slot);
+        Skill skill = SkillRegistry.get(equippedId);
+        if (!(skill instanceof ActiveSkill active) || !active.canPerform(this)) return true;
+
+        SkillSlotState state = getCombatProfile().getPlayerSkillContainer().getSlotState(slot);
+        if (System.currentTimeMillis() < state.cooldownExpiresAt()) return true;
+
+        InputActionExecutor.execute(action, this);
+
+        abilitySlotManager.consumeUse(slotIndex);
+        long expiry = System.currentTimeMillis() + active.calculateCooldown(this);
+        SkillSlotState current = getCombatProfile().getPlayerSkillContainer().getSlotState(slot);
+        getCombatProfile().getPlayerSkillContainer().setSlotState(slot,
+            new SkillSlotState(current.remainingUses(), current.remainingDurability(), expiry));
+
+        return true;
     }
 
     @Override
@@ -774,10 +836,12 @@ public class SwordPlayer extends Combatant {
      * Must be called after construction and after {@link #reloadInventoryButtons()}.
      */
     private void updateManagedItems() {
-        managedItems = List.of(
+        List<SlotAnchoredItem> items = new ArrayList<>(List.of(
             shieldItem, chestplateItem, menuButton,
             currencyStorageButton, materialStorageButton, questStorageButton
-        );
+        ));
+        items.addAll(abilitySlotManager.getSlotItems());
+        managedItems = List.copyOf(items);
     }
 
     /**

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -487,7 +487,7 @@ public class SwordPlayer extends Combatant {
             activationContext = ActivationContext.NORMAL;
         }
 
-        if (handleAbilityInput(input)) {
+        if (isAtRoot() && handleAbilityInput(input)) {
             resetTree();
             return;
         }

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -10,6 +10,9 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import btm.sword.system.action.skill.type.impl.charge.ChargeAction;
+import btm.sword.system.action.skill.type.impl.charge.ChargeSession;
+
 import org.bukkit.Color;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -121,6 +124,10 @@ public class SwordPlayer extends Combatant {
     private final SlotAnchoredItem chestplateItem;
     @Getter
     private final AbilitySlotManager abilitySlotManager;
+
+    /** Active charge session for chargeable abilities, or {@code null} if not charging. */
+    @Getter @Setter
+    private ChargeSession activeCharge;
 
     /** Economy storage for materials, credits, and auto-pickup preferences. Loaded from and saved to the database. */
     private PlayerStorage playerStorage;
@@ -555,6 +562,10 @@ public class SwordPlayer extends Combatant {
         InputAction action = inputExecutionTree.getNextAction();
 
         if (action != null) {
+            // The simplest way for charge action to pass is simply to let it step using the
+            // Left of a basic attack, but just block the action
+            if (input == InputType.LEFT && ChargeAction.isHoldingChargeable(this)) return;
+
             InputActionExecutor.execute(action, this);
         }
 
@@ -575,39 +586,47 @@ public class SwordPlayer extends Combatant {
         return itemType == SwordItemType.ACTIVE_1 || itemType == SwordItemType.ACTIVE_2;
     }
 
+    public boolean isHeldItemOnCooldown() {
+        return getItemStackInHand(true) instanceof ItemStack item && player.getCooldown(item) > 0;
+    }
+
     private boolean handleAbilityInput(InputType input) {
+        if (ChargeAction.isHoldingChargeable(this)) return false;
         int heldSlot = player.getInventory().getHeldItemSlot();
+
+        // Gate: is this even an ability slot? If not, let the normal input tree handle it.
         SwordItemType itemType = abilitySlotManager.getActiveTypeForHeldSlot(heldSlot);
         if (itemType == null) return false;
 
-        // Only LEFT (tap) and RIGHT_HOLD (charge/throw) trigger abilities
-        if (input != InputType.LEFT && input != InputType.RIGHT_HOLD) return false;
-        boolean holdVariant = input == InputType.RIGHT_HOLD;
+        // From here on, this IS an ability slot (return true to consume the input)
+        if (input == InputType.LEFT) {
+            if (isHeldItemOnCooldown()) return true;
 
-        SkillSlot slot = itemType == SwordItemType.ACTIVE_1 ? SkillSlot.ACTIVE_1 : SkillSlot.ACTIVE_2;
-        int slotIndex = heldSlot; // heldSlot is already the hotbar index (1 or 2)
+            SkillSlot slot = itemType == SwordItemType.ACTIVE_1 ? SkillSlot.ACTIVE_1 : SkillSlot.ACTIVE_2;
 
-        InputAction action = SkillSlotActionFactory.create(this, slot, holdVariant);
-        if (action == null) return false;
+            InputAction action = SkillSlotActionFactory.create(this, slot, false);
+            if (action == null) return true;
 
-        // slotEnabled already guarantees EQUIPPED — isEquipped check not needed
+            SkillId equippedId = getCombatProfile().getPlayerSkillContainer().getEquipped(slot);
+            Skill skill = SkillRegistry.get(equippedId);
+            if (!(skill instanceof ActiveSkill active) || !active.canPerform(this)) return true;
 
-        SkillId equippedId = getCombatProfile().getPlayerSkillContainer().getEquipped(slot);
-        Skill skill = SkillRegistry.get(equippedId);
-        if (!(skill instanceof ActiveSkill active) || !active.canPerform(this)) return true;
+            SkillSlotState state = getCombatProfile().getPlayerSkillContainer().getSlotState(slot);
+            if (System.currentTimeMillis() < state.cooldownExpiresAt()) return true;
 
-        SkillSlotState state = getCombatProfile().getPlayerSkillContainer().getSlotState(slot);
-        if (System.currentTimeMillis() < state.cooldownExpiresAt()) return true;
+            InputActionExecutor.execute(action, this);
 
-        InputActionExecutor.execute(action, this);
+            abilitySlotManager.consumeUse(heldSlot);
+            long expiry = System.currentTimeMillis() + active.calculateCooldown(this);
+            SkillSlotState current = getCombatProfile().getPlayerSkillContainer().getSlotState(slot);
+            getCombatProfile().getPlayerSkillContainer().setSlotState(slot,
+                new SkillSlotState(current.remainingUses(), current.remainingDurability(), expiry));
 
-        abilitySlotManager.consumeUse(slotIndex);
-        long expiry = System.currentTimeMillis() + active.calculateCooldown(this);
-        SkillSlotState current = getCombatProfile().getPlayerSkillContainer().getSlotState(slot);
-        getCombatProfile().getPlayerSkillContainer().setSlotState(slot,
-            new SkillSlotState(current.remainingUses(), current.remainingDurability(), expiry));
-
-        return true;
+            return true;
+        }
+        else {
+            return false;
+        }
     }
 
     @Override
@@ -1111,7 +1130,7 @@ public class SwordPlayer extends Combatant {
     }
 
     public boolean notHoldingAbilityItem() {
-        return abilitySlotManager.getActiveTypeForHeldSlot(player.getInventory().getHeldItemSlot()) == null;
+        return !abilitySlotManager.isAbilityHeldSlot(player.getInventory().getHeldItemSlot());
     }
 
     public boolean normalActState() {

--- a/src/main/java/btm/sword/system/input/InputExecutionTree.java
+++ b/src/main/java/btm/sword/system/input/InputExecutionTree.java
@@ -467,9 +467,6 @@ public class InputExecutionTree {
                     if (dynamic) return pair.action().get();
                     if (pairCache == null) pairCache = new IdentityHashMap<>();
                     InputAction action = pairCache.computeIfAbsent(pair, p -> p.action().get());
-                    // TODO: allow for the ability to cast from different actions...?
-                    // Running into some issues here with healing and the NoOP, where the healing action
-                    // is available if holding blade, but S -> S should also be able to be fired, if the player does not want to continue healing...
                     if (action.unableToCast(owner)) {
                         continue;
                     }

--- a/src/main/java/btm/sword/system/input/InputRegistrar.java
+++ b/src/main/java/btm/sword/system/input/InputRegistrar.java
@@ -568,8 +568,10 @@ public class InputRegistrar {
                                                 SwordPlayer owner,
                                                 SkillSlot slot, int slotIndex) {
         // Tap variant
-        new InputExecutionTree.InputNodeBuilder(root, List.of(InputType.SWAP, InputType.RIGHT))
-            .action(new LinkedList<>(List.of(
+        new InputExecutionTree.InputNodeBuilder(root, List.of(
+            InputType.SWAP,
+            InputType.RIGHT
+        )).action(new LinkedList<>(List.of(
                 new InputExecutionTree.ActionContextPair(
                     () -> SkillSlotActionFactory.create(owner, slot, false),
                     sp -> sp.activeItemState(slotIndex))
@@ -578,7 +580,7 @@ public class InputRegistrar {
             .sameItemRequired(true)
             .cancellable(true)
             .display(true)
-            .visibleIf(ActivationContext.onlyIn(ActivationContext.NORMAL))
+            .visibleIf(ActivationContext.onlyIn(ActivationContext.NORMAL)) //TODO here: check if the player is holding an active item here as well
             .build();
 
         // Hold variant

--- a/src/main/java/btm/sword/system/input/InputRegistrar.java
+++ b/src/main/java/btm/sword/system/input/InputRegistrar.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import btm.sword.utility.Debug;
+
 import org.bukkit.Material;
 
 import btm.sword.config.Config;
@@ -15,6 +17,7 @@ import btm.sword.system.action.attack.AttackAction;
 import btm.sword.system.action.attack.DashAttackAction;
 import btm.sword.system.action.movement.DashDirection;
 import btm.sword.system.action.movement.MovementAction;
+import btm.sword.system.action.skill.type.impl.charge.ChargeAction;
 import btm.sword.system.action.skill.container.SkillSlot;
 import btm.sword.system.action.skill.container.SkillSlotActionFactory;
 import btm.sword.system.action.throwing.ThrowAction;
@@ -114,12 +117,7 @@ public class InputRegistrar {
             new InputExecutionTree.ActionContextPair(
                 () -> InputAction.builder()
                     .name("Block")
-                    .action(c -> {
-                        // TODO: Revert after testing
-//                        PacketDisplayEntityGroup group = PacketDisplayEntityGroup.getGroup() // TODO:
-
-                        BlockAction.startBlock((SwordPlayer) c);
-                    })
+                    .action(c -> BlockAction.startBlock((SwordPlayer) c))
                     .cooldown(executor -> 0)
                     .canCast(c -> true)
                     .displayDisabled(false)
@@ -190,7 +188,7 @@ public class InputRegistrar {
                 .build(),
                 SwordPlayer::canBeginThrow)
             )))
-            .timeoutTicks(100)
+            .timeoutTicks(500)
             .sameItemRequired(true)
             .cancellable(true)
             .display(true)
@@ -219,8 +217,57 @@ public class InputRegistrar {
             .sameItemRequired(true)
             .cancellable(true)
             .display(true)
-            .visibleIf(sp -> sp.notHoldingAbilityItem())
+            .visibleIf(SwordPlayer::notHoldingAbilityItem)
             .build();
+
+        // Chargeable ability
+        new InputExecutionTree.InputNodeBuilder(root, List.of(
+            InputType.LEFT,
+            InputType.RIGHT
+        )).action(new LinkedList<>(List.of(
+                new InputExecutionTree.ActionContextPair(
+                    () -> InputAction.builder()
+                        .name("Begin Charge")
+                        .action(ChargeAction::startCharge)
+                        .cooldown(executor -> 0)
+                        .canCast(c -> c instanceof SwordPlayer sp &&
+                            ChargeAction.isHoldingChargeable(sp) &&
+                            !sp.isHeldItemOnCooldown())
+                        .displayDisabled(false)
+                        .resetIfCannotPerform(true)
+                        .build(),
+                    c -> c instanceof SwordPlayer sp &&
+                        ChargeAction.isHoldingChargeable(sp) &&
+                        !sp.isHeldItemOnCooldown())
+            )))
+            .cancellable(true)
+            .display(true)
+            .visibleIf(ChargeAction::isHoldingChargeable)
+            .build();
+
+        // Chargeable ability
+        new InputExecutionTree.InputNodeBuilder(root, List.of(
+            InputType.LEFT,
+            InputType.RIGHT,
+            InputType.RIGHT_HOLD
+        )).action(new LinkedList<>(List.of(
+            new InputExecutionTree.ActionContextPair(
+                () -> InputAction.builder()
+                    .name("Release Charge")
+                    .action(c -> Debug.combat("Release now happens implicitly within Charge Action..."))
+                    .cooldown(executor -> 0)
+                    .canCast(c -> true)
+                    .displayDisabled(false)
+                    .resetIfCannotPerform(true)
+                    .build(),
+                sp -> true)
+        )))
+            .cancellable(true)
+            .minHoldTime(250)
+            .display(true)
+            .visibleIf(ChargeAction::isHoldingChargeable)
+            .build();
+
 
         // debug kill
         new InputExecutionTree.InputNodeBuilder(root, List.of(
@@ -462,17 +509,17 @@ public class InputRegistrar {
             new InputExecutionTree.InputNodeBuilder(root,
                 Collections.nCopies(step, InputType.LEFT)
             ).action(new LinkedList<>(List.of(
-                    new InputExecutionTree.ActionContextPair(
-                        () -> InputAction.builder()
-                            .action(executor -> UmbralBladeAction.wieldedUmbralBladeAttack(executor, comboStep))
-                            .cooldown(cooldown)
-                            .canCast(Combatant::canPerformAction)
-                            .castDuration(attackCastDuration)
-                            .displayCooldown(true)
-                            .displayDisabled(true)
-                            .resetIfCannotPerform(false)
-                            .build(),
-                        SwordPlayer::umbralBladeState),
+                new InputExecutionTree.ActionContextPair(
+                    () -> InputAction.builder()
+                        .action(executor -> UmbralBladeAction.wieldedUmbralBladeAttack(executor, comboStep))
+                        .cooldown(cooldown)
+                        .canCast(Combatant::canPerformAction)
+                        .castDuration(attackCastDuration)
+                        .displayCooldown(true)
+                        .displayDisabled(true)
+                        .resetIfCannotPerform(false)
+                        .build(),
+                    SwordPlayer::umbralBladeState),
                 new InputExecutionTree.ActionContextPair(
                     () -> InputAction.builder()
                         .action(executor -> UmbralBladeAction.basicAttackWithLink(executor, comboStep))

--- a/src/main/java/btm/sword/system/input/InputRegistrar.java
+++ b/src/main/java/btm/sword/system/input/InputRegistrar.java
@@ -6,8 +6,6 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import btm.sword.utility.Debug;
-
 import org.bukkit.Material;
 
 import btm.sword.config.Config;
@@ -17,15 +15,16 @@ import btm.sword.system.action.attack.AttackAction;
 import btm.sword.system.action.attack.DashAttackAction;
 import btm.sword.system.action.movement.DashDirection;
 import btm.sword.system.action.movement.MovementAction;
-import btm.sword.system.action.skill.type.impl.charge.ChargeAction;
 import btm.sword.system.action.skill.container.SkillSlot;
 import btm.sword.system.action.skill.container.SkillSlotActionFactory;
+import btm.sword.system.action.skill.type.impl.charge.ChargeAction;
 import btm.sword.system.action.throwing.ThrowAction;
 import btm.sword.system.action.utility.GrabAction;
 import btm.sword.system.action.utility.UtilityAction;
 import btm.sword.system.entity.aspect.AspectType;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.utility.Debug;
 import btm.sword.utility.SwordTimeUnit;
 
 

--- a/src/main/java/btm/sword/system/input/InputRegistrar.java
+++ b/src/main/java/btm/sword/system/input/InputRegistrar.java
@@ -428,9 +428,6 @@ public class InputRegistrar {
             .visibleIf(ActivationContext.onlyIn(ActivationContext.NORMAL))
             .build();
 
-        // Active Skill slots (ACTIVE_1 and ACTIVE_2)
-        registerActiveSkillSlot(root, owner, SkillSlot.ACTIVE_1, 1);
-        registerActiveSkillSlot(root, owner, SkillSlot.ACTIVE_2, 2);
     }
 
     // ── Helper methods ──────────────────────────────────────────────────────
@@ -550,49 +547,6 @@ public class InputRegistrar {
                     SwordPlayer::normalActState)
             )))
             .timeoutTicks(3)
-            .cancellable(true)
-            .display(true)
-            .visibleIf(ActivationContext.onlyIn(ActivationContext.NORMAL))
-            .build();
-    }
-
-    /**
-     * Registers tap and hold variants for an active skill slot.
-     *
-     * @param root      the tree root node
-     * @param owner     the player who owns the tree
-     * @param slot      the skill slot to bind
-     * @param slotIndex the hotbar slot index (1 or 2) for context predicate
-     */
-    private static void registerActiveSkillSlot(InputExecutionTree.InputNode root,
-                                                SwordPlayer owner,
-                                                SkillSlot slot, int slotIndex) {
-        // Tap variant
-        new InputExecutionTree.InputNodeBuilder(root, List.of(
-            InputType.SWAP,
-            InputType.RIGHT
-        )).action(new LinkedList<>(List.of(
-                new InputExecutionTree.ActionContextPair(
-                    () -> SkillSlotActionFactory.create(owner, slot, false),
-                    sp -> sp.activeItemState(slotIndex))
-            )))
-            .dynamic(true)
-            .sameItemRequired(true)
-            .cancellable(true)
-            .display(true)
-            .visibleIf(ActivationContext.onlyIn(ActivationContext.NORMAL)) //TODO here: check if the player is holding an active item here as well
-            .build();
-
-        // Hold variant
-        new InputExecutionTree.InputNodeBuilder(root, List.of(
-            InputType.SWAP, InputType.RIGHT, InputType.RIGHT_HOLD
-        )).action(new LinkedList<>(List.of(
-                new InputExecutionTree.ActionContextPair(
-                    () -> SkillSlotActionFactory.create(owner, slot, true),
-                    sp -> sp.activeItemState(slotIndex))
-            )))
-            .dynamic(true)
-            .sameItemRequired(true)
             .cancellable(true)
             .display(true)
             .visibleIf(ActivationContext.onlyIn(ActivationContext.NORMAL))

--- a/src/main/java/btm/sword/system/input/InputRegistrar.java
+++ b/src/main/java/btm/sword/system/input/InputRegistrar.java
@@ -182,17 +182,20 @@ public class InputRegistrar {
                 .name("Throw Ready")
                 .action(ThrowAction::throwReady)
                 .cooldown(executor -> 0)
-                .canCast(c -> c.canPerformAction() && (c instanceof SwordPlayer sp && sp.nonUmbralState()))
+                .canCast(c -> c.canPerformAction() &&
+                        (!(c instanceof SwordPlayer sp) ||
+                            sp.nonUmbralState() && sp.notHoldingAbilityItem()))
                 .displayDisabled(true)
                 .resetIfCannotPerform(true)
                 .build(),
-                SwordPlayer::nonUmbralState)
+                SwordPlayer::canBeginThrow)
             )))
             .timeoutTicks(100)
             .sameItemRequired(true)
             .cancellable(true)
             .display(true)
-            .visibleIf(ActivationContext.onlyIn(ActivationContext.NORMAL))
+            .visibleIf(sp -> sp.notHoldingAbilityItem() &&
+                    ActivationContext.onlyIn(ActivationContext.NORMAL).test(sp))
             .build();
 
         // throw
@@ -216,6 +219,7 @@ public class InputRegistrar {
             .sameItemRequired(true)
             .cancellable(true)
             .display(true)
+            .visibleIf(sp -> sp.notHoldingAbilityItem())
             .build();
 
         // debug kill

--- a/src/main/java/btm/sword/system/inventory/menu/AbilityHistoryMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/AbilityHistoryMenu.java
@@ -1,0 +1,115 @@
+package btm.sword.system.inventory.menu;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+import org.bukkit.Material;
+
+import btm.sword.system.action.skill.history.AbilityHistoryAction;
+import btm.sword.system.action.skill.history.AbilityHistoryEntry;
+import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.item.ItemStackBuilder;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import xyz.xenondevs.invui.item.impl.SimpleItem;
+
+/**
+ * Paged menu displaying a player's ability event history — uses and surrenders.
+ *
+ * <p>Each entry shows the ability name, action type, and timestamp. Entries are
+ * displayed newest-first. The menu is read-only; no interaction beyond navigation
+ * and returning to the Character Menu is provided.
+ *
+ * <p><b>Layout</b> (6-row chest, 54 slots):</p>
+ * <pre>
+ * P # # # # # # # #
+ * x x x x x x x x x
+ * x x x x x x x x x
+ * x x x x x x x x x
+ * x x x x x x x x x
+ * # # # # &lt; # &gt; # #
+ * </pre>
+ * {@code P} = back to Character Menu, {@code <}/{@code >} = page navigation.
+ */
+public class AbilityHistoryMenu extends Menu {
+
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+
+    public AbilityHistoryMenu(SwordPlayer player) {
+        super(player);
+    }
+
+    @Override
+    public void open() {
+//        Player player = swordPlayer.player();
+//        PlayerAbilityHistory history = swordPlayer.getAbilityHistory();
+//
+//        List<AbilityHistoryEntry> entries = history.entries();
+//
+//        List<Item> items = new ArrayList<>();
+//        // Newest first
+//        for (int i = entries.size() - 1; i >= 0; i--) {
+//            items.add(buildEntryItem(entries.get(i)));
+//        }
+//
+//        if (items.isEmpty()) {
+//            items.add(new SimpleItem(
+//                new ItemStackBuilder(Material.GRAY_STAINED_GLASS_PANE)
+//                    .name(Component.text("No ability events recorded yet.", NamedTextColor.GRAY))
+//                    .build()
+//            ));
+//        }
+//
+//        SimpleItem back = new SimpleItem(
+//            new ItemStackBuilder(Material.COPPER_TRAPDOOR)
+//                .name(Component.text("Back to Character Menu", NamedTextColor.GRAY))
+//                .build(),
+//            click -> new CharacterMenu(swordPlayer).open()
+//        );
+//
+//        PagedGui<Item> gui = PagedGui.items()
+//            .setStructure(
+//                "P # # # # # # # #",
+//                "x x x x x x x x x",
+//                "x x x x x x x x x",
+//                "x x x x x x x x x",
+//                "x x x x x x x x x",
+//                "# # # # < # > # #")
+//            .addIngredient('#', BORDER)
+//            .addIngredient('x', Markers.CONTENT_LIST_SLOT_HORIZONTAL)
+//            .addIngredient('P', back)
+//            .setContent(items)
+//            .build();
+//
+//        Window window = Window.single()
+//            .setViewer(player)
+//            .setTitle("Ability History")
+//            .setGui(gui)
+//            .build();
+//
+//        window.open();
+    }
+
+    private SimpleItem buildEntryItem(AbilityHistoryEntry entry) {
+        boolean surrendered = entry.action() == AbilityHistoryAction.SURRENDERED;
+
+        Material icon = surrendered ? Material.BARRIER : Material.ECHO_SHARD;
+        NamedTextColor actionColor = surrendered ? NamedTextColor.RED : NamedTextColor.AQUA;
+        String actionLabel = surrendered ? "Surrendered" : "Used";
+
+        String dateStr = DATE_FORMAT.format(new Date(entry.timestamp()));
+
+        return new SimpleItem(
+            new ItemStackBuilder(icon)
+                .name(Component.text(entry.displayName(), NamedTextColor.WHITE, TextDecoration.BOLD))
+                .lore(List.of(
+                    Component.text(actionLabel, actionColor),
+                    Component.text(dateStr, NamedTextColor.DARK_GRAY)
+                ))
+                .hideAll()
+                .build()
+        );
+    }
+}

--- a/src/main/java/btm/sword/system/inventory/menu/CharacterMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/CharacterMenu.java
@@ -18,6 +18,7 @@ import btm.sword.system.action.skill.SkillRegistry;
 import btm.sword.system.action.skill.container.SkillSlot;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.item.ItemStackBuilder;
+import btm.sword.system.item.special.AbilitySlotManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
@@ -110,6 +111,20 @@ public class CharacterMenu extends Menu {
         return click -> new SkillSelectionMenu(swordPlayer, slot).open();
     }
 
+    // TODO: remove — dev shortcut for replenishing ability slots during testing
+    private SimpleItem buildReplenishButton() {
+        return new SimpleItem(
+            new ItemStackBuilder(Material.HONEY_BOTTLE)
+                .name(Component.text("[Dev] Replenish Abilities", NamedTextColor.YELLOW, TextDecoration.BOLD))
+                .build(),
+            click -> {
+                swordPlayer.getAbilitySlotManager().refresh(AbilitySlotManager.SLOT_1);
+                swordPlayer.getAbilitySlotManager().refresh(AbilitySlotManager.SLOT_2);
+                this.open();
+            }
+        );
+    }
+
     /**
      * Builds a dev-only button that opens {@link DevStatEditorMenu}.
      * Hidden for non-op players (replaced with BORDER).
@@ -148,12 +163,13 @@ public class CharacterMenu extends Menu {
                 "# . { 1 2 3 { . #", // 3 Umbral Skills
                 ". . 4 - 9 - 5 . .", // 2 other active skills and 1 Core Passive
                 ". . { 6 7 8 { . .", // 3 other passives
-                "# . . . . . . D #",
+                "# . . . . . Z D #",
                 "# # # < W > # # #") // weapon combat proficiencies and info (equip normal weapon-specific passives and skills
             .addIngredient('#', BORDER)
             .addIngredient('S', swordPlayer.getPlayerHead())
             .addIngredient('<', generatePreviousButtonOrDefault())
             .addIngredient('>', generateForwardPreviousButtonOrDefault())
+            .addIngredient('Z', buildReplenishButton())
             .addIngredient('D', buildDevStatsButton(player));
 
         for (Map.Entry<Character, SkillSlot> entry : menuSlots.entrySet()) {
@@ -164,7 +180,7 @@ public class CharacterMenu extends Menu {
 
         Window window = Window.single()
             .setViewer(player)
-            .setTitle("MainMenu")
+            .setTitle("Character Loadout")
             .setGui(gui)
             .build();
 

--- a/src/main/java/btm/sword/system/inventory/menu/DevMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/DevMenu.java
@@ -180,6 +180,14 @@ public class DevMenu extends Menu {
             click -> btm.sword.system.join.InitialJoinCutscene.play(swordPlayer)
         );
 
+        SimpleItem skillEquip = new SimpleItem(
+            new ItemStackBuilder(Material.KNOWLEDGE_BOOK)
+                .name(Component.text("Skill Equip", NamedTextColor.LIGHT_PURPLE, TextDecoration.BOLD))
+                .lore(List.of(Component.text("Force-equip any skill to any slot", NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> new DevSkillEquipMenu(swordPlayer).open()
+        );
+
         SimpleItem itemLibrary = new SimpleItem(
             new ItemStackBuilder(Material.BOOKSHELF)
                 .name(Component.text("Item Library", NamedTextColor.GOLD, TextDecoration.BOLD))
@@ -262,7 +270,7 @@ public class DevMenu extends Menu {
         Gui gui = Gui.normal()
             .setStructure(
                 "# # # # # # # # #",
-                "# J N S F . L C #",
+                "# J N S F A L C #",
                 "# P X B K . H E #",
                 "# R I . T . M W #",
                 "# # # < . > # # #")
@@ -274,6 +282,7 @@ public class DevMenu extends Menu {
             .addIngredient('N', deuTools)
             .addIngredient('S', staticScene)
             .addIngredient('F', fakePlayerScene)
+            .addIngredient('A', skillEquip)
             .addIngredient('L', itemLibrary)
             .addIngredient('X', joinCutscene)
             .addIngredient('B', bossBarTest)

--- a/src/main/java/btm/sword/system/inventory/menu/DevSkillEquipMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/DevSkillEquipMenu.java
@@ -1,0 +1,132 @@
+package btm.sword.system.inventory.menu;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.Material;
+
+import btm.sword.system.action.skill.Skill;
+import btm.sword.system.action.skill.SkillRegistry;
+import btm.sword.system.action.skill.container.PlayerSkillContainer;
+import btm.sword.system.action.skill.container.SkillSlot;
+import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.item.ItemStackBuilder;
+import btm.sword.system.item.special.AbilitySlotManager;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import xyz.xenondevs.invui.gui.PagedGui;
+import xyz.xenondevs.invui.gui.structure.Markers;
+import xyz.xenondevs.invui.item.Item;
+import xyz.xenondevs.invui.item.impl.SimpleItem;
+import xyz.xenondevs.invui.window.Window;
+
+/**
+ * Dev-only two-level skill equip menu.
+ * <p>
+ * Level 1 — lists every registered skill. Level 2 — lists the {@link SkillSlot}s
+ * compatible with the chosen skill's type. Selecting a slot calls
+ * {@link PlayerSkillContainer#discover} + {@link PlayerSkillContainer#equip}, bypassing
+ * normal availability checks, and refreshes the hotbar for active slots.
+ * </p>
+ */
+public class DevSkillEquipMenu extends Menu {
+
+    /**
+     * @param swordPlayer the player opening this menu
+     */
+    public DevSkillEquipMenu(SwordPlayer swordPlayer) {
+        super(swordPlayer);
+    }
+
+    @Override
+    public void open() {
+        List<Item> skillItems = new ArrayList<>();
+        for (Skill skill : SkillRegistry.skillMapping.values()) {
+            skillItems.add(new SimpleItem(skill.icon(), click -> openSlotPicker(skill)));
+        }
+
+        SimpleItem back = new SimpleItem(
+            new ItemStackBuilder(Material.COPPER_TRAPDOOR)
+                .name(Component.text("Back", NamedTextColor.GRAY))
+                .build(),
+            click -> new DevMenu(swordPlayer).open()
+        );
+
+        PagedGui<Item> gui = PagedGui.items()
+            .setStructure(
+                "P # # # # # # # #",
+                "x x x x x x x x x",
+                "x x x x x x x x x",
+                "# # # < # > # # #")
+            .addIngredient('#', BORDER)
+            .addIngredient('x', Markers.CONTENT_LIST_SLOT_HORIZONTAL)
+            .addIngredient('P', back)
+            .setContent(skillItems)
+            .build();
+
+        Window.single()
+            .setViewer(swordPlayer.player())
+            .setTitle("Dev — Equip Skill")
+            .setGui(gui)
+            .build()
+            .open();
+    }
+
+    /**
+     * Opens the slot-picker level for the given skill, showing only slots whose type matches.
+     *
+     * @param skill the skill to equip
+     */
+    private void openSlotPicker(Skill skill) {
+        List<Item> slotItems = new ArrayList<>();
+        PlayerSkillContainer container = swordPlayer.getCombatProfile().getPlayerSkillContainer();
+
+        for (SkillSlot slot : SkillSlot.values()) {
+            if (slot.type() != skill.type()) continue;
+            slotItems.add(new SimpleItem(
+                new ItemStackBuilder(Material.LIME_STAINED_GLASS_PANE)
+                    .name(Component.text(slot.title(), NamedTextColor.GREEN, TextDecoration.BOLD))
+                    .build(),
+                click -> {
+                    container.discover(skill.id());
+                    container.equip(slot, skill.id());
+                    if (slot == SkillSlot.ACTIVE_1) {
+                        swordPlayer.getAbilitySlotManager().refresh(AbilitySlotManager.SLOT_1);
+                    } else if (slot == SkillSlot.ACTIVE_2) {
+                        swordPlayer.getAbilitySlotManager().refresh(AbilitySlotManager.SLOT_2);
+                    }
+                    swordPlayer.message(Component.text("Equipped ", NamedTextColor.GREEN)
+                        .append(Component.text(skill.id().asString(), NamedTextColor.WHITE))
+                        .append(Component.text(" → " + slot.title(), NamedTextColor.GRAY)));
+                    open();
+                }
+            ));
+        }
+
+        SimpleItem back = new SimpleItem(
+            new ItemStackBuilder(Material.COPPER_TRAPDOOR)
+                .name(Component.text("Back", NamedTextColor.GRAY))
+                .build(),
+            click -> open()
+        );
+
+        PagedGui<Item> gui = PagedGui.items()
+            .setStructure(
+                "P # # # # # # # #",
+                "x x x x x x x x x",
+                "# # # < # > # # #")
+            .addIngredient('#', BORDER)
+            .addIngredient('x', Markers.CONTENT_LIST_SLOT_HORIZONTAL)
+            .addIngredient('P', back)
+            .setContent(slotItems)
+            .build();
+
+        Window.single()
+            .setViewer(swordPlayer.player())
+            .setTitle("Pick Slot — " + skill.id().asString())
+            .setGui(gui)
+            .build()
+            .open();
+    }
+}

--- a/src/main/java/btm/sword/system/inventory/menu/SkillSelectionMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/SkillSelectionMenu.java
@@ -108,7 +108,7 @@ public class SkillSelectionMenu extends Menu {
 
         Window window = Window.single()
             .setViewer(swordPlayer.getPlayer())
-            .setTitle("MainMenu")
+            .setTitle(slot.title())
             .setGui(gui)
             .build();
 

--- a/src/main/java/btm/sword/system/inventory/menu/SkillSelectionMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/SkillSelectionMenu.java
@@ -1,20 +1,25 @@
 package btm.sword.system.inventory.menu;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
 
 import btm.sword.system.action.skill.Skill;
 import btm.sword.system.action.skill.SkillId;
 import btm.sword.system.action.skill.SkillRegistry;
 import btm.sword.system.action.skill.SkillType;
 import btm.sword.system.action.skill.container.PlayerSkillContainer;
+import btm.sword.system.action.skill.container.SkillAvailability;
 import btm.sword.system.action.skill.container.SkillSlot;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.item.ItemStackBuilder;
+import btm.sword.system.item.special.AbilitySlotManager;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import xyz.xenondevs.invui.gui.PagedGui;
 import xyz.xenondevs.invui.gui.structure.Markers;
 import xyz.xenondevs.invui.item.Item;
@@ -33,18 +38,40 @@ public class SkillSelectionMenu extends Menu {
         this.type = slot.type();
     }
 
+    private void refreshAbilitySlot(SkillSlot skillSlot) {
+        if (skillSlot == SkillSlot.ACTIVE_1) {
+            swordPlayer.getAbilitySlotManager().refresh(AbilitySlotManager.SLOT_1);
+        } else if (skillSlot == SkillSlot.ACTIVE_2) {
+            swordPlayer.getAbilitySlotManager().refresh(AbilitySlotManager.SLOT_2);
+        }
+    }
+
     @Override
     public void open() {
         AtomicReference<SkillId> curSelected = new AtomicReference<>(skillContainer.getEquipped(slot));
 
-        List<Item> skillSelectItems = skillContainer.freeSkillIds(type)
+        List<Item> skillSelectItems = new ArrayList<>(skillContainer.freeSkillIds(type)
             .stream()
-            .map(id -> new SimpleItem(
+            .map(id -> (Item) new SimpleItem(
                 SkillRegistry.get(id).icon(),
                 click -> {
                     skillContainer.equip(slot, id);
+                    refreshAbilitySlot(slot);
                     this.open();
-                })).collect(Collectors.toList()); // this line eliminates the type difference error.
+                })).collect(Collectors.toList())); // this line eliminates the type difference error.
+
+        // Discovered but locked skills (depleted / relinquished) — shown but not selectable
+        for (SkillId id : skillContainer.lockedSkillIds(type)) {
+            SkillAvailability availability = skillContainer.getAvailability(id);
+            Component lockLabel = availability == SkillAvailability.RELINQUISHED
+                ? Component.text(" [Relinquished]", NamedTextColor.DARK_RED)
+                : Component.text(" [Depleted]", NamedTextColor.DARK_GRAY);
+            ItemStack lockedIcon = new ItemStackBuilder(SkillRegistry.get(id).icon().getType())
+                .name(SkillRegistry.get(id).icon().getItemMeta().displayName().append(lockLabel))
+                .hideAll()
+                .build();
+            skillSelectItems.add(new SimpleItem(lockedIcon, click -> {}));
+        }
 
         Skill cur = SkillRegistry.get(curSelected.get());
 
@@ -56,6 +83,7 @@ public class SkillSelectionMenu extends Menu {
             : new SimpleItem(cur.icon(),
             click -> {
                 skillContainer.unequip(slot);
+                refreshAbilitySlot(slot);
                 this.open();
             });
 

--- a/src/main/java/btm/sword/system/item/AbilityInventoryUtil.java
+++ b/src/main/java/btm/sword/system/item/AbilityInventoryUtil.java
@@ -1,0 +1,67 @@
+package btm.sword.system.item;
+
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import btm.sword.system.action.skill.SkillId;
+
+/**
+ * Utility methods for locating and consuming physical ability items in a player's inventory.
+ *
+ * <p>Ability items are identified by the {@link KeyRegistry#ABILITY_ID_KEY} PDC tag
+ * stamped on them by {@link AbilityItemBuilder}.
+ */
+public final class AbilityInventoryUtil {
+
+    private AbilityInventoryUtil() {}
+
+    /**
+     * Finds the first {@link ItemStack} in the player's inventory that matches the given ability id.
+     *
+     * @param player the player whose inventory to scan
+     * @param id     the ability id to match against
+     * @return the matching item, or {@code null} if none found
+     */
+    @Nullable
+    public static ItemStack findAbilityItem(Player player, SkillId id) {
+        for (ItemStack item : player.getInventory().getContents()) {
+            if (item == null || item.isEmpty()) continue;
+            SkillId found = AbilityItemReader.readId(item);
+            if (id.equals(found)) return item;
+        }
+        return null;
+    }
+
+    /**
+     * Returns {@code true} if the player has at least one physical item for the given ability id.
+     *
+     * @param player the player to check
+     * @param id     the ability id to match
+     * @return {@code true} if found
+     */
+    public static boolean hasAbilityItem(Player player, SkillId id) {
+        return findAbilityItem(player, id) != null;
+    }
+
+    /**
+     * Removes one ability item matching the given id from the player's inventory.
+     * If the stack has more than one item, the count is decremented. Otherwise the
+     * slot is cleared.
+     *
+     * @param player the player whose inventory to modify
+     * @param id     the ability id to match
+     * @return {@code true} if an item was found and removed
+     */
+    public static boolean removeAbilityItem(Player player, SkillId id) {
+        ItemStack item = findAbilityItem(player, id);
+        if (item == null) return false;
+
+        if (item.getAmount() > 1) {
+            item.setAmount(item.getAmount() - 1);
+        } else {
+            item.setAmount(0); // Bukkit removes the slot when set to 0
+        }
+        return true;
+    }
+}

--- a/src/main/java/btm/sword/system/item/AbilityItemBuilder.java
+++ b/src/main/java/btm/sword/system/item/AbilityItemBuilder.java
@@ -1,0 +1,45 @@
+package btm.sword.system.item;
+
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+
+import btm.sword.system.action.skill.SkillId;
+
+/**
+ * Utility for producing physical world items that represent abilities.
+ *
+ * <p>Every ability world item is tagged with the {@link KeyRegistry#ABILITY_ID_KEY} PDC key
+ * so it can later be identified via {@link AbilityItemReader}. Implementations provide
+ * the base {@link ItemStack} (visual appearance, name, lore) through the ability's own
+ * {@link btm.sword.system.action.skill.type.AbilitySkill#buildWorldItem()} — this class
+ * stamps the identity tag onto that stack.
+ *
+ * <h2>Usage</h2>
+ * <pre>
+ * // Inside an AbilitySkill implementation:
+ * public ItemStack buildWorldItem() {
+ *     ItemStack base = ItemStackBuilder.of(Material.ECHO_SHARD)
+ *         .name(name())
+ *         .lore(description())
+ *         .build();
+ *     return AbilityItemBuilder.tag(base, id());
+ * }
+ * </pre>
+ */
+public final class AbilityItemBuilder {
+
+    private AbilityItemBuilder() {}
+
+    /**
+     * Tags the given {@link ItemStack} with the supplied {@link SkillId} as its ability identity.
+     * The item is modified in-place and returned for chaining convenience.
+     *
+     * @param item the base item to stamp
+     * @param id   the ability's stable identifier
+     * @return the same item, now tagged with {@link KeyRegistry#ABILITY_ID_KEY}
+     */
+    public static ItemStack tag(ItemStack item, SkillId id) {
+        KeyRegistry.setKeyField(item, KeyRegistry.ABILITY_ID_KEY, PersistentDataType.STRING, id.asString());
+        return item;
+    }
+}

--- a/src/main/java/btm/sword/system/item/AbilityItemReader.java
+++ b/src/main/java/btm/sword/system/item/AbilityItemReader.java
@@ -1,0 +1,46 @@
+package btm.sword.system.item;
+
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.Nullable;
+
+import btm.sword.system.action.skill.SkillId;
+
+/**
+ * Reads the ability identity tag from a physical ability world item.
+ *
+ * @see AbilityItemBuilder
+ */
+public final class AbilityItemReader {
+
+    private AbilityItemReader() {}
+
+    /**
+     * Returns the {@link SkillId} stored in the item's {@link KeyRegistry#ABILITY_ID_KEY}
+     * PDC tag, or {@code null} if the item is not an ability item or the tag is malformed.
+     *
+     * @param item the item to inspect (may be {@code null} or empty)
+     * @return the ability's {@link SkillId}, or {@code null}
+     */
+    @Nullable
+    public static SkillId readId(ItemStack item) {
+        if (item == null || item.isEmpty()) return null;
+        String raw = KeyRegistry.getKeyField(item, KeyRegistry.ABILITY_ID_KEY, PersistentDataType.STRING);
+        if (raw == null) return null;
+        try {
+            return SkillId.parse(raw);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Returns {@code true} if the item has a valid {@link KeyRegistry#ABILITY_ID_KEY} tag.
+     *
+     * @param item the item to check
+     * @return {@code true} if this is an ability world item
+     */
+    public static boolean isAbilityItem(ItemStack item) {
+        return readId(item) != null;
+    }
+}

--- a/src/main/java/btm/sword/system/item/KeyRegistry.java
+++ b/src/main/java/btm/sword/system/item/KeyRegistry.java
@@ -177,6 +177,30 @@ public final class KeyRegistry {
     /** Cached {@link NamespacedKey} for {@link #WEAPON_TYPE}. */
     public static final NamespacedKey WEAPON_TYPE_KEY = key(WEAPON_TYPE);
 
+
+    /**
+     * Persistent data key stamped on every physical ability world item.
+     * Value is the {@link btm.sword.system.action.skill.SkillId#asString()} of the ability it represents.
+     * Used by {@link btm.sword.system.item.AbilityItemReader} to identify and match ability items.
+     */
+    public static final String ABILITY_ID = "ability_id";
+
+    /** Cached {@link NamespacedKey} for {@link #ABILITY_ID}. */
+    public static final NamespacedKey ABILITY_ID_KEY = key(ABILITY_ID);
+
+
+    /**
+     * Persistent data key marking an item as occupying an ability hotbar slot.
+     * Value is either {@code "PLACEHOLDER"} (locked/empty/depleted states) or
+     * {@code "EQUIPPED"} (an active ability item placed in the slot).
+     * Used by {@link btm.sword.system.item.special.AbilitySlotItem#isSatisfied} to
+     * identify valid ability-slot items during inventory upkeep.
+     */
+    public static final String ABILITY_SLOT = "ability_slot";
+
+    /** Cached {@link NamespacedKey} for {@link #ABILITY_SLOT}. */
+    public static final NamespacedKey ABILITY_SLOT_KEY = key(ABILITY_SLOT);
+
     // ------------------------------
     //  Utility Methods
     // ------------------------------

--- a/src/main/java/btm/sword/system/item/special/AbilitySlotItem.java
+++ b/src/main/java/btm/sword/system/item/special/AbilitySlotItem.java
@@ -1,0 +1,169 @@
+package btm.sword.system.item.special;
+
+import java.util.List;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+
+import btm.sword.system.item.ItemStackBuilder;
+import btm.sword.system.item.KeyRegistry;
+import btm.sword.system.item.SwordItemType;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+
+/**
+ * A {@link SlotAnchoredItem} managing one ability hotbar slot (slot 1 or 2).
+ *
+ * <p>The slot has four visual states:
+ * <ul>
+ *   <li>{@link SlotState#LOCKED} — gray glass, slot has not been unlocked.</li>
+ *   <li>{@link SlotState#EMPTY} — gray glass, unlocked but no ability equipped.</li>
+ *   <li>{@link SlotState#EQUIPPED} — the ability's world item, tagged and non-movable.</li>
+ *   <li>{@link SlotState#DEPLETED} — black glass, ability uses exhausted.</li>
+ * </ul>
+ *
+ * <p>{@link #isSatisfied(Player)} returns {@code true} when any of these four states
+ * occupies the target slot. If none match, {@link #restore(Player)} replaces the slot
+ * with the current state's item.</p>
+ *
+ * <p>These items follow the same protection pattern as the umbral blade and soul link —
+ * they are only protected/restored when {@link btm.sword.utility.Debug#SPECIAL_ITEM_CHECKS_ENABLED}
+ * is {@code true}. The {@code inventoryUpkeep()} loop already checks this for managed items.</p>
+ */
+public class AbilitySlotItem extends SlotAnchoredItem {
+
+    /** Visual states for an ability hotbar slot. */
+    public enum SlotState {
+        /** Slot has not been unlocked yet. */
+        LOCKED,
+        /** Unlocked but no ability equipped. */
+        EMPTY,
+        /** An ability is equipped and has remaining uses. */
+        EQUIPPED,
+        /** Ability uses exhausted. */
+        DEPLETED
+    }
+
+    private SlotState state;
+    private final SwordItemType swordItemType;
+
+    /**
+     * The mutable item that represents the current visual state. Overrides the
+     * immutable {@code itemStack} from {@link SpecialItem} for restore operations.
+     */
+    private ItemStack currentItem;
+
+    /**
+     * Constructs an {@code AbilitySlotItem} for the given hotbar slot.
+     *
+     * @param targetSlot    the inventory slot index (1 or 2)
+     * @param swordItemType {@link SwordItemType#ACTIVE_1} or {@link SwordItemType#ACTIVE_2}
+     * @param initialState  the initial visual state
+     */
+    public AbilitySlotItem(int targetSlot, SwordItemType swordItemType, SlotState initialState) {
+        super(buildStateItem(initialState, swordItemType), targetSlot, KeyRegistry.ABILITY_SLOT_KEY);
+        this.swordItemType = swordItemType;
+        this.state = initialState;
+        this.currentItem = buildStateItem(initialState, swordItemType);
+    }
+
+    /**
+     * Returns the current visual state of this slot.
+     *
+     * @return the current {@link SlotState}
+     */
+    public SlotState getState() {
+        return state;
+    }
+
+    /**
+     * Updates the slot's visual state and internal item. Does not place the item
+     * into the player's inventory — call {@link #restore(Player)} afterward.
+     *
+     * @param newState the new state
+     */
+    public void setState(SlotState newState) {
+        this.state = newState;
+        this.currentItem = buildStateItem(newState, swordItemType);
+    }
+
+    /**
+     * Updates the slot to {@link SlotState#EQUIPPED} with a specific ability item.
+     * The item is tagged with the ability slot PDC key and the appropriate {@link SwordItemType}.
+     *
+     * @param abilityItem the ability's world item (already tagged with {@code ability_id})
+     */
+    public void setEquipped(ItemStack abilityItem) {
+        this.state = SlotState.EQUIPPED;
+        ItemStack tagged = abilityItem.clone();
+        KeyRegistry.setKeyField(tagged, KeyRegistry.ABILITY_SLOT_KEY, PersistentDataType.STRING,
+            SlotState.EQUIPPED.name());
+        KeyRegistry.setKeyField(tagged, KeyRegistry.ITEM_TYPE_KEY, PersistentDataType.STRING,
+            swordItemType.string());
+        KeyRegistry.setKeyField(tagged, KeyRegistry.NON_MOVABLE_KEY, PersistentDataType.BOOLEAN, true);
+        this.currentItem = tagged;
+    }
+
+    /**
+     * Returns {@code true} if the target slot holds any valid ability-slot item
+     * (locked, empty, equipped, or depleted placeholder).
+     *
+     * @param player the player whose inventory to check
+     * @return {@code true} if the slot is occupied by an ability-slot item
+     */
+    @Override
+    public boolean isSatisfied(Player player) {
+        ItemStack slotItem = player.getInventory().getItem(getTargetSlot());
+        if (slotItem == null || slotItem.isEmpty()) return false;
+        return KeyRegistry.hasKey(slotItem, KeyRegistry.ABILITY_SLOT_KEY);
+    }
+
+    /**
+     * Places the current state's item into the target slot.
+     *
+     * @param player the player whose inventory to restore the item into
+     */
+    @Override
+    public void restore(Player player) {
+        player.getInventory().setItem(getTargetSlot(), currentItem);
+    }
+
+    // ── Static item builders ─────────────────────────────────────────────────
+
+    private static ItemStack buildStateItem(SlotState state, SwordItemType swordItemType) {
+        return switch (state) {
+            case LOCKED -> buildPlaceholder(Material.GRAY_STAINED_GLASS_PANE,
+                Component.text("Locked Ability Slot", NamedTextColor.DARK_GRAY, TextDecoration.BOLD),
+                List.of(Component.text("Unlock this slot from the Character Menu.", NamedTextColor.GRAY)),
+                swordItemType);
+            case EMPTY -> buildPlaceholder(Material.GRAY_STAINED_GLASS_PANE,
+                Component.text("Empty Ability Slot", NamedTextColor.GRAY),
+                List.of(Component.text("Equip an ability from the Character Menu.", NamedTextColor.GRAY)),
+                swordItemType);
+            case DEPLETED -> buildPlaceholder(Material.BLACK_STAINED_GLASS_PANE,
+                Component.text("Depleted", NamedTextColor.DARK_GRAY, TextDecoration.ITALIC),
+                List.of(Component.text("This ability has been used up.", NamedTextColor.DARK_GRAY)),
+                swordItemType);
+            case EQUIPPED -> // Equipped items are set via setEquipped(); this fallback should not normally be reached.
+                buildPlaceholder(Material.GRAY_STAINED_GLASS_PANE,
+                    Component.text("Empty Ability Slot", NamedTextColor.GRAY),
+                    List.of(Component.text("Equip an ability from the Character Menu.", NamedTextColor.GRAY)),
+                    swordItemType);
+        };
+    }
+
+    private static ItemStack buildPlaceholder(Material material, Component name,
+                                              List<Component> lore, SwordItemType swordItemType) {
+        ItemStack item = ItemStackBuilder.of(material)
+            .name(name)
+            .lore(lore)
+            .tagSwordItem(swordItemType)
+            .build();
+        KeyRegistry.setKeyField(item, KeyRegistry.ABILITY_SLOT_KEY, PersistentDataType.STRING, "PLACEHOLDER");
+        KeyRegistry.setKeyField(item, KeyRegistry.NON_MOVABLE_KEY, PersistentDataType.BOOLEAN, true);
+        return item;
+    }
+}

--- a/src/main/java/btm/sword/system/item/special/AbilitySlotItem.java
+++ b/src/main/java/btm/sword/system/item/special/AbilitySlotItem.java
@@ -1,6 +1,7 @@
 package btm.sword.system.item.special;
 
 import java.util.List;
+import java.util.Map;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -146,6 +147,14 @@ public class AbilitySlotItem extends SlotAnchoredItem {
                 player.getInventory().setItem(getTargetSlot(), null);
             }
             return;
+        }
+        // Preserve any non-ability item currently in the slot — move it elsewhere
+        ItemStack existing = player.getInventory().getItem(getTargetSlot());
+        if (existing != null && !existing.isEmpty()
+                && !KeyRegistry.hasKey(existing, KeyRegistry.ABILITY_SLOT_KEY)) {
+            Map<Integer, ItemStack> overflow = player.getInventory().addItem(existing);
+            overflow.values().forEach(leftover ->
+                player.getWorld().dropItemNaturally(player.getLocation(), leftover));
         }
         player.getInventory().setItem(getTargetSlot(), currentItem);
     }

--- a/src/main/java/btm/sword/system/item/special/AbilitySlotItem.java
+++ b/src/main/java/btm/sword/system/item/special/AbilitySlotItem.java
@@ -108,15 +108,24 @@ public class AbilitySlotItem extends SlotAnchoredItem {
     }
 
     /**
-     * Returns {@code true} if the target slot holds any valid ability-slot item
-     * (locked, empty, equipped, or depleted placeholder).
+     * Returns {@code true} if the slot is satisfied.
+     *
+     * <p>For {@link SlotState#LOCKED} and {@link SlotState#EMPTY}, the slot is satisfied as long
+     * as it does not contain a stale ability item (tagged with {@link KeyRegistry#ABILITY_SLOT_KEY}).
+     * If one is found, the slot is unsatisfied so {@link #restore(Player)} can clear it.
+     * For {@link SlotState#EQUIPPED} and {@link SlotState#DEPLETED}, the slot must contain an
+     * item tagged with {@link KeyRegistry#ABILITY_SLOT_KEY}.</p>
      *
      * @param player the player whose inventory to check
-     * @return {@code true} if the slot is occupied by an ability-slot item
+     * @return {@code true} if the slot is occupied correctly or does not need enforcement
      */
     @Override
     public boolean isSatisfied(Player player) {
         ItemStack slotItem = player.getInventory().getItem(getTargetSlot());
+        if (state == SlotState.LOCKED || state == SlotState.EMPTY) {
+            // Satisfied unless a stale ability item is still sitting here
+            return slotItem == null || !KeyRegistry.hasKey(slotItem, KeyRegistry.ABILITY_SLOT_KEY);
+        }
         if (slotItem == null || slotItem.isEmpty()) return false;
         return KeyRegistry.hasKey(slotItem, KeyRegistry.ABILITY_SLOT_KEY);
     }
@@ -124,10 +133,21 @@ public class AbilitySlotItem extends SlotAnchoredItem {
     /**
      * Places the current state's item into the target slot.
      *
+     * <p>For {@link SlotState#LOCKED} and {@link SlotState#EMPTY}, clears any stale ability item
+     * from the slot but otherwise leaves the hotbar slot free for the player.
+     * For {@link SlotState#EQUIPPED} and {@link SlotState#DEPLETED}, writes the current item.</p>
+     *
      * @param player the player whose inventory to restore the item into
      */
     @Override
     public void restore(Player player) {
+        if (state == SlotState.LOCKED || state == SlotState.EMPTY) {
+            ItemStack current = player.getInventory().getItem(getTargetSlot());
+            if (current != null && KeyRegistry.hasKey(current, KeyRegistry.ABILITY_SLOT_KEY)) {
+                player.getInventory().setItem(getTargetSlot(), null);
+            }
+            return;
+        }
         player.getInventory().setItem(getTargetSlot(), currentItem);
     }
 

--- a/src/main/java/btm/sword/system/item/special/AbilitySlotItem.java
+++ b/src/main/java/btm/sword/system/item/special/AbilitySlotItem.java
@@ -10,6 +10,7 @@ import org.bukkit.persistence.PersistentDataType;
 import btm.sword.system.item.ItemStackBuilder;
 import btm.sword.system.item.KeyRegistry;
 import btm.sword.system.item.SwordItemType;
+import lombok.Getter;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -47,6 +48,13 @@ public class AbilitySlotItem extends SlotAnchoredItem {
         DEPLETED
     }
 
+    /**
+     * -- GETTER --
+     *  Returns the current visual state of this slot.
+     *
+     * @return the current {@link SlotState}
+     */
+    @Getter
     private SlotState state;
     private final SwordItemType swordItemType;
 
@@ -68,15 +76,6 @@ public class AbilitySlotItem extends SlotAnchoredItem {
         this.swordItemType = swordItemType;
         this.state = initialState;
         this.currentItem = buildStateItem(initialState, swordItemType);
-    }
-
-    /**
-     * Returns the current visual state of this slot.
-     *
-     * @return the current {@link SlotState}
-     */
-    public SlotState getState() {
-        return state;
     }
 
     /**

--- a/src/main/java/btm/sword/system/item/special/AbilitySlotManager.java
+++ b/src/main/java/btm/sword/system/item/special/AbilitySlotManager.java
@@ -88,6 +88,7 @@ public class AbilitySlotManager {
      *
      * @param slotIndex 1 or 2
      */
+    @SuppressWarnings("deprecation") // updateInventory is deprecated but functionally necessary here
     public void refresh(int slotIndex) {
         SkillSlot skillSlot = toSkillSlot(slotIndex);
         // Reset slot state — new equip starts fresh
@@ -101,6 +102,9 @@ public class AbilitySlotManager {
             slot2.restore(owner.player());
         }
         syncEnabled();
+        // Force client sync — without this, equipping while the slot is selected
+        // or while a menu is open may not visually register until the next tick.
+        owner.player().updateInventory();
     }
 
     /**
@@ -187,6 +191,7 @@ public class AbilitySlotManager {
      *
      * @param slotIndex 1 or 2
      */
+    @SuppressWarnings("deprecation") // updateInventory is deprecated but functionally necessary here
     public void addUse(int slotIndex) {
         SkillSlot skillSlot = toSkillSlot(slotIndex);
         AbilitySkill ability = resolveAbility(skillSlot);
@@ -203,6 +208,27 @@ public class AbilitySlotManager {
         refreshSlot(slotItem, skillSlot, newUses, getRemainingDurability(slotIndex));
         slotItem.restore(owner.player());
         syncEnabled();
+        owner.player().updateInventory();
+    }
+
+    /**
+     * Looks up which active slot (if any) has the given ability equipped, then
+     * calls {@link #addUse(int)} to restore one stack use. No-ops if neither
+     * slot matches the ability ID.
+     *
+     * @param abilityIdStr the {@link SkillId#asString()} stamped on the projectile
+     */
+    public void refundByAbilityId(String abilityIdStr) {
+        PlayerSkillContainer container = owner.getCombatProfile().getPlayerSkillContainer();
+        SkillId eq1 = container.getEquipped(SkillSlot.ACTIVE_1);
+        if (eq1 != null && eq1.asString().equals(abilityIdStr)) {
+            addUse(SLOT_1);
+            return;
+        }
+        SkillId eq2 = container.getEquipped(SkillSlot.ACTIVE_2);
+        if (eq2 != null && eq2.asString().equals(abilityIdStr)) {
+            addUse(SLOT_2);
+        }
     }
 
     /**
@@ -286,6 +312,28 @@ public class AbilitySlotManager {
         if (heldSlot == SLOT_1 && slotEnabled[0]) return SwordItemType.ACTIVE_1;
         if (heldSlot == SLOT_2 && slotEnabled[1]) return SwordItemType.ACTIVE_2;
         return null;
+    }
+
+    /**
+     * Returns {@code true} if the given hotbar slot holds an ability item in either
+     * {@link AbilitySlotItem.SlotState#EQUIPPED} or {@link AbilitySlotItem.SlotState#DEPLETED} state.
+     *
+     * <p>Unlike {@link #getActiveTypeForHeldSlot(int)}, this includes depleted slots so that
+     * dash/grab/catch pickup interactions still work when the ability's uses are exhausted.</p>
+     *
+     * @param heldSlot the player's currently held hotbar slot index
+     * @return {@code true} if the slot is EQUIPPED or DEPLETED
+     */
+    public boolean isAbilityHeldSlot(int heldSlot) {
+        if (heldSlot == SLOT_1) {
+            AbilitySlotItem.SlotState s = slot1.getState();
+            return s == AbilitySlotItem.SlotState.EQUIPPED || s == AbilitySlotItem.SlotState.DEPLETED;
+        }
+        if (heldSlot == SLOT_2) {
+            AbilitySlotItem.SlotState s = slot2.getState();
+            return s == AbilitySlotItem.SlotState.EQUIPPED || s == AbilitySlotItem.SlotState.DEPLETED;
+        }
+        return false;
     }
 
     // ── Internal ─────────────────────────────────────────────────────────────

--- a/src/main/java/btm/sword/system/item/special/AbilitySlotManager.java
+++ b/src/main/java/btm/sword/system/item/special/AbilitySlotManager.java
@@ -1,0 +1,340 @@
+package btm.sword.system.item.special;
+
+import java.util.List;
+import java.util.Set;
+
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import btm.sword.system.action.skill.AbilityUseType;
+import btm.sword.system.action.skill.Skill;
+import btm.sword.system.action.skill.SkillId;
+import btm.sword.system.action.skill.SkillIds;
+import btm.sword.system.action.skill.SkillRegistry;
+import btm.sword.system.action.skill.container.PlayerSkillContainer;
+import btm.sword.system.action.skill.container.SkillSlot;
+import btm.sword.system.action.skill.type.AbilitySkill;
+import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.item.SwordItemType;
+
+/**
+ * Per-player manager that owns two {@link AbilitySlotItem}s for hotbar slots 1 and 2.
+ *
+ * <p>Responsibilities:
+ * <ul>
+ *   <li>{@link #initialize()} — reads equipped state from {@link PlayerSkillContainer}
+ *       and builds the correct items for each slot.</li>
+ *   <li>{@link #refresh(int)} — rebuilds a single slot (called after equip/unequip
+ *       from the CharacterMenu).</li>
+ *   <li>{@link #consumeUse(int)} — applies all active {@link AbilityUseType}s for the
+ *       equipped ability, potentially depleting the slot when any finite resource hits zero.</li>
+ *   <li>{@link #deplete(int)} — replaces the slot item with the DEPLETED placeholder.</li>
+ * </ul>
+ *
+ * <p>Resource tracking is non-exclusive: an ability may combine {@link AbilityUseType#STACK},
+ * {@link AbilityUseType#DURABILITY}, and {@link AbilityUseType#COOLDOWN} simultaneously.
+ * Each is tracked and applied independently; the slot depletes when <em>any</em> finite
+ * resource reaches zero.</p>
+ *
+ * <p>Both {@link AbilitySlotItem} instances should be added to the player's
+ * {@code managedItems} list for periodic upkeep.</p>
+ */
+public class AbilitySlotManager {
+
+    /** Hotbar slot index for ACTIVE_1. */
+    public static final int SLOT_1 = 1;
+
+    /** Hotbar slot index for ACTIVE_2. */
+    public static final int SLOT_2 = 2;
+
+    private final SwordPlayer owner;
+    private final AbilitySlotItem slot1;
+    private final AbilitySlotItem slot2;
+
+    /**
+     * Remaining stack-use count per slot. {@code -1} means not applicable (no STACK use type).
+     * Persisted across sessions via {@link btm.sword.system.playerdata.store.repository.AbilityStateRepository}.
+     */
+    private int remainingUses1 = -1;
+    private int remainingUses2 = -1;
+
+    /**
+     * Remaining durability per slot. {@code -1} means not applicable (no DURABILITY use type).
+     * Persisted across sessions via {@link btm.sword.system.playerdata.store.repository.AbilityStateRepository}.
+     */
+    private int remainingDurability1 = -1;
+    private int remainingDurability2 = -1;
+
+    /**
+     * Constructs the manager with default LOCKED placeholder items.
+     *
+     * @param owner the player who owns these ability slots
+     */
+    public AbilitySlotManager(SwordPlayer owner) {
+        this.owner = owner;
+        this.slot1 = new AbilitySlotItem(SLOT_1, SwordItemType.ACTIVE_1, AbilitySlotItem.SlotState.LOCKED);
+        this.slot2 = new AbilitySlotItem(SLOT_2, SwordItemType.ACTIVE_2, AbilitySlotItem.SlotState.LOCKED);
+    }
+
+    /**
+     * Reads the player's equipped skills and builds the correct items for both slots.
+     * Should be called after construction and after the player's combat profile is loaded.
+     */
+    public void initialize() {
+        refreshSlot(slot1, SkillSlot.ACTIVE_1, remainingUses1, remainingDurability1);
+        refreshSlot(slot2, SkillSlot.ACTIVE_2, remainingUses2, remainingDurability2);
+        restore(owner.player());
+    }
+
+    /**
+     * Rebuilds a single slot after equip/unequip. Resets both resource counters to max.
+     *
+     * @param slotIndex 1 or 2
+     */
+    public void refresh(int slotIndex) {
+        if (slotIndex == SLOT_1) {
+            remainingUses1 = -1;
+            remainingDurability1 = -1;
+            refreshSlot(slot1, SkillSlot.ACTIVE_1, -1, -1);
+            slot1.restore(owner.player());
+        } else {
+            remainingUses2 = -1;
+            remainingDurability2 = -1;
+            refreshSlot(slot2, SkillSlot.ACTIVE_2, -1, -1);
+            slot2.restore(owner.player());
+        }
+    }
+
+    /**
+     * Consumes one activation from the ability in the given slot.
+     * All active {@link AbilityUseType}s are applied independently:
+     * STACK decrements the use count, DURABILITY degrades the bar, COOLDOWN applies an
+     * item-cooldown overlay. The slot is depleted if any finite resource reaches zero.
+     *
+     * @param slotIndex 1 or 2
+     */
+    public void consumeUse(int slotIndex) {
+        AbilitySkill ability = resolveAbility(slotIndex == SLOT_1 ? SkillSlot.ACTIVE_1 : SkillSlot.ACTIVE_2);
+        if (ability == null) return;
+
+        Player player = owner.player();
+        int targetSlot = slotIndex;
+        ItemStack current = player.getInventory().getItem(targetSlot);
+        Set<AbilityUseType> types = ability.useTypes();
+
+        if (types.contains(AbilityUseType.STACK)) {
+            int remaining = getRemainingUses(slotIndex);
+            if (remaining > 0) {
+                remaining--;
+                setRemainingUses(slotIndex, remaining);
+                if (remaining <= 0) {
+                    deplete(slotIndex);
+                    return;
+                }
+                if (current != null) {
+                    current.setAmount(remaining);
+                }
+            }
+        }
+
+        if (types.contains(AbilityUseType.DURABILITY)) {
+            int remaining = getRemainingDurability(slotIndex);
+            if (remaining > 0) {
+                remaining--;
+                setRemainingDurability(slotIndex, remaining);
+                if (remaining <= 0) {
+                    deplete(slotIndex);
+                    return;
+                }
+                if (current != null) {
+                    updateDurabilityDisplay(current, remaining, ability.maxDurability());
+                }
+            }
+        }
+
+        if (types.contains(AbilityUseType.COOLDOWN) && ability.cooldownTicks() > 0 && current != null) {
+            int ticks = ability.cooldownTicks();
+            player.setCooldown(current.getType(), ticks);
+        }
+    }
+
+    /**
+     * Replaces the slot item with the DEPLETED placeholder.
+     *
+     * @param slotIndex 1 or 2
+     */
+    public void deplete(int slotIndex) {
+        AbilitySlotItem item = slotIndex == SLOT_1 ? slot1 : slot2;
+        item.setState(AbilitySlotItem.SlotState.DEPLETED);
+        setRemainingUses(slotIndex, 0);
+        setRemainingDurability(slotIndex, 0);
+        item.restore(owner.player());
+    }
+
+    /**
+     * Returns {@code true} if the given slot has an actual ability equipped (not locked/empty/depleted).
+     *
+     * @param slotIndex 1 or 2
+     * @return {@code true} if equipped with a usable ability
+     */
+    public boolean isEquipped(int slotIndex) {
+        AbilitySlotItem item = slotIndex == SLOT_1 ? slot1 : slot2;
+        return item.getState() == AbilitySlotItem.SlotState.EQUIPPED;
+    }
+
+    /**
+     * Returns the two {@link AbilitySlotItem}s for inclusion in the managed items list.
+     *
+     * @return unmodifiable list of the two slot items
+     */
+    public List<AbilitySlotItem> getSlotItems() {
+        return List.of(slot1, slot2);
+    }
+
+    /**
+     * Returns the remaining stack-use count for the given slot.
+     * Returns {@code -1} if STACK tracking is not active for the equipped ability.
+     *
+     * @param slotIndex 1 or 2
+     * @return remaining use count, or {@code -1}
+     */
+    public int getRemainingUses(int slotIndex) {
+        return slotIndex == SLOT_1 ? remainingUses1 : remainingUses2;
+    }
+
+    /**
+     * Sets the remaining stack-use count for the given slot. Used by persistence on load.
+     *
+     * @param slotIndex 1 or 2
+     * @param uses      remaining use count
+     */
+    public void setRemainingUses(int slotIndex, int uses) {
+        if (slotIndex == SLOT_1) {
+            remainingUses1 = uses;
+        } else {
+            remainingUses2 = uses;
+        }
+    }
+
+    /**
+     * Returns the remaining durability for the given slot.
+     * Returns {@code -1} if DURABILITY tracking is not active for the equipped ability.
+     *
+     * @param slotIndex 1 or 2
+     * @return remaining durability, or {@code -1}
+     */
+    public int getRemainingDurability(int slotIndex) {
+        return slotIndex == SLOT_1 ? remainingDurability1 : remainingDurability2;
+    }
+
+    /**
+     * Sets the remaining durability for the given slot. Used by persistence on load.
+     *
+     * @param slotIndex 1 or 2
+     * @param durability remaining durability
+     */
+    public void setRemainingDurability(int slotIndex, int durability) {
+        if (slotIndex == SLOT_1) {
+            remainingDurability1 = durability;
+        } else {
+            remainingDurability2 = durability;
+        }
+    }
+
+    /**
+     * Restores both slot items into the player's inventory.
+     *
+     * @param player the player whose inventory to populate
+     */
+    public void restore(Player player) {
+        slot1.restore(player);
+        slot2.restore(player);
+    }
+
+    // ── Internal ─────────────────────────────────────────────────────────────
+
+    private void refreshSlot(AbilitySlotItem slotItem, SkillSlot skillSlot,
+                              int persistedUses, int persistedDurability) {
+        PlayerSkillContainer container = owner.getCombatProfile().getPlayerSkillContainer();
+        SkillId equipped = container.getEquipped(skillSlot);
+
+        if (equipped == null || equipped.equals(SkillIds.LOCKED)) {
+            slotItem.setState(AbilitySlotItem.SlotState.LOCKED);
+            return;
+        }
+
+        if (equipped.equals(SkillIds.NONE)) {
+            slotItem.setState(AbilitySlotItem.SlotState.EMPTY);
+            return;
+        }
+
+        Skill skill = SkillRegistry.get(equipped);
+        if (!(skill instanceof AbilitySkill ability)) {
+            slotItem.setState(AbilitySlotItem.SlotState.EMPTY);
+            return;
+        }
+
+        Set<AbilityUseType> types = ability.useTypes();
+        int slotIndex = slotItem == slot1 ? SLOT_1 : SLOT_2;
+
+        // Resolve and store remaining uses
+        int uses = resolveUses(ability, persistedUses);
+        setRemainingUses(slotIndex, uses);
+
+        // Resolve and store remaining durability
+        int durability = resolveDurability(ability, persistedDurability);
+        setRemainingDurability(slotIndex, durability);
+
+        // Depleted if any finite resource is exhausted
+        if (types.contains(AbilityUseType.STACK) && uses == 0) {
+            slotItem.setState(AbilitySlotItem.SlotState.DEPLETED);
+            return;
+        }
+        if (types.contains(AbilityUseType.DURABILITY) && durability == 0) {
+            slotItem.setState(AbilitySlotItem.SlotState.DEPLETED);
+            return;
+        }
+
+        // Build the equipped world item, applying visual resource states
+        ItemStack worldItem = ability.buildWorldItem();
+        if (types.contains(AbilityUseType.STACK)) {
+            worldItem.setAmount(Math.max(1, uses));
+        }
+        if (types.contains(AbilityUseType.DURABILITY)) {
+            updateDurabilityDisplay(worldItem, durability, ability.maxDurability());
+        }
+
+        slotItem.setEquipped(worldItem);
+    }
+
+    private int resolveUses(AbilitySkill ability, int persisted) {
+        if (!ability.useTypes().contains(AbilityUseType.STACK)) return -1;
+        return persisted >= 0 ? persisted : ability.maxUses();
+    }
+
+    private int resolveDurability(AbilitySkill ability, int persisted) {
+        if (!ability.useTypes().contains(AbilityUseType.DURABILITY)) return -1;
+        return persisted >= 0 ? persisted : ability.maxDurability();
+    }
+
+    private AbilitySkill resolveAbility(SkillSlot skillSlot) {
+        PlayerSkillContainer container = owner.getCombatProfile().getPlayerSkillContainer();
+        SkillId equipped = container.getEquipped(skillSlot);
+        if (equipped == null || equipped.equals(SkillIds.LOCKED) || equipped.equals(SkillIds.NONE)) {
+            return null;
+        }
+        Skill skill = SkillRegistry.get(equipped);
+        return skill instanceof AbilitySkill ability ? ability : null;
+    }
+
+    private void updateDurabilityDisplay(ItemStack item, int remaining, int max) {
+        if (item.getItemMeta() instanceof org.bukkit.inventory.meta.Damageable damageable) {
+            int maxDurability = item.getType().getMaxDurability();
+            if (maxDurability > 0 && max > 0) {
+                int damage = (int) ((1.0 - (double) remaining / max) * maxDurability);
+                damageable.setDamage(Math.min(damage, maxDurability - 1));
+                item.setItemMeta(damageable);
+            }
+        }
+    }
+}

--- a/src/main/java/btm/sword/system/item/special/AbilitySlotManager.java
+++ b/src/main/java/btm/sword/system/item/special/AbilitySlotManager.java
@@ -181,6 +181,31 @@ public class AbilitySlotManager {
     }
 
     /**
+     * Adds one use back to the given slot (e.g. on projectile pickup).
+     * If the slot was depleted, transitions it back to EQUIPPED. No-ops if the slot has no
+     * {@link AbilityUseType#STACK} ability or is already at max uses.
+     *
+     * @param slotIndex 1 or 2
+     */
+    public void addUse(int slotIndex) {
+        SkillSlot skillSlot = toSkillSlot(slotIndex);
+        AbilitySkill ability = resolveAbility(skillSlot);
+        if (ability == null || !ability.useTypes().contains(AbilityUseType.STACK)) return;
+
+        int current = getRemainingUses(slotIndex);
+        int max = ability.maxUses();
+        if (current >= max) return;
+
+        int newUses = current < 0 ? 1 : Math.min(current + 1, max);
+        setRemainingUses(slotIndex, newUses);
+
+        AbilitySlotItem slotItem = slotIndex == SLOT_1 ? slot1 : slot2;
+        refreshSlot(slotItem, skillSlot, newUses, getRemainingDurability(slotIndex));
+        slotItem.restore(owner.player());
+        syncEnabled();
+    }
+
+    /**
      * Returns the two {@link AbilitySlotItem}s for inclusion in the managed items list.
      *
      * @return unmodifiable list of the two slot items

--- a/src/main/java/btm/sword/system/item/special/AbilitySlotManager.java
+++ b/src/main/java/btm/sword/system/item/special/AbilitySlotManager.java
@@ -13,6 +13,7 @@ import btm.sword.system.action.skill.SkillIds;
 import btm.sword.system.action.skill.SkillRegistry;
 import btm.sword.system.action.skill.container.PlayerSkillContainer;
 import btm.sword.system.action.skill.container.SkillSlot;
+import btm.sword.system.action.skill.container.SkillSlotState;
 import btm.sword.system.action.skill.type.AbilitySkill;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.item.SwordItemType;
@@ -52,20 +53,6 @@ public class AbilitySlotManager {
     private final AbilitySlotItem slot2;
 
     /**
-     * Remaining stack-use count per slot. {@code -1} means not applicable (no STACK use type).
-     * Persisted across sessions via {@link btm.sword.system.playerdata.store.repository.AbilityStateRepository}.
-     */
-    private int remainingUses1 = -1;
-    private int remainingUses2 = -1;
-
-    /**
-     * Remaining durability per slot. {@code -1} means not applicable (no DURABILITY use type).
-     * Persisted across sessions via {@link btm.sword.system.playerdata.store.repository.AbilityStateRepository}.
-     */
-    private int remainingDurability1 = -1;
-    private int remainingDurability2 = -1;
-
-    /**
      * Constructs the manager with default LOCKED placeholder items.
      *
      * @param owner the player who owns these ability slots
@@ -81,8 +68,11 @@ public class AbilitySlotManager {
      * Should be called after construction and after the player's combat profile is loaded.
      */
     public void initialize() {
-        refreshSlot(slot1, SkillSlot.ACTIVE_1, remainingUses1, remainingDurability1);
-        refreshSlot(slot2, SkillSlot.ACTIVE_2, remainingUses2, remainingDurability2);
+        PlayerSkillContainer container = owner.getCombatProfile().getPlayerSkillContainer();
+        SkillSlotState state1 = container.getSlotState(SkillSlot.ACTIVE_1);
+        SkillSlotState state2 = container.getSlotState(SkillSlot.ACTIVE_2);
+        refreshSlot(slot1, SkillSlot.ACTIVE_1, state1.remainingUses(), state1.remainingDurability());
+        refreshSlot(slot2, SkillSlot.ACTIVE_2, state2.remainingUses(), state2.remainingDurability());
         restore(owner.player());
     }
 
@@ -92,14 +82,14 @@ public class AbilitySlotManager {
      * @param slotIndex 1 or 2
      */
     public void refresh(int slotIndex) {
+        SkillSlot skillSlot = toSkillSlot(slotIndex);
+        // Reset slot state — new equip starts fresh
+        owner.getCombatProfile().getPlayerSkillContainer()
+            .setSlotState(skillSlot, SkillSlotState.EMPTY);
         if (slotIndex == SLOT_1) {
-            remainingUses1 = -1;
-            remainingDurability1 = -1;
             refreshSlot(slot1, SkillSlot.ACTIVE_1, -1, -1);
             slot1.restore(owner.player());
         } else {
-            remainingUses2 = -1;
-            remainingDurability2 = -1;
             refreshSlot(slot2, SkillSlot.ACTIVE_2, -1, -1);
             slot2.restore(owner.player());
         }
@@ -199,21 +189,21 @@ public class AbilitySlotManager {
      * @return remaining use count, or {@code -1}
      */
     public int getRemainingUses(int slotIndex) {
-        return slotIndex == SLOT_1 ? remainingUses1 : remainingUses2;
+        return owner.getCombatProfile().getPlayerSkillContainer()
+            .getSlotState(toSkillSlot(slotIndex)).remainingUses();
     }
 
     /**
-     * Sets the remaining stack-use count for the given slot. Used by persistence on load.
+     * Sets the remaining stack-use count for the given slot, preserving other state dimensions.
      *
      * @param slotIndex 1 or 2
      * @param uses      remaining use count
      */
     public void setRemainingUses(int slotIndex, int uses) {
-        if (slotIndex == SLOT_1) {
-            remainingUses1 = uses;
-        } else {
-            remainingUses2 = uses;
-        }
+        SkillSlot slot = toSkillSlot(slotIndex);
+        PlayerSkillContainer container = owner.getCombatProfile().getPlayerSkillContainer();
+        SkillSlotState current = container.getSlotState(slot);
+        container.setSlotState(slot, new SkillSlotState(uses, current.remainingDurability(), current.cooldownExpiresAt()));
     }
 
     /**
@@ -224,21 +214,21 @@ public class AbilitySlotManager {
      * @return remaining durability, or {@code -1}
      */
     public int getRemainingDurability(int slotIndex) {
-        return slotIndex == SLOT_1 ? remainingDurability1 : remainingDurability2;
+        return owner.getCombatProfile().getPlayerSkillContainer()
+            .getSlotState(toSkillSlot(slotIndex)).remainingDurability();
     }
 
     /**
-     * Sets the remaining durability for the given slot. Used by persistence on load.
+     * Sets the remaining durability for the given slot, preserving other state dimensions.
      *
      * @param slotIndex 1 or 2
      * @param durability remaining durability
      */
     public void setRemainingDurability(int slotIndex, int durability) {
-        if (slotIndex == SLOT_1) {
-            remainingDurability1 = durability;
-        } else {
-            remainingDurability2 = durability;
-        }
+        SkillSlot slot = toSkillSlot(slotIndex);
+        PlayerSkillContainer container = owner.getCombatProfile().getPlayerSkillContainer();
+        SkillSlotState current = container.getSlotState(slot);
+        container.setSlotState(slot, new SkillSlotState(current.remainingUses(), durability, current.cooldownExpiresAt()));
     }
 
     /**
@@ -252,6 +242,10 @@ public class AbilitySlotManager {
     }
 
     // ── Internal ─────────────────────────────────────────────────────────────
+
+    private SkillSlot toSkillSlot(int slotIndex) {
+        return slotIndex == SLOT_1 ? SkillSlot.ACTIVE_1 : SkillSlot.ACTIVE_2;
+    }
 
     private void refreshSlot(AbilitySlotItem slotItem, SkillSlot skillSlot,
                               int persistedUses, int persistedDurability) {

--- a/src/main/java/btm/sword/system/item/special/AbilitySlotManager.java
+++ b/src/main/java/btm/sword/system/item/special/AbilitySlotManager.java
@@ -53,6 +53,12 @@ public class AbilitySlotManager {
     private final AbilitySlotItem slot2;
 
     /**
+     * Whether each ability slot currently has an EQUIPPED (usable) ability.
+     * Index 0 = SLOT_1, index 1 = SLOT_2. Kept in sync after every state change.
+     */
+    private final boolean[] slotEnabled = {false, false};
+
+    /**
      * Constructs the manager with default LOCKED placeholder items.
      *
      * @param owner the player who owns these ability slots
@@ -73,6 +79,7 @@ public class AbilitySlotManager {
         SkillSlotState state2 = container.getSlotState(SkillSlot.ACTIVE_2);
         refreshSlot(slot1, SkillSlot.ACTIVE_1, state1.remainingUses(), state1.remainingDurability());
         refreshSlot(slot2, SkillSlot.ACTIVE_2, state2.remainingUses(), state2.remainingDurability());
+        syncEnabled();
         restore(owner.player());
     }
 
@@ -93,6 +100,7 @@ public class AbilitySlotManager {
             refreshSlot(slot2, SkillSlot.ACTIVE_2, -1, -1);
             slot2.restore(owner.player());
         }
+        syncEnabled();
     }
 
     /**
@@ -108,8 +116,7 @@ public class AbilitySlotManager {
         if (ability == null) return;
 
         Player player = owner.player();
-        int targetSlot = slotIndex;
-        ItemStack current = player.getInventory().getItem(targetSlot);
+        ItemStack current = player.getInventory().getItem(slotIndex);
         Set<AbilityUseType> types = ability.useTypes();
 
         if (types.contains(AbilityUseType.STACK)) {
@@ -159,6 +166,7 @@ public class AbilitySlotManager {
         setRemainingUses(slotIndex, 0);
         setRemainingDurability(slotIndex, 0);
         item.restore(owner.player());
+        syncEnabled();
     }
 
     /**
@@ -241,7 +249,27 @@ public class AbilitySlotManager {
         slot2.restore(player);
     }
 
+    /**
+     * Returns the {@link SwordItemType} for the ability at the given hotbar slot index,
+     * or {@code null} if that slot does not have an active (equipped) ability.
+     * Used by {@code handleAbilityInput} as a reliable alternative to PDC tag lookups.
+     *
+     * @param heldSlot the player's currently held hotbar slot index
+     * @return {@link SwordItemType#ACTIVE_1}, {@link SwordItemType#ACTIVE_2}, or {@code null}
+     */
+    public SwordItemType getActiveTypeForHeldSlot(int heldSlot) {
+        if (heldSlot == SLOT_1 && slotEnabled[0]) return SwordItemType.ACTIVE_1;
+        if (heldSlot == SLOT_2 && slotEnabled[1]) return SwordItemType.ACTIVE_2;
+        return null;
+    }
+
     // ── Internal ─────────────────────────────────────────────────────────────
+
+    /** Syncs {@link #slotEnabled} from the current {@link AbilitySlotItem} states. */
+    private void syncEnabled() {
+        slotEnabled[0] = slot1.getState() == AbilitySlotItem.SlotState.EQUIPPED;
+        slotEnabled[1] = slot2.getState() == AbilitySlotItem.SlotState.EQUIPPED;
+    }
 
     private SkillSlot toSkillSlot(int slotIndex) {
         return slotIndex == SLOT_1 ? SkillSlot.ACTIVE_1 : SkillSlot.ACTIVE_2;

--- a/src/main/java/btm/sword/system/playerdata/store/SqlitePlayerDataStore.java
+++ b/src/main/java/btm/sword/system/playerdata/store/SqlitePlayerDataStore.java
@@ -12,6 +12,8 @@ import java.util.UUID;
 import java.util.logging.Logger;
 
 import btm.sword.system.action.skill.container.PlayerSkillContainer;
+import btm.sword.system.action.skill.container.SkillSlot;
+import btm.sword.system.action.skill.container.SkillSlotState;
 import btm.sword.system.entity.aspect.AspectType;
 import btm.sword.system.entity.aspect.value.AspectValue;
 import btm.sword.system.entity.base.CombatProfile;
@@ -20,6 +22,7 @@ import btm.sword.system.playerdata.PlayerStorage;
 import btm.sword.system.playerdata.store.repository.AspectRepository;
 import btm.sword.system.playerdata.store.repository.ProfileRepository;
 import btm.sword.system.playerdata.store.repository.SkillRepository;
+import btm.sword.system.playerdata.store.repository.SkillStateRepository;
 import btm.sword.system.playerdata.store.repository.StorageRepository;
 
 /**
@@ -34,7 +37,7 @@ import btm.sword.system.playerdata.store.repository.StorageRepository;
  */
 public class SqlitePlayerDataStore implements PlayerDataStore {
 
-    private static final int CURRENT_SCHEMA_VERSION = 1;
+    private static final int CURRENT_SCHEMA_VERSION = 2;
 
     private final File dbFile;
     private final Logger logger;
@@ -43,6 +46,7 @@ public class SqlitePlayerDataStore implements PlayerDataStore {
     private ProfileRepository profileRepo;
     private AspectRepository aspectRepo;
     private SkillRepository skillRepo;
+    private SkillStateRepository skillStateRepo;
     private StorageRepository storageRepo;
 
     /**
@@ -74,11 +78,13 @@ public class SqlitePlayerDataStore implements PlayerDataStore {
         profileRepo = new ProfileRepository(conn);
         aspectRepo = new AspectRepository(conn);
         skillRepo = new SkillRepository(conn);
+        skillStateRepo = new SkillStateRepository(conn);
         storageRepo = new StorageRepository(conn);
 
         profileRepo.createTable();
         aspectRepo.createTable();
         skillRepo.createTable();
+        skillStateRepo.createTable();
         storageRepo.createTable();
         createSchemaVersionTable();
 
@@ -108,6 +114,9 @@ public class SqlitePlayerDataStore implements PlayerDataStore {
             } else {
                 skillContainer = new PlayerSkillContainer(skillData.available(), skillData.equipped());
             }
+            // available map now carries SkillAvailability states — constructor above handles it
+            Map<SkillSlot, SkillSlotState> slotStates = skillStateRepo.load(uuid);
+            slotStates.forEach(skillContainer::setSlotState);
             combatProfile.setPlayerSkillContainer(skillContainer);
 
             return new PlayerData(uuid, profile.firstLogin(), profile.joinSequenceCompleted(),
@@ -129,7 +138,8 @@ public class SqlitePlayerDataStore implements PlayerDataStore {
                     data.getDateOfFirstLogin().getTime(), profile.getMaxAirDodges());
                 aspectRepo.save(uuid, profile.getStats());
                 PlayerSkillContainer skills = profile.getPlayerSkillContainer();
-                skillRepo.save(uuid, skills.equippedView(), skills.allAvailableSkillIds());
+                skillRepo.save(uuid, skills.equippedView(), skills.allDiscoveredSkillAvailabilities());
+                skillStateRepo.save(uuid, skills.allSlotStates());
                 storageRepo.save(uuid, data.getPlayerStorage());
                 conn.commit();
             } catch (SQLException e) {
@@ -196,6 +206,10 @@ public class SqlitePlayerDataStore implements PlayerDataStore {
         if (version < CURRENT_SCHEMA_VERSION) {
             logger.info("[PlayerData] Schema at v" + version + ", migrating to v" + CURRENT_SCHEMA_VERSION);
             // V0 → V1: initial schema (tables already created above — nothing more to migrate)
+            if (version < 2) {
+                // V1 → V2: add availability column to player_available_skills
+                skillRepo.migrateV1ToV2();
+            }
             setSchemaVersion(CURRENT_SCHEMA_VERSION);
             logger.info("[PlayerData] Schema migration complete.");
         }

--- a/src/main/java/btm/sword/system/playerdata/store/repository/AbilityHistoryRepository.java
+++ b/src/main/java/btm/sword/system/playerdata/store/repository/AbilityHistoryRepository.java
@@ -1,0 +1,122 @@
+package btm.sword.system.playerdata.store.repository;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import btm.sword.system.action.skill.SkillId;
+import btm.sword.system.action.skill.history.AbilityHistoryAction;
+import btm.sword.system.action.skill.history.AbilityHistoryEntry;
+import btm.sword.system.action.skill.history.PlayerAbilityHistory;
+
+/**
+ * Handles reads and writes for the {@code player_ability_history} table.
+ *
+ * <p>Each row represents one {@link AbilityHistoryEntry}: the player UUID, the ability id,
+ * the display name at time of event, the action (USED / SURRENDERED), and the timestamp.
+ * Rows are append-only — existing entries are never updated or deleted.
+ */
+public class AbilityHistoryRepository {
+
+    private final Connection conn;
+
+    /** @param conn the shared JDBC connection */
+    public AbilityHistoryRepository(Connection conn) {
+        this.conn = conn;
+    }
+
+    /**
+     * Creates the history table if it does not already exist.
+     *
+     * @throws SQLException on any DB error
+     */
+    public void createTable() throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "CREATE TABLE IF NOT EXISTS player_ability_history ("
+                + "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                + "uuid TEXT NOT NULL,"
+                + "skill_id TEXT NOT NULL,"
+                + "display_name TEXT NOT NULL,"
+                + "action TEXT NOT NULL,"
+                + "timestamp INTEGER NOT NULL)")) {
+            stmt.execute();
+        }
+    }
+
+    /**
+     * Loads all history entries for the given player, oldest-first.
+     *
+     * @param uuid the player's unique ID
+     * @return their full ability history
+     * @throws SQLException on any DB error
+     */
+    public PlayerAbilityHistory load(UUID uuid) throws SQLException {
+        List<AbilityHistoryEntry> entries = new ArrayList<>();
+
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "SELECT skill_id, display_name, action, timestamp"
+                + " FROM player_ability_history WHERE uuid = ? ORDER BY timestamp ASC")) {
+            stmt.setString(1, uuid.toString());
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    try {
+                        SkillId id = SkillId.parse(rs.getString("skill_id"));
+                        String name = rs.getString("display_name");
+                        AbilityHistoryAction action = AbilityHistoryAction.valueOf(rs.getString("action"));
+                        long ts = rs.getLong("timestamp");
+                        entries.add(new AbilityHistoryEntry(id, name, action, ts));
+                    } catch (IllegalArgumentException e) {
+                        // Removed skill or malformed action — skip row
+                    }
+                }
+            }
+        }
+
+        return new PlayerAbilityHistory(entries);
+    }
+
+    /**
+     * Appends any entries in {@code history} that are not yet in the database for this player.
+     * Uses the entry count currently stored to determine the offset — new entries added
+     * during this session are inserted; previously persisted rows are untouched.
+     *
+     * @param uuid    the player's unique ID
+     * @param history the full in-memory history to persist
+     * @throws SQLException on any DB error
+     */
+    public void save(UUID uuid, PlayerAbilityHistory history) throws SQLException {
+        List<AbilityHistoryEntry> all = history.entries();
+        if (all.isEmpty()) return;
+
+        // Count how many rows we already have for this player so we only insert new ones.
+        int stored = 0;
+        try (PreparedStatement count = conn.prepareStatement(
+                "SELECT COUNT(*) FROM player_ability_history WHERE uuid = ?")) {
+            count.setString(1, uuid.toString());
+            try (ResultSet rs = count.executeQuery()) {
+                if (rs.next()) stored = rs.getInt(1);
+            }
+        }
+
+        List<AbilityHistoryEntry> newEntries = all.subList(stored, all.size());
+        if (newEntries.isEmpty()) return;
+
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "INSERT INTO player_ability_history (uuid, skill_id, display_name, action, timestamp)"
+                + " VALUES (?, ?, ?, ?, ?)")) {
+            for (AbilityHistoryEntry entry : newEntries) {
+                stmt.setString(1, uuid.toString());
+                stmt.setString(2, entry.id().asString());
+                stmt.setString(3, entry.displayName());
+                stmt.setString(4, entry.action().name());
+                stmt.setLong(5, entry.timestamp());
+                stmt.addBatch();
+            }
+            stmt.executeBatch();
+        }
+    }
+}

--- a/src/main/java/btm/sword/system/playerdata/store/repository/AbilityStateRepository.java
+++ b/src/main/java/btm/sword/system/playerdata/store/repository/AbilityStateRepository.java
@@ -1,0 +1,131 @@
+package btm.sword.system.playerdata.store.repository;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.UUID;
+
+import btm.sword.system.action.skill.container.SkillSlot;
+
+/**
+ * Handles reads and writes for the {@code player_ability_state} table.
+ *
+ * <p>Each row stores the remaining resource counts for a single ability slot (e.g.
+ * {@link SkillSlot#ACTIVE_1} or {@link SkillSlot#ACTIVE_2}). Both
+ * {@link btm.sword.system.action.skill.AbilityUseType#STACK} and
+ * {@link btm.sword.system.action.skill.AbilityUseType#DURABILITY} are persisted
+ * independently per slot. {@code -1} in either column indicates that tracking type is
+ * not active for the current ability in that slot.
+ * {@link btm.sword.system.action.skill.AbilityUseType#COOLDOWN} is never persisted
+ * (cooldowns reset across sessions).</p>
+ */
+public class AbilityStateRepository {
+
+    /**
+     * Persisted resource state for a single ability slot.
+     *
+     * @param remainingUses       remaining stack-use count, or {@code -1} if not tracked
+     * @param remainingDurability remaining durability, or {@code -1} if not tracked
+     */
+    public record SlotState(int remainingUses, int remainingDurability) {}
+
+    private final Connection conn;
+
+    /** @param conn the shared JDBC connection */
+    public AbilityStateRepository(Connection conn) {
+        this.conn = conn;
+    }
+
+    /**
+     * Creates the ability state table if it does not already exist.
+     *
+     * @throws SQLException on any DB error
+     */
+    public void createTable() throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "CREATE TABLE IF NOT EXISTS player_ability_state ("
+                + "uuid TEXT NOT NULL,"
+                + "slot TEXT NOT NULL,"
+                + "remaining_uses INTEGER NOT NULL DEFAULT -1,"
+                + "remaining_durability INTEGER NOT NULL DEFAULT -1,"
+                + "PRIMARY KEY (uuid, slot))")) {
+            stmt.execute();
+        }
+    }
+
+    /**
+     * Loads the resource state for all active ability slots for the given player.
+     *
+     * @param uuid the player's unique ID
+     * @return a map of slot to {@link SlotState} (only contains entries for slots with persisted data)
+     * @throws SQLException on any DB error
+     */
+    public Map<SkillSlot, SlotState> load(UUID uuid) throws SQLException {
+        EnumMap<SkillSlot, SlotState> result = new EnumMap<>(SkillSlot.class);
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "SELECT slot, remaining_uses, remaining_durability"
+                + " FROM player_ability_state WHERE uuid = ?")) {
+            stmt.setString(1, uuid.toString());
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    try {
+                        SkillSlot slot = SkillSlot.valueOf(rs.getString("slot"));
+                        int uses = rs.getInt("remaining_uses");
+                        int durability = rs.getInt("remaining_durability");
+                        result.put(slot, new SlotState(uses, durability));
+                    } catch (IllegalArgumentException e) {
+                        // Unknown slot name — skip
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Persists the resource state for a single ability slot using {@code INSERT OR REPLACE}.
+     *
+     * @param uuid               the player's unique ID
+     * @param slot               the ability slot
+     * @param remainingUses      remaining stack-use count, or {@code -1} if not tracked
+     * @param remainingDurability remaining durability, or {@code -1} if not tracked
+     * @throws SQLException on any DB error
+     */
+    public void save(UUID uuid, SkillSlot slot, int remainingUses, int remainingDurability) throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "INSERT OR REPLACE INTO player_ability_state (uuid, slot, remaining_uses, remaining_durability)"
+                + " VALUES (?, ?, ?, ?)")) {
+            stmt.setString(1, uuid.toString());
+            stmt.setString(2, slot.name());
+            stmt.setInt(3, remainingUses);
+            stmt.setInt(4, remainingDurability);
+            stmt.execute();
+        }
+    }
+
+    /**
+     * Persists resource state for multiple slots in a batch.
+     *
+     * @param uuid      the player's unique ID
+     * @param slotStates map of slot to {@link SlotState}
+     * @throws SQLException on any DB error
+     */
+    public void saveAll(UUID uuid, Map<SkillSlot, SlotState> slotStates) throws SQLException {
+        if (slotStates.isEmpty()) return;
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "INSERT OR REPLACE INTO player_ability_state (uuid, slot, remaining_uses, remaining_durability)"
+                + " VALUES (?, ?, ?, ?)")) {
+            for (Map.Entry<SkillSlot, SlotState> entry : slotStates.entrySet()) {
+                stmt.setString(1, uuid.toString());
+                stmt.setString(2, entry.getKey().name());
+                stmt.setInt(3, entry.getValue().remainingUses());
+                stmt.setInt(4, entry.getValue().remainingDurability());
+                stmt.addBatch();
+            }
+            stmt.executeBatch();
+        }
+    }
+}

--- a/src/main/java/btm/sword/system/playerdata/store/repository/SkillRepository.java
+++ b/src/main/java/btm/sword/system/playerdata/store/repository/SkillRepository.java
@@ -4,15 +4,15 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.EnumMap;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
 import btm.sword.system.action.skill.Skill;
 import btm.sword.system.action.skill.SkillId;
 import btm.sword.system.action.skill.SkillRegistry;
+import btm.sword.system.action.skill.container.SkillAvailability;
 import btm.sword.system.action.skill.container.SkillSlot;
 
 /**
@@ -45,9 +45,24 @@ public class SkillRepository {
              PreparedStatement s2 = conn.prepareStatement(
                 "CREATE TABLE IF NOT EXISTS player_available_skills ("
                 + "uuid TEXT NOT NULL, skill_id TEXT NOT NULL,"
+                + " availability TEXT NOT NULL DEFAULT 'AVAILABLE',"
                 + " PRIMARY KEY (uuid, skill_id))")) {
             s1.execute();
             s2.execute();
+        }
+    }
+
+    /**
+     * Migrates the {@code player_available_skills} table from schema v1 (no availability column)
+     * to v2 by adding the column with a default of {@code AVAILABLE} for all existing rows.
+     *
+     * @throws SQLException on any DB error
+     */
+    public void migrateV1ToV2() throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "ALTER TABLE player_available_skills ADD COLUMN"
+                + " availability TEXT NOT NULL DEFAULT 'AVAILABLE'")) {
+            stmt.execute();
         }
     }
 
@@ -60,7 +75,7 @@ public class SkillRepository {
      */
     public SkillData load(UUID uuid) throws SQLException {
         EnumMap<SkillSlot, SkillId> equipped = new EnumMap<>(SkillSlot.class);
-        List<SkillId> available = new ArrayList<>();
+        Map<SkillId, SkillAvailability> available = new HashMap<>();
 
         try (PreparedStatement stmt = conn.prepareStatement(
                 "SELECT slot, skill_id FROM player_skill_slots WHERE uuid = ?")) {
@@ -79,14 +94,16 @@ public class SkillRepository {
         }
 
         try (PreparedStatement stmt = conn.prepareStatement(
-                "SELECT skill_id FROM player_available_skills WHERE uuid = ?")) {
+                "SELECT skill_id, availability FROM player_available_skills WHERE uuid = ?")) {
             stmt.setString(1, uuid.toString());
             try (ResultSet rs = stmt.executeQuery()) {
                 while (rs.next()) {
                     try {
-                        available.add(SkillId.parse(rs.getString("skill_id")));
+                        SkillId id = SkillId.parse(rs.getString("skill_id"));
+                        SkillAvailability avail = SkillAvailability.valueOf(rs.getString("availability"));
+                        available.put(id, avail);
                     } catch (IllegalArgumentException e) {
-                        // Invalid id — skip
+                        // Invalid id or unknown availability value — skip
                     }
                 }
             }
@@ -104,7 +121,7 @@ public class SkillRepository {
      * @param available the current available (unlocked) skill list
      * @throws SQLException on any DB error
      */
-    public void save(UUID uuid, Map<SkillSlot, SkillId> equipped, List<SkillId> available)
+    public void save(UUID uuid, Map<SkillSlot, SkillId> equipped, Map<SkillId, SkillAvailability> available)
             throws SQLException {
         try (PreparedStatement del1 = conn.prepareStatement(
                 "DELETE FROM player_skill_slots WHERE uuid = ?");
@@ -131,12 +148,13 @@ public class SkillRepository {
 
         if (!available.isEmpty()) {
             try (PreparedStatement stmt = conn.prepareStatement(
-                    "INSERT INTO player_available_skills (uuid, skill_id) VALUES (?, ?)")) {
-                for (SkillId id : available) {
-                    Skill skill = SkillRegistry.get(id);
+                    "INSERT INTO player_available_skills (uuid, skill_id, availability) VALUES (?, ?, ?)")) {
+                for (Map.Entry<SkillId, SkillAvailability> entry : available.entrySet()) {
+                    Skill skill = SkillRegistry.get(entry.getKey());
                     if (skill == null) continue; // skill was removed from game — don't persist
                     stmt.setString(1, uuid.toString());
-                    stmt.setString(2, id.asString());
+                    stmt.setString(2, entry.getKey().asString());
+                    stmt.setString(3, entry.getValue().name());
                     stmt.addBatch();
                 }
                 stmt.executeBatch();
@@ -147,8 +165,8 @@ public class SkillRepository {
     /**
      * Raw skill data loaded from the database.
      *
-     * @param available the list of all unlocked skill IDs
+     * @param available a map of all discovered skill IDs to their availability state
      * @param equipped  the map of equipped skill slots to their assigned skill
      */
-    public record SkillData(List<SkillId> available, EnumMap<SkillSlot, SkillId> equipped) {}
+    public record SkillData(Map<SkillId, SkillAvailability> available, EnumMap<SkillSlot, SkillId> equipped) {}
 }

--- a/src/main/java/btm/sword/system/playerdata/store/repository/SkillStateRepository.java
+++ b/src/main/java/btm/sword/system/playerdata/store/repository/SkillStateRepository.java
@@ -1,0 +1,109 @@
+package btm.sword.system.playerdata.store.repository;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.UUID;
+
+import btm.sword.system.action.skill.container.SkillSlot;
+import btm.sword.system.action.skill.container.SkillSlotState;
+
+/**
+ * Handles reads and writes for the {@code player_skill_slot_state} table.
+ * <p>
+ * Each row tracks the persisted resource state for one ability slot:
+ * remaining uses, remaining durability, and cooldown expiry timestamp (epoch-millis).
+ * This lets cooldowns survive log-off/log-in cycles so players cannot reset
+ * long-duration abilities by disconnecting.
+ * </p>
+ */
+public class SkillStateRepository {
+
+    private final Connection conn;
+
+    /** @param conn the shared JDBC connection */
+    public SkillStateRepository(Connection conn) {
+        this.conn = conn;
+    }
+
+    /**
+     * Creates the slot-state table if it does not already exist.
+     *
+     * @throws SQLException on any DB error
+     */
+    public void createTable() throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "CREATE TABLE IF NOT EXISTS player_skill_slot_state ("
+                + "uuid TEXT NOT NULL, slot TEXT NOT NULL,"
+                + " remaining_uses INTEGER NOT NULL DEFAULT -1,"
+                + " remaining_durability INTEGER NOT NULL DEFAULT -1,"
+                + " cooldown_expires_at INTEGER NOT NULL DEFAULT 0,"
+                + " PRIMARY KEY (uuid, slot))")) {
+            stmt.execute();
+        }
+    }
+
+    /**
+     * Loads all persisted slot states for the given player.
+     *
+     * @param uuid the player's unique ID
+     * @return map of skill slot to its state; missing slots default to {@link SkillSlotState#EMPTY}
+     * @throws SQLException on any DB error
+     */
+    public Map<SkillSlot, SkillSlotState> load(UUID uuid) throws SQLException {
+        Map<SkillSlot, SkillSlotState> result = new EnumMap<>(SkillSlot.class);
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "SELECT slot, remaining_uses, remaining_durability, cooldown_expires_at"
+                + " FROM player_skill_slot_state WHERE uuid = ?")) {
+            stmt.setString(1, uuid.toString());
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    try {
+                        SkillSlot slot = SkillSlot.valueOf(rs.getString("slot"));
+                        int uses = rs.getInt("remaining_uses");
+                        int durability = rs.getInt("remaining_durability");
+                        long cooldown = rs.getLong("cooldown_expires_at");
+                        result.put(slot, new SkillSlotState(uses, durability, cooldown));
+                    } catch (IllegalArgumentException e) {
+                        // Unknown or removed slot — skip
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Replaces all slot-state data for the given player.
+     *
+     * @param uuid   the player's unique ID
+     * @param states the current slot states to persist
+     * @throws SQLException on any DB error
+     */
+    public void save(UUID uuid, Map<SkillSlot, SkillSlotState> states) throws SQLException {
+        try (PreparedStatement del = conn.prepareStatement(
+                "DELETE FROM player_skill_slot_state WHERE uuid = ?")) {
+            del.setString(1, uuid.toString());
+            del.execute();
+        }
+        if (states.isEmpty()) return;
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "INSERT INTO player_skill_slot_state"
+                + " (uuid, slot, remaining_uses, remaining_durability, cooldown_expires_at)"
+                + " VALUES (?, ?, ?, ?, ?)")) {
+            for (Map.Entry<SkillSlot, SkillSlotState> entry : states.entrySet()) {
+                SkillSlotState state = entry.getValue();
+                stmt.setString(1, uuid.toString());
+                stmt.setString(2, entry.getKey().name());
+                stmt.setInt(3, state.remainingUses());
+                stmt.setInt(4, state.remainingDurability());
+                stmt.setLong(5, state.cooldownExpiresAt());
+                stmt.addBatch();
+            }
+            stmt.executeBatch();
+        }
+    }
+}

--- a/src/main/java/btm/sword/utility/math/VectorUtil.java
+++ b/src/main/java/btm/sword/utility/math/VectorUtil.java
@@ -73,6 +73,11 @@ public class VectorUtil {
         return new Basis(right, up, dir);
     }
 
+    public static boolean isBroken(Vector v) {
+        return Double.isNaN(v.getX()) || Double.isNaN(v.getY()) || Double.isNaN(v.getZ())
+            || Double.isInfinite(v.getX()) || Double.isInfinite(v.getY()) || Double.isInfinite(v.getZ());
+    }
+
     /**
      * Rotates an existing basis around its local axes.
      * <p>


### PR DESCRIPTION
## Summary
- Ability projectile pickup (dash/grab/catch) now refunds a use instead of giving the raw visual item; works when holding an equipped **or depleted** ability slot
- Fixed input tree lock-out: `handleAbilityInput` only consumes LEFT, preventing the tree from advancing past root when the player is on cooldown
- Added `ChargeableAbility` abstract class, `ChargeSession`, and `ChargeAction` — chargeable abilities hook into RIGHT (charge start) and RIGHT_HOLD (release) through the input tree
- `IceSpellAbility`: BLUE_ICE block that scales 0.25→3.0 over 3s with Y-axis rotation and sine-wave bob; releaseable at 0.5 scale; thrown via `throwDirect` at current charge scale
- Non-ability items in an equipped slot are relocated gracefully on equip; `updateInventory()` added after refund to force client sync

## Test plan
- [ ] Equip IceSpellAbility to ACTIVE_1, hold RIGHT → ice block spawns and grows with bob/rotation; release after threshold → projectile fires
- [ ] Release before 0.5 scale → charge cancels silently
- [ ] Equip KnifeThrow, throw all uses → slot depletes; throw knife → grab it back → use refunded, slot becomes EQUIPPED again
- [ ] With depleted ability slot held, dash toward a thrown knife → pickup triggers refund
- [ ] Left-click while on ability cooldown → input consumed (no normal attack), next left-click works once cooldown clears
- [ ] Equip ability to a non-empty slot → existing item moves to inventory rather than being deleted