### PR TITLE
[Docs] Extend Javadoc coverage (warnings ~890 → 100)

### DIFF
--- a/src/main/java/btm/sword/Sword.java
+++ b/src/main/java/btm/sword/Sword.java
@@ -39,6 +39,15 @@ import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
 import lombok.Getter;
 import xyz.xenondevs.invui.InvUI;
 
+/**
+ * Root plugin class for <b>Sword: Combat Evolved</b>.
+ * <p>
+ * Bootstraps all subsystems in {@link #onEnable()} (config, entity arbiter, listeners,
+ * commands, player-data, inventory menus, display rigs, join sequencing) and tears them
+ * down cleanly in {@link #onDisable()}. Exposes a static {@link #getInstance()} accessor
+ * and a thin {@link #print(String)} logging helper used throughout the codebase.
+ * </p>
+ */
 public final class Sword extends JavaPlugin {
     @Getter
     private static Sword instance;

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -53,6 +53,8 @@ public class Config {
      *   <li><b>loader</b> - Custom loader for type-specific YAML parsing</li>
      * </ul>
      * </p>
+     *
+     * @param <T> the Java type of the configuration value
      */
     public static final class ConfigEntry<T> {
         public final String path;
@@ -70,6 +72,15 @@ public class Config {
             T load(ConfigurationSection section, String path, T defaultValue);
         }
 
+        /**
+         * Constructs a {@code ConfigEntry} and immediately self-registers it in {@link Config#ENTRIES}.
+         *
+         * @param path         YAML key (dot-separated, e.g. {@code "debug.skip_data_load"})
+         * @param defaultValue value used when the key is absent from config.yaml
+         * @param type         boxed type of the value
+         * @param assign       consumer that writes the loaded value into the owning static field
+         * @param loader       reads the raw value from a {@link ConfigurationSection}
+         */
         public ConfigEntry(String path, T defaultValue, Class<T> type, Consumer<T> assign, Loader<T> loader) {
             this.path = path;
             this.defaultValue = defaultValue;
@@ -276,21 +287,27 @@ public class Config {
      */
     public static class Direction {
         private static final Vector UP = new Vector(0, 1, 0);
+        /** @return a fresh clone of the world-up unit vector {@code (0, 1, 0)}. */
         public static Vector UP() { return UP.clone(); }
 
         private static final Vector DOWN = new Vector(0, -1, 0);
+        /** @return a fresh clone of the world-down unit vector {@code (0, -1, 0)}. */
         public static Vector DOWN() { return DOWN.clone(); }
 
         private static final Vector NORTH = new Vector(0, 0, -1);
+        /** @return a fresh clone of the north unit vector {@code (0, 0, -1)}. */
         public static Vector NORTH() { return NORTH.clone(); }
 
         private static final Vector SOUTH = new Vector(0, 0, 1);
+        /** @return a fresh clone of the south unit vector {@code (0, 0, 1)}. */
         public static Vector SOUTH() { return SOUTH.clone(); }
 
         private static final Vector OUT_UP = new Vector(0, 1, 1);
+        /** @return a fresh clone of the out-and-up diagonal vector {@code (0, 1, 1)}. */
         public static Vector OUT_UP() { return OUT_UP.clone(); }
 
         private static final Vector OUT_DOWN = new Vector(0, -1, 1);
+        /** @return a fresh clone of the out-and-down diagonal vector {@code (0, -1, 1)}. */
         public static Vector OUT_DOWN() { return OUT_DOWN.clone(); }
     }
     //endregion
@@ -298,6 +315,11 @@ public class Config {
     // ==============================================================================
     //region COLOR
     // ==============================================================================
+    /**
+     * All configurable Adventure {@link net.kyori.adventure.text.format.TextColor} and Bukkit
+     * {@link org.bukkit.Color} values used for UI text, particle effects, and glow tints.
+     * Hot-reloaded via {@code /sword reload}.
+     */
     public static class SwordColor {
         public static TextColor TEXT_RESOURCE_COLOR = TextColor.color(222, 222, 222);
         static { register(
@@ -1691,6 +1713,12 @@ public class Config {
     // ==============================================================================
     //region AUDIO - Sound effects and audio feedback
     // ==============================================================================
+    /**
+     * All configurable audio properties: global enable toggle, per-event sound keys,
+     * volumes, and pitches. Values map to {@link btm.sword.utility.sound.SwordSoundType} entries
+     * and are used by {@link btm.sword.utility.sound.SoundWrapper} and
+     * {@link btm.sword.utility.Prefab.Sounds}.
+     */
     public static class Audio {
         // Sounds configuration
         public static boolean SOUNDS_ENABLED = true;
@@ -2870,6 +2898,11 @@ public class Config {
     // ==============================================================================
     //region GRAB
     // ==============================================================================
+    /**
+     * All configurable parameters for the grab action: durations, range, hold physics,
+     * pull speed, and aspect-scaling factors. Used by
+     * {@link btm.sword.system.action.utility.GrabAction}.
+     */
     public static class Grab {
         public static int CAST_DURATION = 750;
         static { register(
@@ -3218,6 +3251,11 @@ public class Config {
     // ==============================================================================
     //region UmbralBlade States
     // ==============================================================================
+    /**
+     * All configurable parameters for the UmbralBlade weapon and its state machine:
+     * lunge timings, throw/recall physics, lodging thresholds, and blade display properties.
+     * Used by {@link btm.sword.system.entity.umbral.UmbralBlade} and its states.
+     */
     public static class UmbralBlade {
         public static double LUNGE_TIME_CUTOFF = 1.1;
         static { register(
@@ -3863,6 +3901,10 @@ public class Config {
     }
     //endregion
 
+    /**
+     * Material icons used for section header buttons throughout the inventory menu system.
+     * Each entry corresponds to one collapsible section in the dev/character menus.
+     */
     public static class Menu {
         /** Material icon for the Umbral section button. */
         public static Material UMBRAL_ICON = Material.HEAVY_CORE;

--- a/src/main/java/btm/sword/gamemode/ArenaManager.java
+++ b/src/main/java/btm/sword/gamemode/ArenaManager.java
@@ -7,4 +7,6 @@ package btm.sword.gamemode;
  */
 public class ArenaManager {
 
+    /** Creates an {@code ArenaManager}. */
+    public ArenaManager() { }
 }

--- a/src/main/java/btm/sword/listeners/EntityListener.java
+++ b/src/main/java/btm/sword/listeners/EntityListener.java
@@ -25,6 +25,16 @@ import btm.sword.system.entity.impl.Hostile;
 import btm.sword.utility.Prefab;
 import net.donnypz.displayentityutils.events.AnimationCompleteEvent;
 
+/**
+ * Listener for entity lifecycle, damage, animation, and pickup events.
+ *
+ * <p>Bridges Bukkit/Paper entity events into the SwordEntity system: new
+ * {@link org.bukkit.entity.LivingEntity} instances are registered with
+ * {@link btm.sword.system.entity.SwordEntityArbiter}, departing entities are cleaned up,
+ * vanilla damage is intercepted and re-routed through the Sword combat pipeline, DEU
+ * animation completion drives death sequencing, and LIGHTNING_ROD item displays are tagged
+ * as weapon-slot anchors for {@link btm.sword.system.entity.display.DisplayRig}.</p>
+ */
 public class EntityListener implements Listener {
     /**
      * Handles the event when any entity is added to the world (including players).
@@ -139,9 +149,6 @@ public class EntityListener implements Listener {
 
     /**
      * Handles item pickup events by entities.
-     * <p>
-     *
-     * </p>
      *
      * @param event the {@link EntityPickupItemEvent} triggered when an entity picks up an item
      */

--- a/src/main/java/btm/sword/listeners/WorldListener.java
+++ b/src/main/java/btm/sword/listeners/WorldListener.java
@@ -14,8 +14,24 @@ import org.bukkit.inventory.ItemStack;
 import btm.sword.config.Config;
 import btm.sword.system.control.SwordScheduler;
 
+/**
+ * Listener for world-level events: block interactions and item consumption.
+ *
+ * <p>Block breaking and placing are gated behind
+ * {@link btm.sword.config.Config.World#BLOCK_INTERACTION_ALLOW_BLOCK_PLACING}. When
+ * placing is forbidden the event is cancelled outright; when allowed, any block placed
+ * by a player is immediately restored to its pre-placement stack so that blocks are never
+ * truly consumed (preserving the combat-focused design intent of not depleting inventory).
+ * Item-consumption events are similarly intercepted so consumables are never removed from
+ * the player's hand.</p>
+ */
 public class WorldListener implements Listener {
 
+    /**
+     * Cancels block-break events when block interactions are disabled.
+     *
+     * @param event the {@link BlockBreakEvent} to gate
+     */
     @EventHandler
     public void onBlockBreak(BlockBreakEvent event) {
         if (!Config.World.BLOCK_INTERACTION_ALLOW_BLOCK_PLACING) {
@@ -23,6 +39,12 @@ public class WorldListener implements Listener {
         }
     }
 
+    /**
+     * Cancels block-place events when block interactions are disabled, or restores the used
+     * item stack one tick later so players are never charged a block from their inventory.
+     *
+     * @param event the {@link BlockPlaceEvent} to gate
+     */
     @EventHandler
     public void onBlockPlace(BlockPlaceEvent event) {
         if (!Config.World.BLOCK_INTERACTION_ALLOW_BLOCK_PLACING) {
@@ -44,6 +66,12 @@ public class WorldListener implements Listener {
         }, 50, TimeUnit.MILLISECONDS);
     }
 
+    /**
+     * Prevents consumables from being removed by replacing the consumed item with a clone
+     * of itself, effectively making all food/potions infinite.
+     *
+     * @param event the {@link PlayerItemConsumeEvent} to intercept
+     */
     @EventHandler
     public void onItemConsume(PlayerItemConsumeEvent event) {
         event.setReplacement(event.getItem().clone());

--- a/src/main/java/btm/sword/system/action/ActionCaster.java
+++ b/src/main/java/btm/sword/system/action/ActionCaster.java
@@ -20,6 +20,16 @@ public final class ActionCaster {
 
     private ActionCaster() {}
 
+    /**
+     * Executes {@code action} on the next server tick and, if {@code castDurationMillis > 0},
+     * stores the resulting {@link BukkitTask} on {@code executor} to block further actions
+     * for the specified duration (scaled by the global time arbiter).
+     *
+     * @param executor          the combatant performing the cast
+     * @param castDurationMillis how long (in ms) to lock the executor after casting; {@code <= 0}
+     *                          means no lock is applied
+     * @param action            the action payload to run on the next tick
+     */
     public static void cast(Combatant executor, int castDurationMillis, Runnable action) {
         BukkitTask castTask = Bukkit.getScheduler().runTask(plugin, action);
 

--- a/src/main/java/btm/sword/system/action/attack/AttackAction.java
+++ b/src/main/java/btm/sword/system/action/attack/AttackAction.java
@@ -25,13 +25,19 @@ import btm.sword.utility.misc.ConsumerToConsumePair;
  * knockback, and associated cooldowns.
  */
 public class AttackAction extends SwordAction {
+
+    /** Creates an {@code AttackAction}. */
+    public AttackAction() { }
+
     /**
      * Executes a basic attack for the given {@link Combatant} and {@link AttackType}.
      * <p>
      * Selects the correct attack variant based on the item in hand and whether the
      * executor is grounded or airborne. Aerial attacks reset the executor's combo tree.
      *
-     * @param executor The combatant performing the attack.
+     * @param executor  the combatant performing the attack
+     * @param comboStep the current step in the combo sequence (1-indexed), used to select
+     *                  the appropriate attack profile and alternating punch side
      */
     public static void basicAttack(Combatant executor, int comboStep) {
         ItemStack itemUsedInAttack = executor.getItemStackInHand(true);

--- a/src/main/java/btm/sword/system/action/attack/DashAttackAction.java
+++ b/src/main/java/btm/sword/system/action/attack/DashAttackAction.java
@@ -12,7 +12,31 @@ import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.entity.umbral.input.BladeRequest;
 import btm.sword.system.entity.umbral.statemachine.state.StandbyState;
 
+/**
+ * Resolves and fires the appropriate attack for a dash-momentum hit.
+ *
+ * <p>Selects between a punch, a directional blade attack (if the umbral blade is in standby
+ * with sufficient soulfire), or a full weapon-style forward/backward dash attack based on
+ * the executor's current equipment and state.</p>
+ */
 public class DashAttackAction extends SwordAction {
+
+    /**
+     * Fires a dash-momentum attack for {@code executor} in the given {@code direction}.
+     *
+     * <p>Resolution order:
+     * <ol>
+     *   <li>Untagged / PUNCH-style items → {@link PunchAction#throwPunch}</li>
+     *   <li>Soul-link held + blade in Standby + enough soulfire → blade quick-attack</li>
+     *   <li>Otherwise → direction-keyed {@link btm.sword.system.attack.style.AttackProfile} from
+     *       the weapon's {@link btm.sword.system.attack.style.WeaponAttackStyle}</li>
+     * </ol>
+     * </p>
+     *
+     * @param executor  the combatant performing the attack
+     * @param direction the dash direction ({@link DashDirection#FORWARD} or
+     *                  {@link DashDirection#BACKWARD})
+     */
     public static void dashAttack(Combatant executor, DashDirection direction) {
         ItemStack itemUsedInAttack = executor.getItemStackInHand(true);
         WeaponAttackStyle weaponAttackStyle = WeaponAttackStyle.fromString(itemUsedInAttack);

--- a/src/main/java/btm/sword/system/action/movement/DashDirection.java
+++ b/src/main/java/btm/sword/system/action/movement/DashDirection.java
@@ -1,5 +1,9 @@
 package btm.sword.system.action.movement;
 
+/**
+ * The direction component of a dash, used to select the appropriate attack profile and
+ * control projectile/impulse direction during dash-momentum actions.
+ */
 public enum DashDirection {
     NONE,
     FORWARD,

--- a/src/main/java/btm/sword/system/action/skill/Skill.java
+++ b/src/main/java/btm/sword/system/action/skill/Skill.java
@@ -7,14 +7,48 @@ import org.bukkit.inventory.ItemStack;
 import net.kyori.adventure.text.Component;
 
 /**
- * Always register new skill implementations in {@link SkillRegistry}
+ * Common contract for all skills — passives, actives, and ability items.
+ *
+ * <p>Every implementation must be registered in {@link SkillRegistry} so it can be
+ * looked up by {@link SkillId} at runtime. Use the appropriate base class:
+ * {@link btm.sword.system.action.skill.type.PassiveSkill},
+ * {@link btm.sword.system.action.skill.type.ActiveSkill}, or one of the {@code AbilitySkill}
+ * subtypes for physical-item abilities.</p>
  */
 public interface Skill {
 
-    SkillId id();          // Stable identifier
+    /**
+     * Returns the stable identifier used to look this skill up in {@link SkillRegistry}.
+     *
+     * @return the skill's unique {@link SkillId}
+     */
+    SkillId id();
+
+    /**
+     * Returns the broad category of this skill.
+     *
+     * @return one of {@link SkillType#ACTIVE}, {@link SkillType#PASSIVE}, or {@link SkillType#UMBRAL}
+     */
     SkillType type();
 
+    /**
+     * Returns the inventory icon shown in skill-selection menus.
+     *
+     * @return the icon {@link ItemStack}
+     */
     ItemStack icon();
+
+    /**
+     * Returns the display name of this skill.
+     *
+     * @return the skill name {@link Component}
+     */
     Component name();
+
+    /**
+     * Returns the description lines shown in skill-selection menu tooltips.
+     *
+     * @return an ordered list of description {@link Component}s
+     */
     List<Component> description();
 }

--- a/src/main/java/btm/sword/system/action/skill/SkillId.java
+++ b/src/main/java/btm/sword/system/action/skill/SkillId.java
@@ -9,6 +9,8 @@ import org.jetbrains.annotations.NotNull;
  * <p>Use the {@link #of(String, String)} factory for most cases (namespace = plugin id,
  * value = skill name). {@link #parse(String)} accepts the {@code "namespace:value"} serialised
  * form used in player-data persistence.</p>
+ *
+ * @param key the underlying {@link NamespacedKey} that uniquely identifies the skill
  */
 public record SkillId(NamespacedKey key) {
 

--- a/src/main/java/btm/sword/system/action/skill/type/AbilitySkill.java
+++ b/src/main/java/btm/sword/system/action/skill/type/AbilitySkill.java
@@ -28,7 +28,11 @@ import btm.sword.system.action.skill.Skill;
  */
 public interface AbilitySkill extends Skill {
 
-    /** @return the ability classification governing activation and consumption behavior */
+    /**
+     * Returns the ability classification governing activation and consumption behavior.
+     *
+     * @return the {@link AbilityType} for this ability
+     */
     AbilityType abilityType();
 
     /**

--- a/src/main/java/btm/sword/system/action/skill/type/ActivatableAbility.java
+++ b/src/main/java/btm/sword/system/action/skill/type/ActivatableAbility.java
@@ -11,6 +11,9 @@ import btm.sword.system.action.skill.AbilityType;
  */
 public abstract class ActivatableAbility extends ActiveSkill implements AbilitySkill {
 
+    /** Creates an {@code ActivatableAbility}. */
+    protected ActivatableAbility() { }
+
     @Override
     public AbilityType abilityType() {
         return AbilityType.ACTIVATABLE;

--- a/src/main/java/btm/sword/system/action/skill/type/ActiveSkill.java
+++ b/src/main/java/btm/sword/system/action/skill/type/ActiveSkill.java
@@ -20,6 +20,9 @@ import net.kyori.adventure.text.Component;
  */
 public abstract class ActiveSkill implements Skill {
 
+    /** Creates an {@code ActiveSkill}. */
+    protected ActiveSkill() { }
+
     /** Cached {@link InputAction} so cooldowns persist across dynamic re-resolves. */
     @Getter @Setter
     private InputAction cachedInputAction;

--- a/src/main/java/btm/sword/system/action/skill/type/ConsumableActive.java
+++ b/src/main/java/btm/sword/system/action/skill/type/ConsumableActive.java
@@ -1,5 +1,12 @@
 package btm.sword.system.action.skill.type;
 
+/**
+ * An active skill that is consumed on use (e.g. has a finite number of uses, repair charges, etc.).
+ *
+ * <p>Extend this class for skills where the world item is depleted or expended through
+ * repeated activations, as opposed to {@link ActivatableAbility} which never consumes
+ * the backing item.</p>
+ */
 public abstract class ConsumableActive extends ActiveSkill {
     // uses left, repair uses, etc.
 }

--- a/src/main/java/btm/sword/system/action/skill/type/PassiveSkill.java
+++ b/src/main/java/btm/sword/system/action/skill/type/PassiveSkill.java
@@ -7,6 +7,14 @@ import btm.sword.system.action.skill.Skill;
 import btm.sword.system.item.ItemStackBuilder;
 import net.kyori.adventure.text.Component;
 
+/**
+ * Base class for passive skills that are always active while equipped.
+ *
+ * <p>Provides a default {@link #icon()} placeholder. Subclasses should override
+ * {@code icon()} with an appropriate item and implement any passive effect hooks.
+ * For passive skills that also exist as physical world items, extend
+ * {@link PassiveAbilitySkill} instead.</p>
+ */
 public abstract class PassiveSkill implements Skill {
     @Override
     public ItemStack icon() {

--- a/src/main/java/btm/sword/system/attack/style/shape/ArcShape.java
+++ b/src/main/java/btm/sword/system/attack/style/shape/ArcShape.java
@@ -21,6 +21,11 @@ import btm.sword.utility.math.Basis;
  *
  * <p>Use the {@link #of} factory for a standard local-space arc. The {@code rangeMultiplier}
  * passed to {@link #resolve} scales the {@code radius}.
+ *
+ * @param radius     distance from the attack origin to the arc path, in blocks
+ * @param startAngle azimuthal start angle in radians ({@code 0} = forward)
+ * @param endAngle   azimuthal end angle in radians
+ * @param height     vertical offset from the origin to the arc plane, in blocks
  */
 public record ArcShape(double radius,
                        double startAngle,
@@ -34,6 +39,7 @@ public record ArcShape(double radius,
      * @param startAngle azimuthal start angle in radians ({@code 0} = forward, positive = toward right)
      * @param endAngle   azimuthal end angle in radians; use {@code startAngle + 2π} for a full circle
      * @param height     vertical offset from the origin to the arc plane, in blocks
+     * @return a new {@code ArcShape} with the given parameters
      */
     public static ArcShape of(double radius, double startAngle, double endAngle, double height) {
         return new ArcShape(radius, startAngle, endAngle, height);
@@ -45,6 +51,7 @@ public record ArcShape(double radius,
      * @param radius     distance from the attack origin to the arc path, in blocks
      * @param startAngle azimuthal start angle in radians
      * @param endAngle   azimuthal end angle in radians
+     * @return a new {@code ArcShape} at height {@code 0.0}
      */
     public static ArcShape of(double radius, double startAngle, double endAngle) {
         return new ArcShape(radius, startAngle, endAngle, 0.0);

--- a/src/main/java/btm/sword/system/attack/style/shape/BezierShape.java
+++ b/src/main/java/btm/sword/system/attack/style/shape/BezierShape.java
@@ -21,6 +21,10 @@ import btm.sword.utility.math.ControlVectors;
  *       transformation. Used when geometry is computed procedurally at attack time (e.g.,
  *       sweeps targeting a specific entity). Use {@link #worldSpace} to create a world-space shape.</li>
  * </ul>
+ *
+ * @param controlVectors the cubic Bézier control points (local or world space)
+ * @param isWorldSpace   {@code true} if {@code controlVectors} are in world space;
+ *                       {@code false} if they are local to the attacker's orientation
  */
 public record BezierShape(ControlVectors controlVectors,
                           boolean isWorldSpace) implements AttackShape {

--- a/src/main/java/btm/sword/system/attack/style/shape/ConeShape.java
+++ b/src/main/java/btm/sword/system/attack/style/shape/ConeShape.java
@@ -26,6 +26,11 @@ import btm.sword.utility.math.Basis;
  * <p>All angles are in radians. {@code startSweepAngle = 0} aligns with the attacker's
  * {@code right} vector in the plane perpendicular to forward.
  * The {@code rangeMultiplier} passed to {@link #resolve} scales the {@code range}.
+ *
+ * @param halfAngle       polar angle from the cone axis to its surface, in radians
+ * @param range           reach from the apex to the rim, in blocks
+ * @param startSweepAngle azimuthal start angle around the forward axis, in radians
+ * @param endSweepAngle   azimuthal end angle around the forward axis, in radians
  */
 public record ConeShape(double halfAngle, double range, double startSweepAngle,
                         double endSweepAngle) implements AttackShape {
@@ -38,6 +43,7 @@ public record ConeShape(double halfAngle, double range, double startSweepAngle,
      * @param startSweepAngle azimuthal start angle around the forward axis, in radians
      * @param endSweepAngle   azimuthal end angle around the forward axis, in radians;
      *                        use {@code startSweepAngle + 2π} for a full revolution
+     * @return a new {@code ConeShape} with the specified geometry
      */
     public static ConeShape of(double halfAngle, double range,
                                double startSweepAngle, double endSweepAngle) {
@@ -53,6 +59,7 @@ public record ConeShape(double halfAngle, double range, double startSweepAngle,
      * @param halfAngle polar angle from the forward axis to the cone surface, in radians
      * @param range     reach of the cone, in blocks
      * @param halfSweep half the total azimuthal sweep, in radians
+     * @return a new {@code ConeShape} sweeping from {@code -halfSweep} to {@code +halfSweep}
      */
     public static ConeShape symmetric(double halfAngle, double range, double halfSweep) {
         return new ConeShape(halfAngle, range, -halfSweep, halfSweep);

--- a/src/main/java/btm/sword/system/entity/ai/state/ApproachState.java
+++ b/src/main/java/btm/sword/system/entity/ai/state/ApproachState.java
@@ -22,6 +22,9 @@ import btm.sword.system.entity.impl.Hostile;
  */
 public class ApproachState extends HostileAIFacade {
 
+    /** Creates an {@code ApproachState}. */
+    public ApproachState() { }
+
     @Override
     public String name() {
         return "APPROACH";

--- a/src/main/java/btm/sword/system/entity/ai/state/AttackReadyState.java
+++ b/src/main/java/btm/sword/system/entity/ai/state/AttackReadyState.java
@@ -16,6 +16,9 @@ import btm.sword.system.entity.impl.Hostile;
  */
 public class AttackReadyState extends HostileAIFacade {
 
+    /** Creates an {@code AttackReadyState}. */
+    public AttackReadyState() { }
+
     @Override
     public String name() {
         return "ATTACK_READY";

--- a/src/main/java/btm/sword/system/entity/ai/state/AttackState.java
+++ b/src/main/java/btm/sword/system/entity/ai/state/AttackState.java
@@ -29,6 +29,9 @@ import net.donnypz.displayentityutils.utils.DisplayEntities.machine.MachineState
  */
 public class AttackState extends HostileAIFacade {
 
+    /** Creates an {@code AttackState}. */
+    public AttackState() { }
+
     @Override
     public String name() {
         return "ATTACK";

--- a/src/main/java/btm/sword/system/entity/mob/AnimationSlot.java
+++ b/src/main/java/btm/sword/system/entity/mob/AnimationSlot.java
@@ -15,7 +15,11 @@ public record AnimationSlot(String tag, int durationTicks) {
     /** Sentinel for a slot with no animation registered. */
     public static final AnimationSlot NONE = new AnimationSlot("", 0);
 
-    /** Returns {@code true} when this slot has a non-empty animation tag. */
+    /**
+     * Returns {@code true} when this slot has a non-empty animation tag.
+     *
+     * @return {@code true} if {@code tag} is non-null and non-empty
+     */
     public boolean hasTag() {
         return tag != null && !tag.isEmpty();
     }

--- a/src/main/java/btm/sword/system/entity/umbral/statemachine/state/AttackingHeavyState.java
+++ b/src/main/java/btm/sword/system/entity/umbral/statemachine/state/AttackingHeavyState.java
@@ -47,6 +47,10 @@ import btm.sword.utility.math.ControlVectors;
  *
  */
 public class AttackingHeavyState extends UmbralStateFacade {
+
+    /** Creates an {@code AttackingHeavyState}. */
+    public AttackingHeavyState() { }
+
     @Override
     public String name() {
         return "ATTACKING_HEAVY";

--- a/src/main/java/btm/sword/system/entity/umbral/statemachine/state/AttackingQuickState.java
+++ b/src/main/java/btm/sword/system/entity/umbral/statemachine/state/AttackingQuickState.java
@@ -47,6 +47,10 @@ import btm.sword.utility.display.DrawUtil;
  *
  */
 public class AttackingQuickState extends UmbralStateFacade {
+
+    /** Creates an {@code AttackingQuickState}. */
+    public AttackingQuickState() { }
+
     @Override
     public String name() {
         return "ATTACKING_QUICK";

--- a/src/main/java/btm/sword/system/input/InputAction.java
+++ b/src/main/java/btm/sword/system/input/InputAction.java
@@ -227,7 +227,7 @@ public class InputAction {
         return new Builder();
     }
 
-    /** */
+    /** Builder for constructing {@link InputAction} instances with a fluent API. */
     public static class Builder {
         private String name = "Pass-Through";
         private Consumer<Combatant> action;

--- a/src/main/java/btm/sword/system/item/armor/ArmorType.java
+++ b/src/main/java/btm/sword/system/item/armor/ArmorType.java
@@ -18,7 +18,11 @@ public enum ArmorType {
         this.id = id;
     }
 
-    /** Returns the unique string identifier for this armor type. */
+    /**
+     * Returns the unique string identifier for this armor type.
+     *
+     * @return the armor type id string
+     */
     public String id() {
         return id;
     }

--- a/src/main/java/btm/sword/system/playerdata/store/repository/AbilityHistoryRepository.java
+++ b/src/main/java/btm/sword/system/playerdata/store/repository/AbilityHistoryRepository.java
@@ -24,7 +24,11 @@ public class AbilityHistoryRepository {
 
     private final Connection conn;
 
-    /** @param conn the shared JDBC connection */
+    /**
+     * Constructs a repository backed by the given JDBC connection.
+     *
+     * @param conn the shared JDBC connection
+     */
     public AbilityHistoryRepository(Connection conn) {
         this.conn = conn;
     }

--- a/src/main/java/btm/sword/system/playerdata/store/repository/AbilityStateRepository.java
+++ b/src/main/java/btm/sword/system/playerdata/store/repository/AbilityStateRepository.java
@@ -34,7 +34,11 @@ public class AbilityStateRepository {
 
     private final Connection conn;
 
-    /** @param conn the shared JDBC connection */
+    /**
+     * Constructs a repository backed by the given JDBC connection.
+     *
+     * @param conn the shared JDBC connection
+     */
     public AbilityStateRepository(Connection conn) {
         this.conn = conn;
     }

--- a/src/main/java/btm/sword/system/playerdata/store/repository/AspectRepository.java
+++ b/src/main/java/btm/sword/system/playerdata/store/repository/AspectRepository.java
@@ -22,7 +22,11 @@ public class AspectRepository {
 
     private final Connection conn;
 
-    /** @param conn the shared JDBC connection */
+    /**
+     * Constructs a repository backed by the given JDBC connection.
+     *
+     * @param conn the shared JDBC connection
+     */
     public AspectRepository(Connection conn) {
         this.conn = conn;
     }

--- a/src/main/java/btm/sword/system/scene/CameraPath.java
+++ b/src/main/java/btm/sword/system/scene/CameraPath.java
@@ -19,6 +19,8 @@ import btm.sword.utility.math.ControlVectors;
  * Call {@link #evaluate(double, World)} with {@code t} in {@code [0, 1]} to obtain
  * a {@link Location} on the curve with yaw/pitch oriented along the tangent direction.
  * </p>
+ *
+ * @param control the four world-space control points defining the cubic Bézier trajectory
  */
 public record CameraPath(ControlVectors control) {
 

--- a/src/main/java/btm/sword/utility/display/DrawUtil.java
+++ b/src/main/java/btm/sword/utility/display/DrawUtil.java
@@ -53,13 +53,15 @@ public class DrawUtil {
     }
 
     /**
-     * @param particles ParticleWrappers to be displayed
-     * @param origin center of circle
-     * @param basis basis to use for orientation of circle
-     * @param outerRadius ~
-     * @param innerRadius ~
-     * @param spacingRadial distance between particles (from the inner to outer radius)
-     * @param spacingArc distance between particles (in radians) around circle
+     * Displays a filled ring of particles in the plane defined by {@code basis}.
+     *
+     * @param particles     the {@link btm.sword.utility.sound.ParticleWrapper} list to spawn
+     * @param origin        the center of the ring
+     * @param basis         orientation basis; the ring lies in the {@code forward}–{@code right} plane
+     * @param outerRadius   outer edge of the ring, in blocks
+     * @param innerRadius   inner edge (hole) of the ring, in blocks
+     * @param spacingRadial distance between particle rows along the radial direction, in blocks
+     * @param spacingArc    angular spacing between particles around the ring, in radians
      */
     public static void circle(List<ParticleWrapper> particles, Location origin, Basis basis, double outerRadius, double innerRadius, double spacingRadial, double spacingArc) {
         Vector up = basis.up();

--- a/src/main/java/btm/sword/utility/math/BezierUtil.java
+++ b/src/main/java/btm/sword/utility/math/BezierUtil.java
@@ -13,6 +13,9 @@ import org.bukkit.util.Vector;
  * </p>
  */
 public class BezierUtil {
+
+    private BezierUtil() { }
+
     /**
      * Constructs a cubic Bézier curve function in 3D space.
      * Returns a function mapping parameter {@code t} (from 0 to 1) to a point on the curve

--- a/src/main/java/btm/sword/utility/statemachine/State.java
+++ b/src/main/java/btm/sword/utility/statemachine/State.java
@@ -10,7 +10,11 @@ package btm.sword.utility.statemachine;
  */
 public abstract class State<T> {
 
-    /** @return a human-readable name for this state, used in debug logs. */
+    /**
+     * Returns a human-readable name for this state, used in debug logs.
+     *
+     * @return the state's display name
+     */
     public abstract String name();
 
     /**


### PR DESCRIPTION
## Summary
- Add class-level and method Javadoc to ~34 files across listeners, action classes, skill hierarchy, attack shapes, AI states, and utilities
- Fix all actionable Javadoc warnings: missing `@param`/`@return`, empty comments, no-main-description, and undocumented default constructors
- Add `private BezierUtil()` constructor (also suppresses `FinalClass` Checkstyle hint)
- Total Javadoc warnings reduced from ~890 to 100 (remaining are undocumented fields in `Config`/`Prefab` — out of scope)

## Test plan
- [ ] `./gradlew check` passes
- [ ] `./gradlew javadoc` shows no warnings outside "no comment" (undocumented fields)