### PR TITLE
[Feat] Roguelike wave-run prototype with CTF infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ $RECYCLE.BIN/
 
 .claude/
 CLAUDE.md
+comms/
 .gradle
 build/
 

--- a/src/main/java/btm/sword/Sword.java
+++ b/src/main/java/btm/sword/Sword.java
@@ -13,6 +13,7 @@ import com.comphenix.protocol.ProtocolManager;
 import btm.sword.commands.SwordCommands;
 import btm.sword.config.ConfigManager;
 import btm.sword.listeners.EntityListener;
+import btm.sword.listeners.ErrorListener;
 import btm.sword.listeners.InputListener;
 import btm.sword.listeners.PlayerListener;
 import btm.sword.listeners.SystemListener;
@@ -68,6 +69,7 @@ public final class Sword extends JavaPlugin {
 
         InvUI.getInstance().setPlugin(this);
 
+        getServer().getPluginManager().registerEvents(new ErrorListener(), this);
         getServer().getPluginManager().registerEvents(new InputListener(), this);
         getServer().getPluginManager().registerEvents(new PlayerListener(), this);
         getServer().getPluginManager().registerEvents(new ServerJoinArbiter(), this);

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -4319,5 +4319,83 @@ public class Config {
                 v -> WAVE_3_WITHER_SKELETONS = v, ConfigurationSection::getInt);
         }
     }
+    //region Ctf
+    /**
+     * Configuration for the Capture the Flag gamemode.
+     * <p>
+     * Controls team spawn locations, flag return timer, respawn delay, win threshold, and
+     * the speed debuff applied to flag carriers.
+     * All values are hot-reloadable via {@code /sword reload}.
+     * </p>
+     */
+    public static class Ctf {
+
+        /** World name shared by both team spawns. */
+        public static String SPAWN_WORLD = "world";
+
+        /** X coordinate of the RED team spawn (also the RED flag spawn). */
+        public static double RED_SPAWN_X = 15.0;
+        /** Y coordinate of the RED team spawn. */
+        public static double RED_SPAWN_Y = 64.0;
+        /** Z coordinate of the RED team spawn. */
+        public static double RED_SPAWN_Z = 0.0;
+
+        /** X coordinate of the BLUE team spawn (also the BLUE flag spawn). */
+        public static double BLUE_SPAWN_X = -15.0;
+        /** Y coordinate of the BLUE team spawn. */
+        public static double BLUE_SPAWN_Y = 64.0;
+        /** Z coordinate of the BLUE team spawn. */
+        public static double BLUE_SPAWN_Z = 0.0;
+
+        /** Seconds before a dropped flag automatically returns to its base. */
+        public static int FLAG_RETURN_TIMER_SECONDS = 30;
+
+        /** Seconds before a dead player respawns at their team spawn. */
+        public static int RESPAWN_DELAY_SECONDS = 5;
+
+        /**
+         * Number of flag captures required to win.
+         * Set to 0 for a timer-only match (most captures at expiry wins).
+         */
+        public static int CAPTURES_TO_WIN = 3;
+
+        /** Radius in blocks within which a flag carrier scores a capture when near their own base. */
+        public static double CAPTURE_RADIUS = 3.0;
+
+        /** Duration in ticks of the Slowness effect applied to flag carriers. Use a large value for a persistent effect. */
+        public static int FLAG_CARRIER_SLOW_DURATION = 999999;
+
+        /** Amplifier (0-based) of the Slowness effect on flag carriers. 0 = Slowness I, 1 = Slowness II. */
+        public static int FLAG_CARRIER_SLOW_AMPLIFIER = 1;
+
+        static {
+            register("ctf.spawn_world", SPAWN_WORLD, String.class,
+                v -> SPAWN_WORLD = v, ConfigurationSection::getString);
+            register("ctf.red_spawn_x", RED_SPAWN_X, Double.class,
+                v -> RED_SPAWN_X = v, ConfigurationSection::getDouble);
+            register("ctf.red_spawn_y", RED_SPAWN_Y, Double.class,
+                v -> RED_SPAWN_Y = v, ConfigurationSection::getDouble);
+            register("ctf.red_spawn_z", RED_SPAWN_Z, Double.class,
+                v -> RED_SPAWN_Z = v, ConfigurationSection::getDouble);
+            register("ctf.blue_spawn_x", BLUE_SPAWN_X, Double.class,
+                v -> BLUE_SPAWN_X = v, ConfigurationSection::getDouble);
+            register("ctf.blue_spawn_y", BLUE_SPAWN_Y, Double.class,
+                v -> BLUE_SPAWN_Y = v, ConfigurationSection::getDouble);
+            register("ctf.blue_spawn_z", BLUE_SPAWN_Z, Double.class,
+                v -> BLUE_SPAWN_Z = v, ConfigurationSection::getDouble);
+            register("ctf.flag_return_timer_seconds", FLAG_RETURN_TIMER_SECONDS, Integer.class,
+                v -> FLAG_RETURN_TIMER_SECONDS = v, ConfigurationSection::getInt);
+            register("ctf.respawn_delay_seconds", RESPAWN_DELAY_SECONDS, Integer.class,
+                v -> RESPAWN_DELAY_SECONDS = v, ConfigurationSection::getInt);
+            register("ctf.captures_to_win", CAPTURES_TO_WIN, Integer.class,
+                v -> CAPTURES_TO_WIN = v, ConfigurationSection::getInt);
+            register("ctf.capture_radius", CAPTURE_RADIUS, Double.class,
+                v -> CAPTURE_RADIUS = v, ConfigurationSection::getDouble);
+            register("ctf.flag_carrier_slow_duration", FLAG_CARRIER_SLOW_DURATION, Integer.class,
+                v -> FLAG_CARRIER_SLOW_DURATION = v, ConfigurationSection::getInt);
+            register("ctf.flag_carrier_slow_amplifier", FLAG_CARRIER_SLOW_AMPLIFIER, Integer.class,
+                v -> FLAG_CARRIER_SLOW_AMPLIFIER = v, ConfigurationSection::getInt);
+        }
+    }
     //endregion
 }

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -4168,4 +4168,66 @@ public class Config {
         }
     }
     //endregion
+
+    // ==============================================================================
+    //region ROGUELIKE - Wave enemy run configuration
+    // ==============================================================================
+    /**
+     * Configuration for the roguelike wave-run gamemode.
+     * <p>
+     * Controls the spawn center location, spawn radius, and per-wave enemy counts.
+     * All values are hot-reloadable via {@code /sword reload}.
+     * </p>
+     */
+    public static class Roguelike {
+
+        /** World name for the roguelike spawn center. */
+        public static String SPAWN_WORLD = "world";
+
+        /** X coordinate of the spawn center. */
+        public static double SPAWN_X = 0.0;
+
+        /** Y coordinate of the spawn center. */
+        public static double SPAWN_Y = 64.0;
+
+        /** Z coordinate of the spawn center. */
+        public static double SPAWN_Z = 0.0;
+
+        /** Radius within which enemies spawn around the center, in blocks. */
+        public static double SPAWN_RADIUS = 8.0;
+
+        /** Number of Pillagers spawned in wave 1. */
+        public static int WAVE_1_PILLAGERS = 3;
+
+        /** Number of Wither Skeletons spawned in wave 2. */
+        public static int WAVE_2_WITHER_SKELETONS = 3;
+
+        /** Number of Pillagers spawned in wave 3. */
+        public static int WAVE_3_PILLAGERS = 2;
+
+        /** Number of Wither Skeletons spawned in wave 3. */
+        public static int WAVE_3_WITHER_SKELETONS = 3;
+
+        static {
+            register("roguelike.spawn_world", SPAWN_WORLD, String.class,
+                v -> SPAWN_WORLD = v, ConfigurationSection::getString);
+            register("roguelike.spawn_x", SPAWN_X, Double.class,
+                v -> SPAWN_X = v, ConfigurationSection::getDouble);
+            register("roguelike.spawn_y", SPAWN_Y, Double.class,
+                v -> SPAWN_Y = v, ConfigurationSection::getDouble);
+            register("roguelike.spawn_z", SPAWN_Z, Double.class,
+                v -> SPAWN_Z = v, ConfigurationSection::getDouble);
+            register("roguelike.spawn_radius", SPAWN_RADIUS, Double.class,
+                v -> SPAWN_RADIUS = v, ConfigurationSection::getDouble);
+            register("roguelike.wave_1_pillagers", WAVE_1_PILLAGERS, Integer.class,
+                v -> WAVE_1_PILLAGERS = v, ConfigurationSection::getInt);
+            register("roguelike.wave_2_wither_skeletons", WAVE_2_WITHER_SKELETONS, Integer.class,
+                v -> WAVE_2_WITHER_SKELETONS = v, ConfigurationSection::getInt);
+            register("roguelike.wave_3_pillagers", WAVE_3_PILLAGERS, Integer.class,
+                v -> WAVE_3_PILLAGERS = v, ConfigurationSection::getInt);
+            register("roguelike.wave_3_wither_skeletons", WAVE_3_WITHER_SKELETONS, Integer.class,
+                v -> WAVE_3_WITHER_SKELETONS = v, ConfigurationSection::getInt);
+        }
+    }
+    //endregion
 }

--- a/src/main/java/btm/sword/gamemode/QueueManager.java
+++ b/src/main/java/btm/sword/gamemode/QueueManager.java
@@ -1,22 +1,40 @@
 package btm.sword.gamemode;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import btm.sword.gamemode.type.CaptureTheFlag1v1;
 import btm.sword.gamemode.type.Gamemode;
+import btm.sword.gamemode.type.RoguelikeRun;
 import btm.sword.system.entity.impl.SwordPlayer;
 
+/**
+ * Manages per-{@link Gamemode} matchmaking queues.
+ * <p>
+ * Players are enqueued via {@link #enqueue} and matched when the queue has
+ * enough players. Roguelike runs start solo (1 player); CTF requires 2.
+ * </p>
+ */
 public class QueueManager {
+
     private static final Map<Class<? extends Gamemode>, Queue<SwordPlayer>> queueMap;
 
     static {
         queueMap = new HashMap<>();
         queueMap.put(CaptureTheFlag1v1.class, new ConcurrentLinkedQueue<>());
+        queueMap.put(RoguelikeRun.class, new ConcurrentLinkedQueue<>());
     }
 
+    /**
+     * Adds the given player to the queue for the specified game mode.
+     * No-ops (with a message) if the player is already queued.
+     *
+     * @param gamemode    the game mode class to queue for
+     * @param swordPlayer the player requesting to join the queue
+     */
     public static void enqueue(Class<? extends Gamemode> gamemode, SwordPlayer swordPlayer) {
         Queue<SwordPlayer> currentPlayerQueue = queueMap.get(gamemode);
         if (currentPlayerQueue.contains(swordPlayer)) {
@@ -30,15 +48,22 @@ public class QueueManager {
         tryStartNextMatch();
     }
 
+    /**
+     * Attempts to start any matches where the queue meets the player threshold.
+     * <p>
+     * Roguelike runs start immediately with 1 player. CTF arena integration is
+     * pending — see inline TODO.
+     * </p>
+     */
     public static void tryStartNextMatch() {
-//        if (arena.isBusy()) return;
-//        if (queue.size() < 2) return;
-//
-//        SwordPlayer p1 = queue.poll();
-//        SwordPlayer p2 = queue.peek();
-//
-//        if (p1 == null) return;
-//
-//        arena.startGame(List.of(p1, p2));
+        Queue<SwordPlayer> roguelikeQueue = queueMap.get(RoguelikeRun.class);
+        if (roguelikeQueue != null && !roguelikeQueue.isEmpty()) {
+            SwordPlayer player = roguelikeQueue.poll();
+            new RoguelikeRun(List.of(player)).start();
+        }
+
+        // TODO: integrate ArenaManager once arena lifecycle is implemented
+        // Queue<SwordPlayer> ctfQueue = queueMap.get(CaptureTheFlag1v1.class);
+        // if (ctfQueue != null && ctfQueue.size() >= 2) { ... }
     }
 }

--- a/src/main/java/btm/sword/gamemode/QueueManager.java
+++ b/src/main/java/btm/sword/gamemode/QueueManager.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import btm.sword.gamemode.type.CaptureTheFlag1v1;
@@ -12,15 +13,24 @@ import btm.sword.gamemode.type.RoguelikeRun;
 import btm.sword.system.entity.impl.SwordPlayer;
 
 /**
- * Manages per-{@link Gamemode} matchmaking queues.
+ * Manages per-{@link Gamemode} matchmaking queues and tracks active matches.
  * <p>
- * Players are enqueued via {@link #enqueue} and matched when the queue has
- * enough players. Roguelike runs start solo (1 player); CTF requires 2.
+ * Players are enqueued via {@link #enqueue} and matched when the queue has enough players.
+ * Roguelike runs start solo (1 player); CTF requires 2.
  * </p>
+ *
+ * <p>Active CTF matches are registered in {@link #activeMatches} so that
+ * {@link btm.sword.listeners.PlayerListener} can route death events to the correct match.</p>
  */
 public class QueueManager {
 
     private static final Map<Class<? extends Gamemode>, Queue<SwordPlayer>> queueMap;
+
+    /**
+     * Maps each participating player's UUID to their active CTF match.
+     * Populated on match start, cleaned up on match stop.
+     */
+    private static final Map<UUID, CaptureTheFlag1v1> activeMatches = new HashMap<>();
 
     static {
         queueMap = new HashMap<>();
@@ -49,10 +59,19 @@ public class QueueManager {
     }
 
     /**
+     * Immediately launches a CTF match for the given player without going through the queue.
+     * Intended for developer testing and single-player debug sessions.
+     *
+     * @param swordPlayer the player to start the match for
+     */
+    public static void startCtfDebug(SwordPlayer swordPlayer) {
+        startCtfMatch(List.of(swordPlayer));
+    }
+
+    /**
      * Attempts to start any matches where the queue meets the player threshold.
      * <p>
-     * Roguelike runs start immediately with 1 player. CTF arena integration is
-     * pending — see inline TODO.
+     * Roguelike runs start immediately with 1 player. CTF requires 2.
      * </p>
      */
     public static void tryStartNextMatch() {
@@ -62,8 +81,39 @@ public class QueueManager {
             new RoguelikeRun(List.of(player)).start();
         }
 
-        // TODO: integrate ArenaManager once arena lifecycle is implemented
-        // Queue<SwordPlayer> ctfQueue = queueMap.get(CaptureTheFlag1v1.class);
-        // if (ctfQueue != null && ctfQueue.size() >= 2) { ... }
+        Queue<SwordPlayer> ctfQueue = queueMap.get(CaptureTheFlag1v1.class);
+        if (ctfQueue != null && ctfQueue.size() >= 2) {
+            SwordPlayer p1 = ctfQueue.poll();
+            SwordPlayer p2 = ctfQueue.poll();
+            startCtfMatch(List.of(p1, p2));
+        }
+    }
+
+    /**
+     * Returns the active CTF match for the given player UUID, or {@code null} if they are not in one.
+     *
+     * @param uuid the player's UUID
+     * @return the active {@link CaptureTheFlag1v1}, or {@code null}
+     */
+    public static CaptureTheFlag1v1 getActiveCtfMatch(UUID uuid) {
+        return activeMatches.get(uuid);
+    }
+
+    /**
+     * Removes the given player from all active match registrations.
+     * Called automatically when a match ends.
+     *
+     * @param uuid the UUID to deregister
+     */
+    public static void deregisterFromMatch(UUID uuid) {
+        activeMatches.remove(uuid);
+    }
+
+    private static void startCtfMatch(List<SwordPlayer> players) {
+        CaptureTheFlag1v1 match = new CaptureTheFlag1v1(players);
+        for (SwordPlayer sp : players) {
+            activeMatches.put(sp.player().getUniqueId(), match);
+        }
+        match.start();
     }
 }

--- a/src/main/java/btm/sword/gamemode/QueueManager.java
+++ b/src/main/java/btm/sword/gamemode/QueueManager.java
@@ -1,5 +1,7 @@
 package btm.sword.gamemode;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +33,12 @@ public class QueueManager {
      * Populated on match start, cleaned up on match stop.
      */
     private static final Map<UUID, CaptureTheFlag1v1> activeMatches = new HashMap<>();
+
+    /**
+     * All currently active roguelike runs.
+     * Populated when a run starts, removed when it stops.
+     */
+    private static final List<RoguelikeRun> activeRoguelikeRuns = new ArrayList<>();
 
     static {
         queueMap = new HashMap<>();
@@ -78,7 +86,7 @@ public class QueueManager {
         Queue<SwordPlayer> roguelikeQueue = queueMap.get(RoguelikeRun.class);
         if (roguelikeQueue != null && !roguelikeQueue.isEmpty()) {
             SwordPlayer player = roguelikeQueue.poll();
-            new RoguelikeRun(List.of(player)).start();
+            startRoguelikeRun(List.of(player));
         }
 
         Queue<SwordPlayer> ctfQueue = queueMap.get(CaptureTheFlag1v1.class);
@@ -107,6 +115,31 @@ public class QueueManager {
      */
     public static void deregisterFromMatch(UUID uuid) {
         activeMatches.remove(uuid);
+    }
+
+    /**
+     * Returns an unmodifiable view of all currently active roguelike runs.
+     *
+     * @return list of active {@link RoguelikeRun} instances
+     */
+    public static List<RoguelikeRun> getActiveRoguelikeRuns() {
+        return Collections.unmodifiableList(activeRoguelikeRuns);
+    }
+
+    /**
+     * Removes the given roguelike run from the active run registry.
+     * Should be called when the run ends.
+     *
+     * @param run the run to deregister
+     */
+    public static void deregisterRoguelikeRun(RoguelikeRun run) {
+        activeRoguelikeRuns.remove(run);
+    }
+
+    private static void startRoguelikeRun(List<SwordPlayer> players) {
+        RoguelikeRun run = new RoguelikeRun(players);
+        activeRoguelikeRuns.add(run);
+        run.start();
     }
 
     private static void startCtfMatch(List<SwordPlayer> players) {

--- a/src/main/java/btm/sword/gamemode/ctf/CtfTeam.java
+++ b/src/main/java/btm/sword/gamemode/ctf/CtfTeam.java
@@ -1,0 +1,122 @@
+package btm.sword.gamemode.ctf;
+
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.DyeColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.banner.Pattern;
+import org.bukkit.block.banner.PatternType;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BannerMeta;
+
+import btm.sword.config.Config;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+
+/**
+ * Represents one of the two teams in a Capture the Flag match.
+ * <p>
+ * Each team owns a banner colour, a spawn location (read from {@link Config.Ctf}), and a
+ * flag spawn location (same point — the base zone center). Call {@link #createFlagItem()} to
+ * produce a patterned banner {@link ItemStack} suitable for a player helmet or an
+ * {@link org.bukkit.entity.ArmorStand} helmet.
+ * </p>
+ */
+public enum CtfTeam {
+
+    /** The red team. Spawn located at {@code Config.Ctf.RED_SPAWN_*}. */
+    RED(DyeColor.RED, Material.RED_BANNER, NamedTextColor.RED),
+
+    /** The blue team. Spawn located at {@code Config.Ctf.BLUE_SPAWN_*}. */
+    BLUE(DyeColor.BLUE, Material.BLUE_BANNER, NamedTextColor.BLUE);
+
+    private final DyeColor dyeColor;
+    private final Material bannerMaterial;
+    private final NamedTextColor textColor;
+
+    CtfTeam(DyeColor dyeColor, Material bannerMaterial, NamedTextColor textColor) {
+        this.dyeColor = dyeColor;
+        this.bannerMaterial = bannerMaterial;
+        this.textColor = textColor;
+    }
+
+    /**
+     * Returns the DyeColor associated with this team.
+     *
+     * @return team dye colour
+     */
+    public DyeColor getDyeColor() {
+        return dyeColor;
+    }
+
+    /**
+     * Returns the Adventure text colour for this team, used in chat/title messages.
+     *
+     * @return team text colour
+     */
+    public NamedTextColor getTextColor() {
+        return textColor;
+    }
+
+    /**
+     * Returns the opposing team.
+     *
+     * @return the other {@link CtfTeam}
+     */
+    public CtfTeam enemy() {
+        return this == RED ? BLUE : RED;
+    }
+
+    /**
+     * Returns the team's spawn location, read live from {@link Config.Ctf}.
+     * <p>
+     * Falls back to the server's first world if the configured world name is not loaded.
+     * </p>
+     *
+     * @return team spawn {@link Location}
+     */
+    public Location getSpawnLocation() {
+        org.bukkit.World world = Bukkit.getWorld(Config.Ctf.SPAWN_WORLD);
+        if (world == null) world = Bukkit.getWorlds().get(0);
+
+        if (this == RED) {
+            return new Location(world, Config.Ctf.RED_SPAWN_X, Config.Ctf.RED_SPAWN_Y, Config.Ctf.RED_SPAWN_Z);
+        } else {
+            return new Location(world, Config.Ctf.BLUE_SPAWN_X, Config.Ctf.BLUE_SPAWN_Y, Config.Ctf.BLUE_SPAWN_Z);
+        }
+    }
+
+    /**
+     * Creates a team-coloured banner {@link ItemStack} with distinctive patterns.
+     * <p>
+     * RED team:  base red  + white CROSS (+) + white BORDER.<br>
+     * BLUE team: base blue + white STRAIGHT_CROSS (×) + white BORDER.
+     * </p>
+     *
+     * @return a named, patterned banner item
+     */
+    public ItemStack createFlagItem() {
+        ItemStack banner = new ItemStack(bannerMaterial);
+        BannerMeta meta = (BannerMeta) banner.getItemMeta();
+
+        if (this == RED) {
+            meta.setPatterns(List.of(
+                new Pattern(DyeColor.WHITE, PatternType.CROSS),
+                new Pattern(DyeColor.WHITE, PatternType.BORDER)
+            ));
+        } else {
+            meta.setPatterns(List.of(
+                new Pattern(DyeColor.WHITE, PatternType.STRAIGHT_CROSS),
+                new Pattern(DyeColor.WHITE, PatternType.BORDER)
+            ));
+        }
+
+        meta.displayName(Component.text(name() + " FLAG", textColor, TextDecoration.BOLD)
+            .decoration(TextDecoration.ITALIC, false));
+        banner.setItemMeta(meta);
+        return banner;
+    }
+}

--- a/src/main/java/btm/sword/gamemode/ctf/FlagEntity.java
+++ b/src/main/java/btm/sword/gamemode/ctf/FlagEntity.java
@@ -1,0 +1,242 @@
+package btm.sword.gamemode.ctf;
+
+import java.util.concurrent.TimeUnit;
+
+import org.bukkit.Location;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Item;
+import org.bukkit.inventory.ItemStack;
+
+import btm.sword.config.Config;
+import btm.sword.system.control.SwordScheduler;
+import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.utility.Prefab;
+import net.kyori.adventure.text.Component;
+
+/**
+ * Represents a single CTF flag with a three-state lifecycle.
+ *
+ * <h3>States</h3>
+ * <ul>
+ *   <li><b>IDLE</b> — an invisible {@link ArmorStand} wearing the team banner sits at the flag
+ *       spawn location. Any nearby enemy player can pick it up.</li>
+ *   <li><b>CARRIED</b> — the ArmorStand is removed, the banner is placed on the carrier's
+ *       helmet slot, and a {@link Prefab.PotionEffects#FLAG_CARRIER_SLOW} effect is applied.</li>
+ *   <li><b>DROPPED</b> — the carrier lost the flag (died or match intervention). A banner
+ *       {@link Item} entity lies on the ground. After {@link Config.Ctf#FLAG_RETURN_TIMER_SECONDS}
+ *       seconds the flag auto-returns to base.</li>
+ * </ul>
+ *
+ * <p>The owning {@link btm.sword.gamemode.type.CaptureTheFlag1v1} instance drives all transitions
+ * by calling the appropriate methods. No state is self-managed except the auto-return timer.</p>
+ */
+public class FlagEntity {
+
+    /** The three observable states of this flag. */
+    public enum State {
+        /** Flag is at its base spawn, represented by an ArmorStand. */
+        IDLE,
+        /** Flag is being carried by a player (banner on their helmet). */
+        CARRIED,
+        /** Flag was dropped; a ground item exists and the auto-return timer is running. */
+        DROPPED
+    }
+
+    private final CtfTeam team;
+    private State state = State.IDLE;
+
+    private ArmorStand flagStand;
+    private SwordPlayer carrier;
+    private ItemStack carrierPrevHelmet;
+    private Item droppedItem;
+
+    private java.util.concurrent.ScheduledFuture<?> returnTimer;
+
+    /**
+     * Creates a new {@code FlagEntity} for the given team. Call {@link #spawnIdle()} to place it.
+     *
+     * @param team the team this flag belongs to
+     */
+    public FlagEntity(CtfTeam team) {
+        this.team = team;
+    }
+
+    /**
+     * Returns the team that owns this flag.
+     *
+     * @return owning {@link CtfTeam}
+     */
+    public CtfTeam getTeam() {
+        return team;
+    }
+
+    /**
+     * Returns the current state of this flag.
+     *
+     * @return current {@link State}
+     */
+    public State getState() {
+        return state;
+    }
+
+    /**
+     * Returns the player currently carrying this flag, or {@code null} if not {@link State#CARRIED}.
+     *
+     * @return the carrier {@link SwordPlayer}, or {@code null}
+     */
+    public SwordPlayer getCarrier() {
+        return carrier;
+    }
+
+    /**
+     * Spawns the flag at the team's configured spawn location as an idle ArmorStand.
+     * No-ops if the flag is not currently {@link State#IDLE}.
+     */
+    public void spawnIdle() {
+        Location loc = team.getSpawnLocation();
+        spawnIdleAt(loc);
+    }
+
+    private void spawnIdleAt(Location loc) {
+        flagStand = (ArmorStand) loc.getWorld().spawnEntity(loc, EntityType.ARMOR_STAND);
+        flagStand.setVisible(false);
+        flagStand.setGravity(false);
+        flagStand.setMarker(true);
+        flagStand.setCollidable(false);
+        flagStand.customName(Component.text(team.name() + " FLAG", team.getTextColor()));
+        flagStand.setCustomNameVisible(true);
+        flagStand.getEquipment().setHelmet(team.createFlagItem());
+        state = State.IDLE;
+    }
+
+    /**
+     * Transitions the flag from {@link State#IDLE} or {@link State#DROPPED} to
+     * {@link State#CARRIED} for the given player.
+     * <p>
+     * Removes the ArmorStand (or ground item), saves the player's current helmet, equips the
+     * banner on their head, and applies the carrier slow effect.
+     * </p>
+     *
+     * @param player the player picking up the flag
+     */
+    public void pickup(SwordPlayer player) {
+        if (state == State.CARRIED) return;
+
+        cancelReturnTimer();
+
+        if (flagStand != null && flagStand.isValid()) {
+            flagStand.remove();
+            flagStand = null;
+        }
+        if (droppedItem != null && droppedItem.isValid()) {
+            droppedItem.remove();
+            droppedItem = null;
+        }
+
+        carrier = player;
+        carrierPrevHelmet = player.player().getInventory().getHelmet();
+        player.player().getInventory().setHelmet(team.createFlagItem());
+        Prefab.PotionEffects.FLAG_CARRIER_SLOW.apply(player);
+
+        player.message(Component.text("You picked up the " + team.name() + " flag!", team.getTextColor()));
+        state = State.CARRIED;
+    }
+
+    /**
+     * Drops the flag at the given location, transitioning to {@link State#DROPPED}.
+     * <p>
+     * Removes the banner from the carrier's helmet (restoring their previous helmet),
+     * removes the carrier slow effect, and starts the auto-return timer.
+     * </p>
+     *
+     * @param loc the location to drop the flag at
+     */
+    public void drop(Location loc) {
+        if (state != State.CARRIED) return;
+
+        restoreCarrierHelmet();
+        spawnDroppedItem(loc);
+        scheduleReturn();
+        state = State.DROPPED;
+    }
+
+    /**
+     * Immediately returns the flag to its base spawn, transitioning to {@link State#IDLE}.
+     * Works from any state.
+     */
+    public void returnToBase() {
+        cancelReturnTimer();
+        cleanupDroppedItem();
+        cleanupCarrier();
+        spawnIdle();
+    }
+
+    /**
+     * Cleans up all entities and effects managed by this flag. Call when the match ends.
+     */
+    public void cleanup() {
+        cancelReturnTimer();
+        cleanupDroppedItem();
+        cleanupCarrier();
+
+        if (flagStand != null && flagStand.isValid()) {
+            flagStand.remove();
+            flagStand = null;
+        }
+    }
+
+    /**
+     * Returns whether the given player is currently carrying this flag.
+     *
+     * @param player the player to check
+     * @return {@code true} if this flag is {@link State#CARRIED} and {@code player} is the carrier
+     */
+    public boolean isCarriedBy(SwordPlayer player) {
+        return state == State.CARRIED && player.equals(carrier);
+    }
+
+    // --- private helpers ---
+
+    private void restoreCarrierHelmet() {
+        if (carrier == null) return;
+        carrier.player().getInventory().setHelmet(carrierPrevHelmet);
+        carrier.player().removePotionEffect(org.bukkit.potion.PotionEffectType.SLOWNESS);
+        carrier = null;
+        carrierPrevHelmet = null;
+    }
+
+    private void cleanupCarrier() {
+        if (carrier != null) {
+            restoreCarrierHelmet();
+        }
+    }
+
+    private void cleanupDroppedItem() {
+        if (droppedItem != null && droppedItem.isValid()) {
+            droppedItem.remove();
+            droppedItem = null;
+        }
+    }
+
+    private void spawnDroppedItem(Location loc) {
+        droppedItem = loc.getWorld().dropItem(loc, team.createFlagItem());
+        droppedItem.setPickupDelay(Integer.MAX_VALUE); // prevent natural pickup
+        droppedItem.setGravity(true);
+    }
+
+    private void scheduleReturn() {
+        returnTimer = SwordScheduler.runBukkitTaskLater(
+            this::returnToBase,
+            Config.Ctf.FLAG_RETURN_TIMER_SECONDS,
+            TimeUnit.SECONDS
+        );
+    }
+
+    private void cancelReturnTimer() {
+        if (returnTimer != null && !returnTimer.isDone()) {
+            returnTimer.cancel(false);
+            returnTimer = null;
+        }
+    }
+}

--- a/src/main/java/btm/sword/gamemode/type/CaptureTheFlag1v1.java
+++ b/src/main/java/btm/sword/gamemode/type/CaptureTheFlag1v1.java
@@ -110,6 +110,7 @@ public class CaptureTheFlag1v1 extends Gamemode {
 
     @Override
     protected String getTitle() {
+        if (scores == null) return "Capture The Flag 1v1";
         int r = scores.get(CtfTeam.RED);
         int b = scores.get(CtfTeam.BLUE);
         return "CTF \u2665 RED " + r + " - " + b + " BLUE";

--- a/src/main/java/btm/sword/gamemode/type/CaptureTheFlag1v1.java
+++ b/src/main/java/btm/sword/gamemode/type/CaptureTheFlag1v1.java
@@ -45,6 +45,8 @@ public class CaptureTheFlag1v1 extends Gamemode {
     private final FlagEntity redFlag = new FlagEntity(CtfTeam.RED);
     private final FlagEntity blueFlag = new FlagEntity(CtfTeam.BLUE);
 
+    private static final int MATCH_DURATION_SECONDS = 180;
+
     /**
      * Creates a new CTF match. Accepts 1 or 2 players.
      * With 1 player they are assigned to RED; BLUE has no player (solo/debug mode).
@@ -53,6 +55,7 @@ public class CaptureTheFlag1v1 extends Gamemode {
      */
     public CaptureTheFlag1v1(List<SwordPlayer> players) {
         super(players);
+        this.durationSeconds = new java.util.concurrent.atomic.AtomicInteger(MATCH_DURATION_SECONDS);
         scores.put(CtfTeam.RED, 0);
         scores.put(CtfTeam.BLUE, 0);
 
@@ -106,6 +109,11 @@ public class CaptureTheFlag1v1 extends Gamemode {
     protected void onTick(int secondsLeft) {
         checkFlagPickups();
         checkCaptures();
+    }
+
+    @Override
+    protected int getMaxDuration() {
+        return MATCH_DURATION_SECONDS;
     }
 
     @Override

--- a/src/main/java/btm/sword/gamemode/type/CaptureTheFlag1v1.java
+++ b/src/main/java/btm/sword/gamemode/type/CaptureTheFlag1v1.java
@@ -1,79 +1,206 @@
 package btm.sword.gamemode.type;
 
+import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
-import org.bukkit.entity.Player;
+import org.bukkit.Location;
 
+import btm.sword.config.Config;
+import btm.sword.gamemode.ctf.CtfTeam;
+import btm.sword.gamemode.ctf.FlagEntity;
+import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.entity.impl.SwordPlayer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.title.Title;
 
 /**
- * A 1v1 Capture-the-Flag game mode.
- * <p>
- * Two players are teleported to opposing spawn offsets at match start. The player with the
- * higher {@link #captureFlag} count when the 3-minute timer expires wins. Flag captures must
- * be driven externally by calling {@link #captureFlag(SwordPlayer)}.
- * </p>
+ * A 1v1 Capture the Flag game mode.
  *
- * <p>Title display integration is pending — see inline TODOs.</p>
+ * <h3>Rules</h3>
+ * <ul>
+ *   <li>Each team has a flag at their base. Carry the enemy flag back to your base to score.</li>
+ *   <li>First team to {@link Config.Ctf#CAPTURES_TO_WIN} captures wins. If {@code CAPTURES_TO_WIN}
+ *       is 0, the match runs for its full duration and the team with more captures at expiry wins.</li>
+ *   <li>On death: the flag is dropped at the death location and a
+ *       {@link Config.Ctf#RESPAWN_DELAY_SECONDS}-second respawn timer fires before the player
+ *       is returned to their team spawn.</li>
+ * </ul>
+ *
+ * <h3>Capture detection</h3>
+ * <p>Checked each tick: a carrier of the <em>enemy</em> flag standing within
+ * {@link Config.Ctf#CAPTURE_RADIUS} blocks of their <em>own</em> team's spawn location scores.</p>
+ *
+ * <h3>Solo / debug mode</h3>
+ * <p>Supports a single player (RED team only) for testing flag mechanics without a second player.</p>
  */
 public class CaptureTheFlag1v1 extends Gamemode {
 
-    private int p1Score = 0;
-    private int p2Score = 0;
+    private final Map<UUID, CtfTeam> playerTeams = new HashMap<>();
+    private final Map<CtfTeam, Integer> scores = new HashMap<>();
+    private final FlagEntity redFlag = new FlagEntity(CtfTeam.RED);
+    private final FlagEntity blueFlag = new FlagEntity(CtfTeam.BLUE);
 
     /**
-     * Creates a new 1v1 CTF match for the two given players with a 3-minute timer.
+     * Creates a new CTF match. Accepts 1 or 2 players.
+     * With 1 player they are assigned to RED; BLUE has no player (solo/debug mode).
      *
-     * @param players exactly two players participating in the match
+     * @param players 1 or 2 players participating in the match
      */
     public CaptureTheFlag1v1(List<SwordPlayer> players) {
         super(players);
-        this.durationSeconds = new AtomicInteger(180); // 3 minutes
+        scores.put(CtfTeam.RED, 0);
+        scores.put(CtfTeam.BLUE, 0);
+
+        playerTeams.put(players.get(0).player().getUniqueId(), CtfTeam.RED);
+        if (players.size() >= 2) {
+            playerTeams.put(players.get(1).player().getUniqueId(), CtfTeam.BLUE);
+        }
     }
 
     @Override
     protected void onStart() {
-        SwordPlayer sp1 = players.getFirst();
-        Player p1 = sp1.player();
-        SwordPlayer sp2 = players.getLast();
-        Player p2 = sp2.player();
+        for (SwordPlayer sp : players) {
+            CtfTeam team = getTeam(sp);
+            sp.player().teleport(team.getSpawnLocation());
+            sp.message(Component.text("Match started! Carry the enemy flag to your base.",
+                NamedTextColor.YELLOW));
+        }
 
-        p1.teleport(p1.getWorld().getSpawnLocation().add(10, 0, 0));
-        p2.teleport(p2.getWorld().getSpawnLocation().add(-10, 0, 0));
+        redFlag.spawnIdle();
+        blueFlag.spawnIdle();
     }
 
     @Override
     protected void onStop() {
-        SwordPlayer sp1 = players.getFirst();
-        Player p1 = sp1.player();
-        SwordPlayer sp2 = players.getLast();
-        Player p2 = sp2.player();
+        redFlag.cleanup();
+        blueFlag.cleanup();
 
-        String result;
-        if (p1Score > p2Score) result = p1.getName() + " wins!";
-        else if (p2Score > p1Score) result = p2.getName() + " wins!";
-        else result = "Tie!";
-        // TODO: display result title to both players
+        int redScore = scores.get(CtfTeam.RED);
+        int blueScore = scores.get(CtfTeam.BLUE);
+
+        CtfTeam winner;
+        if (redScore > blueScore) winner = CtfTeam.RED;
+        else if (blueScore > redScore) winner = CtfTeam.BLUE;
+        else winner = null;
+
+        String resultText = winner != null
+            ? winner.name() + " WINS! (" + scores.get(winner) + " captures)"
+            : "DRAW! (" + redScore + " - " + blueScore + ")";
+
+        NamedTextColor resultColor = winner != null ? winner.getTextColor() : NamedTextColor.YELLOW;
+
+        for (SwordPlayer sp : players) {
+            sp.player().showTitle(Title.title(
+                Component.text(resultText, resultColor, TextDecoration.BOLD),
+                Component.text("Match over", NamedTextColor.GRAY)
+            ));
+        }
     }
 
     @Override
     protected void onTick(int secondsLeft) {
-        // Optional: update scoreboard, etc.
+        checkFlagPickups();
+        checkCaptures();
     }
 
     @Override
     protected String getTitle() {
-        return "Capture The Flag 1v1";
+        int r = scores.get(CtfTeam.RED);
+        int b = scores.get(CtfTeam.BLUE);
+        return "CTF \u2665 RED " + r + " - " + b + " BLUE";
     }
 
     /**
-     * Records a flag capture for the given player, incrementing their score.
+     * Called by {@link btm.sword.gamemode.QueueManager} (via {@link btm.sword.listeners.PlayerListener})
+     * when a participant dies during the match.
+     * <p>
+     * Drops the flag if the dead player was carrying one, then schedules a delayed respawn
+     * at their team spawn.
+     * </p>
      *
-     * @param p the player who captured the flag
+     * @param dead the player who died
      */
-    public void captureFlag(SwordPlayer p) {
-        if (p.equals(players.getFirst())) p1Score++;
-        else p2Score++;
+    public void onPlayerDeath(SwordPlayer dead) {
+        Location deathLoc = dead.player().getLocation();
+
+        if (redFlag.isCarriedBy(dead)) redFlag.drop(deathLoc);
+        if (blueFlag.isCarriedBy(dead)) blueFlag.drop(deathLoc);
+
+        int delaySeconds = Config.Ctf.RESPAWN_DELAY_SECONDS;
+        SwordScheduler.runBukkitTaskLater(() -> {
+            dead.player().spigot().respawn();
+            SwordScheduler.runBukkitTask(() -> {
+                CtfTeam team = getTeam(dead);
+                dead.player().teleport(team.getSpawnLocation());
+                dead.message(Component.text("Respawned at " + team.name() + " base.", team.getTextColor()));
+            });
+        }, delaySeconds, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Returns the {@link CtfTeam} assigned to the given player. Defaults to RED for unknown players.
+     *
+     * @param player the player to look up
+     * @return the player's team
+     */
+    public CtfTeam getTeam(SwordPlayer player) {
+        return playerTeams.getOrDefault(player.player().getUniqueId(), CtfTeam.RED);
+    }
+
+    // --- private tick logic ---
+
+    private void checkFlagPickups() {
+        for (SwordPlayer sp : players) {
+            CtfTeam team = getTeam(sp);
+            FlagEntity enemyFlag = getFlagFor(team.enemy());
+
+            if (enemyFlag.getState() == FlagEntity.State.IDLE
+                    && sp.player().getLocation().distance(team.enemy().getSpawnLocation())
+                        <= Config.Ctf.CAPTURE_RADIUS) {
+                enemyFlag.pickup(sp);
+            }
+        }
+    }
+
+    private void checkCaptures() {
+        for (SwordPlayer sp : players) {
+            CtfTeam team = getTeam(sp);
+            FlagEntity enemyFlag = getFlagFor(team.enemy());
+
+            if (enemyFlag.isCarriedBy(sp)) {
+                Location ownBase = team.getSpawnLocation();
+                if (sp.player().getLocation().distance(ownBase) <= Config.Ctf.CAPTURE_RADIUS) {
+                    score(team, sp, enemyFlag);
+                }
+            }
+        }
+    }
+
+    private void score(CtfTeam team, SwordPlayer scorer, FlagEntity capturedFlag) {
+        scores.merge(team, 1, Integer::sum);
+        int newScore = scores.get(team);
+
+        capturedFlag.returnToBase();
+
+        Component captureMsg = Component.text(scorer.player().getName() + " captured the flag! ", team.getTextColor())
+            .append(Component.text("(" + team.name() + ": " + newScore + ")", NamedTextColor.YELLOW));
+
+        for (SwordPlayer sp : players) {
+            sp.message(captureMsg);
+        }
+
+        int threshold = Config.Ctf.CAPTURES_TO_WIN;
+        if (threshold > 0 && newScore >= threshold) {
+            stop();
+        }
+    }
+
+    private FlagEntity getFlagFor(CtfTeam team) {
+        return team == CtfTeam.RED ? redFlag : blueFlag;
     }
 }

--- a/src/main/java/btm/sword/gamemode/type/Gamemode.java
+++ b/src/main/java/btm/sword/gamemode/type/Gamemode.java
@@ -80,7 +80,7 @@ public abstract class Gamemode {
             },
             () -> {},
             0,
-            20,
+            1000,
             Gamemode.class, "startTimer",
             new PredicateRunnablePair(
                 () -> durationSeconds.get() <= 0,

--- a/src/main/java/btm/sword/gamemode/type/RoguelikeRun.java
+++ b/src/main/java/btm/sword/gamemode/type/RoguelikeRun.java
@@ -1,0 +1,175 @@
+package btm.sword.gamemode.type;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Display;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.TextDisplay;
+
+import btm.sword.config.Config;
+import btm.sword.system.entity.SwordEntityArbiter;
+import btm.sword.system.entity.impl.SwordPlayer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+
+/**
+ * A wave-based roguelike run for one or more players.
+ * <p>
+ * Players survive {@value #TOTAL_WAVES} escalating waves of enemies. After the final wave
+ * is cleared a {@link TextDisplay} reward chest marker appears at the spawn centre.
+ * The run ends either when all waves are cleared or when the 15-minute safety cap
+ * ({@value #MAX_DURATION_SECONDS}s) expires.
+ * </p>
+ *
+ * <p>Spawn centre and per-wave enemy counts are configured via {@link Config.Roguelike}
+ * and are hot-reloadable with {@code /sword reload}.</p>
+ */
+public class RoguelikeRun extends Gamemode {
+
+    private static final int TOTAL_WAVES = 3;
+    private static final int MAX_DURATION_SECONDS = 900; // 15-minute safety cap
+
+    private int currentWave = 0;
+    private boolean runComplete = false;
+    private final List<LivingEntity> currentWaveEnemies = new ArrayList<>();
+    private final Random random = new Random();
+
+    /**
+     * Creates a new roguelike run for the given players.
+     *
+     * @param players players participating in this run
+     */
+    public RoguelikeRun(List<SwordPlayer> players) {
+        super(players);
+        this.durationSeconds = new AtomicInteger(MAX_DURATION_SECONDS);
+    }
+
+    @Override
+    protected int getMaxDuration() {
+        return MAX_DURATION_SECONDS;
+    }
+
+    @Override
+    protected String getTitle() {
+        if (runComplete) {
+            return "Roguelike - Complete!";
+        }
+        return "Roguelike - Wave " + currentWave + "/" + TOTAL_WAVES;
+    }
+
+    @Override
+    protected void onStart() {
+        Location spawnLoc = getSpawnCenter();
+        for (SwordPlayer sp : players) {
+            sp.player().teleport(spawnLoc);
+        }
+        spawnNextWave();
+    }
+
+    @Override
+    protected void onTick(int secondsLeft) {
+        if (currentWaveEnemies.isEmpty()) {
+            return;
+        }
+        currentWaveEnemies.removeIf(e -> e.isDead() || !e.isValid());
+        if (currentWaveEnemies.isEmpty()) {
+            if (currentWave >= TOTAL_WAVES) {
+                runComplete = true;
+                spawnRewardChest();
+                stop();
+            } else {
+                spawnNextWave();
+            }
+        }
+    }
+
+    @Override
+    protected void onStop() {
+        for (LivingEntity e : currentWaveEnemies) {
+            if (e.isValid()) {
+                e.remove();
+            }
+        }
+        currentWaveEnemies.clear();
+
+        Component resultMsg = runComplete
+            ? Component.text("Run complete! Collect your rewards.", NamedTextColor.GOLD, TextDecoration.BOLD)
+            : Component.text("The roguelike run has ended.", NamedTextColor.RED);
+
+        for (SwordPlayer sp : players) {
+            sp.message(resultMsg);
+        }
+    }
+
+    private void spawnNextWave() {
+        currentWave++;
+        currentWaveEnemies.clear();
+
+        Location center = getSpawnCenter();
+        World world = center.getWorld();
+
+        for (EnemySpec spec : getWaveSpec(currentWave)) {
+            for (int i = 0; i < spec.count(); i++) {
+                Location spawnLoc = randomSpawnLocation(center, Config.Roguelike.SPAWN_RADIUS);
+                LivingEntity mob = (LivingEntity) world.spawnEntity(spawnLoc, spec.entityType());
+                SwordEntityArbiter.getOrAdd(mob);
+                currentWaveEnemies.add(mob);
+            }
+        }
+
+        Component waveMsg = Component.text("Wave " + currentWave + " of " + TOTAL_WAVES + " begins!", NamedTextColor.YELLOW);
+        for (SwordPlayer sp : players) {
+            sp.message(waveMsg);
+        }
+    }
+
+    private void spawnRewardChest() {
+        Location chestLoc = getSpawnCenter().add(0, 2, 0);
+        TextDisplay display = (TextDisplay) chestLoc.getWorld().spawnEntity(chestLoc, EntityType.TEXT_DISPLAY);
+        display.text(Component.text("✧ Reward Chest ✧", NamedTextColor.GOLD, TextDecoration.BOLD));
+        display.setBillboard(Display.Billboard.CENTER);
+        // TODO: #285 - distribute MiscItems (Soulfire Flask, Skill Scroll) once item system exists
+    }
+
+    private Location getSpawnCenter() {
+        World world = Bukkit.getWorld(Config.Roguelike.SPAWN_WORLD);
+        if (world == null) {
+            world = Bukkit.getWorlds().get(0);
+        }
+        return new Location(world, Config.Roguelike.SPAWN_X, Config.Roguelike.SPAWN_Y, Config.Roguelike.SPAWN_Z);
+    }
+
+    private Location randomSpawnLocation(Location center, double radius) {
+        double angle = random.nextDouble() * 2 * Math.PI;
+        double distance = random.nextDouble() * radius;
+        double x = center.getX() + distance * Math.cos(angle);
+        double z = center.getZ() + distance * Math.sin(angle);
+        return new Location(center.getWorld(), x, center.getY(), z);
+    }
+
+    private List<EnemySpec> getWaveSpec(int wave) {
+        return switch (wave) {
+            case 1 -> List.of(
+                new EnemySpec(EntityType.PILLAGER, Config.Roguelike.WAVE_1_PILLAGERS)
+            );
+            case 2 -> List.of(
+                new EnemySpec(EntityType.WITHER_SKELETON, Config.Roguelike.WAVE_2_WITHER_SKELETONS)
+            );
+            case 3 -> List.of(
+                new EnemySpec(EntityType.PILLAGER, Config.Roguelike.WAVE_3_PILLAGERS),
+                new EnemySpec(EntityType.WITHER_SKELETON, Config.Roguelike.WAVE_3_WITHER_SKELETONS)
+            );
+            default -> List.of();
+        };
+    }
+
+    private record EnemySpec(EntityType entityType, int count) {}
+}

--- a/src/main/java/btm/sword/gamemode/type/RoguelikeRun.java
+++ b/src/main/java/btm/sword/gamemode/type/RoguelikeRun.java
@@ -25,7 +25,7 @@ import net.kyori.adventure.text.format.TextDecoration;
  * <p>
  * Players survive {@value #TOTAL_WAVES} escalating waves of enemies. After the final wave
  * is cleared a {@link TextDisplay} reward chest marker appears at the spawn centre.
- * The run ends either when all waves are cleared or when the 15-minute safety cap
+ * The run ends either when all waves are cleared or when the 5-minute safety cap
  * ({@value #MAX_DURATION_SECONDS}s) expires.
  * </p>
  *
@@ -35,7 +35,7 @@ import net.kyori.adventure.text.format.TextDecoration;
 public class RoguelikeRun extends Gamemode {
 
     private static final int TOTAL_WAVES = 3;
-    private static final int MAX_DURATION_SECONDS = 900; // 15-minute safety cap
+    private static final int MAX_DURATION_SECONDS = 300; // 5-minute safety cap
 
     private int currentWave = 0;
     private boolean runComplete = false;

--- a/src/main/java/btm/sword/gamemode/type/RoguelikeRun.java
+++ b/src/main/java/btm/sword/gamemode/type/RoguelikeRun.java
@@ -14,6 +14,7 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.TextDisplay;
 
 import btm.sword.config.Config;
+import btm.sword.gamemode.QueueManager;
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.impl.SwordPlayer;
 import net.kyori.adventure.text.Component;
@@ -93,6 +94,8 @@ public class RoguelikeRun extends Gamemode {
 
     @Override
     protected void onStop() {
+        QueueManager.deregisterRoguelikeRun(this);
+
         for (LivingEntity e : currentWaveEnemies) {
             if (e.isValid()) {
                 e.remove();

--- a/src/main/java/btm/sword/listeners/ErrorListener.java
+++ b/src/main/java/btm/sword/listeners/ErrorListener.java
@@ -1,0 +1,65 @@
+package btm.sword.listeners;
+
+import java.util.concurrent.TimeUnit;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+import com.destroystokyo.paper.event.server.ServerExceptionEvent;
+
+import btm.sword.Sword;
+import btm.sword.system.control.SwordScheduler;
+import btm.sword.utility.SwordTimeUnit;
+
+/**
+ * Central error-handling listener for the Sword plugin.
+ * <p>
+ * Captures {@link ServerExceptionEvent} and logs it with full context so server errors
+ * are never silently swallowed.  Also exposes {@link #safeRemove(Entity)}, a drop-in
+ * replacement for {@link Entity#remove()} that catches Paper's chunk-system guard
+ * ({@code "prevented from being removed … processing section status updates"}) and
+ * automatically defers the removal to the following tick.
+ * </p>
+ */
+public class ErrorListener implements Listener {
+
+    /**
+     * Logs every unhandled server exception with its source, message, and stack trace.
+     *
+     * @param event the server exception event fired by Paper
+     */
+    @EventHandler
+    public void onServerException(ServerExceptionEvent event) {
+        Throwable ex = event.getException();
+        Sword.getInstance().getLogger().severe(
+            "[ErrorListener] Unhandled server exception (" + ex.getClass().getSimpleName() + "): " + ex.getMessage()
+        );
+        ex.printStackTrace();
+    }
+
+    // -----------------------------------------------------------------------
+    // Static utilities
+
+    /**
+     * Attempts to remove an entity immediately.  If Paper's chunk-system guard prevents
+     * the removal (entity is mid-section-status-update), the call is deferred one tick
+     * and a warning is logged.
+     *
+     * <p>Safe to call with {@code null} or already-dead entities — both are no-ops.</p>
+     *
+     * @param entity the entity to remove, or {@code null}
+     */
+    public static void safeRemove(Entity entity) {
+        if (entity == null || !entity.isValid()) return;
+        try {
+            entity.remove();
+        } catch (Exception e) {
+            Sword.getInstance().getLogger().warning(
+                "[ErrorListener] Could not remove " + entity.getType()
+                    + " (uuid=" + entity.getUniqueId() + ") immediately — deferring 1 tick. Reason: " + e.getMessage()
+            );
+            SwordScheduler.runBukkitTaskLater(entity::remove, SwordTimeUnit.MILLISECONDS_PER_TICK, TimeUnit.MILLISECONDS);
+        }
+    }
+}

--- a/src/main/java/btm/sword/listeners/ErrorListener.java
+++ b/src/main/java/btm/sword/listeners/ErrorListener.java
@@ -42,9 +42,13 @@ public class ErrorListener implements Listener {
     // Static utilities
 
     /**
-     * Attempts to remove an entity immediately.  If Paper's chunk-system guard prevents
-     * the removal (entity is mid-section-status-update), the call is deferred one tick
-     * and a warning is logged.
+     * Removes an entity, always deferring to the following tick.
+     *
+     * <p>Paper's chunk system silently drops {@code entity.remove()} calls made while
+     * section-status updates are processing (e.g. inside {@code EntityRemoveFromWorldEvent}).
+     * It does not throw — it just logs a warning and returns, leaving the entity alive.
+     * Deferring by one tick guarantees the chunk lock has been released before the
+     * removal executes.</p>
      *
      * <p>Safe to call with {@code null} or already-dead entities — both are no-ops.</p>
      *
@@ -52,14 +56,6 @@ public class ErrorListener implements Listener {
      */
     public static void safeRemove(Entity entity) {
         if (entity == null || !entity.isValid()) return;
-        try {
-            entity.remove();
-        } catch (Exception e) {
-            Sword.getInstance().getLogger().warning(
-                "[ErrorListener] Could not remove " + entity.getType()
-                    + " (uuid=" + entity.getUniqueId() + ") immediately — deferring 1 tick. Reason: " + e.getMessage()
-            );
-            SwordScheduler.runBukkitTaskLater(entity::remove, SwordTimeUnit.MILLISECONDS_PER_TICK, TimeUnit.MILLISECONDS);
-        }
+        SwordScheduler.runBukkitTaskLater(entity::remove, SwordTimeUnit.MILLISECONDS_PER_TICK, TimeUnit.MILLISECONDS);
     }
 }

--- a/src/main/java/btm/sword/listeners/PlayerListener.java
+++ b/src/main/java/btm/sword/listeners/PlayerListener.java
@@ -28,6 +28,8 @@ import org.intellij.lang.annotations.Subst;
 
 import btm.sword.Sword;
 import btm.sword.config.Config;
+import btm.sword.gamemode.QueueManager;
+import btm.sword.gamemode.type.CaptureTheFlag1v1;
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.impl.SwordPlayer;
@@ -60,8 +62,8 @@ public class PlayerListener implements Listener {
     /**
      * Handles player death events.
      * <p>
-     * Currently unimplemented, but can be used in the future to track death-related
-     * statistics or handle cleanup of transient effects.
+     * Forwards the death to the player's active CTF match (if any) so the match can drop
+     * the carried flag and schedule a respawn.
      * </p>
      *
      * @param event the {@link PlayerDeathEvent} triggered when a player dies
@@ -69,6 +71,12 @@ public class PlayerListener implements Listener {
     @EventHandler
     public void onPlayerDeath(PlayerDeathEvent event) {
         SwordEntityArbiter.getOrAdd(event.getPlayer()).onDeath();
+
+        CaptureTheFlag1v1 match = QueueManager.getActiveCtfMatch(event.getPlayer().getUniqueId());
+        if (match != null) {
+            SwordPlayer dead = (SwordPlayer) SwordEntityArbiter.getOrAdd(event.getPlayer());
+            match.onPlayerDeath(dead);
+        }
     }
 
     /**

--- a/src/main/java/btm/sword/listeners/SystemListener.java
+++ b/src/main/java/btm/sword/listeners/SystemListener.java
@@ -6,7 +6,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.world.WorldUnloadEvent;
 
-import com.destroystokyo.paper.event.server.ServerExceptionEvent;
 import com.destroystokyo.paper.event.server.ServerTickEndEvent;
 
 import btm.sword.system.entity.SwordEntityArbiter;
@@ -32,8 +31,8 @@ public class SystemListener implements Listener {
         SwordEntityArbiter.removeAllDisplays();
         // Clean up any status displays in this world
         for (Entity entity : event.getWorld().getEntitiesByClass(TextDisplay.class)) {
-            if (entity.getScoreboardTags().contains("remove_on_shutdown") && entity.isValid() && !entity.isDead()) {
-                entity.remove();
+            if (entity.getScoreboardTags().contains("remove_on_shutdown")) {
+                ErrorListener.safeRemove(entity);
             }
         }
     }
@@ -43,8 +42,4 @@ public class SystemListener implements Listener {
 
     }
 
-    @EventHandler
-    public void onStop(ServerExceptionEvent event) {
-
-    }
 }

--- a/src/main/java/btm/sword/system/action/constraint/CommonConstraints.java
+++ b/src/main/java/btm/sword/system/action/constraint/CommonConstraints.java
@@ -98,7 +98,7 @@ public final class CommonConstraints {
      *
      * <p>Full enforcement (no dash, no grab, no block while carrying) is pending a global context
      * constraint system on {@code Combatant}. Until then, only the speed debuff is active.
-     * See GitHub issue #TODO for the refactor tracking this.</p>
+     * See GitHub issue #297 for the refactor tracking this.</p>
      */
     public static final ActionConstraint NOT_CARRYING_FLAG = c -> true;
 }

--- a/src/main/java/btm/sword/system/action/constraint/CommonConstraints.java
+++ b/src/main/java/btm/sword/system/action/constraint/CommonConstraints.java
@@ -92,4 +92,13 @@ public final class CommonConstraints {
      */
     public static final ActionConstraint NOT_BLOCKING =
         c -> !(c instanceof SwordPlayer sp) || !sp.isBlocking();
+
+    /**
+     * Stub — always passes. Intended to block actions while the player is carrying a CTF flag.
+     *
+     * <p>Full enforcement (no dash, no grab, no block while carrying) is pending a global context
+     * constraint system on {@code Combatant}. Until then, only the speed debuff is active.
+     * See GitHub issue #TODO for the refactor tracking this.</p>
+     */
+    public static final ActionConstraint NOT_CARRYING_FLAG = c -> true;
 }

--- a/src/main/java/btm/sword/system/entity/SwordTeam.java
+++ b/src/main/java/btm/sword/system/entity/SwordTeam.java
@@ -1,0 +1,61 @@
+package btm.sword.system.entity;
+
+import org.bukkit.entity.LivingEntity;
+
+/**
+ * Faction tags used to suppress friendly fire between allied entities.
+ * <p>
+ * Each constant corresponds to a Bukkit scoreboard tag applied to every {@link btm.sword.system.entity.base.SwordEntity}
+ * via {@link btm.sword.system.entity.base.SwordEntity#joinTeam(SwordTeam)} on spawn.
+ * The raw {@code hit()} path in {@code SwordEntity} skips damage when the attacker and defender
+ * share the same tag.
+ * </p>
+ *
+ * <ul>
+ *   <li>{@link #RED}    — hostile mobs ({@link btm.sword.system.entity.impl.Hostile})</li>
+ *   <li>{@link #BLUE}   — players ({@link btm.sword.system.entity.impl.SwordPlayer})</li>
+ *   <li>{@link #GREEN}  — passive entities ({@link btm.sword.system.entity.impl.Passive})</li>
+ *   <li>{@link #YELLOW} — reserved for future use</li>
+ * </ul>
+ */
+public enum SwordTeam {
+
+    /** Hostile mobs — assigned in {@link btm.sword.system.entity.impl.Hostile#onSpawn()}. */
+    RED("sword_team_red"),
+
+    /** Players — assigned in {@link btm.sword.system.entity.impl.SwordPlayer#onSpawn()}. */
+    BLUE("sword_team_blue"),
+
+    /** Passive entities — assigned in {@link btm.sword.system.entity.impl.Passive#onSpawn()}. */
+    GREEN("sword_team_green"),
+
+    /** Reserved for future faction use. */
+    YELLOW("sword_team_yellow");
+
+    private final String tag;
+
+    SwordTeam(String tag) {
+        this.tag = tag;
+    }
+
+    /** Returns the scoreboard tag string applied to Bukkit entities on this team. */
+    public String tag() {
+        return tag;
+    }
+
+    /**
+     * Returns the {@link SwordTeam} for the given entity by inspecting its scoreboard tags,
+     * or {@code null} if the entity carries no sword team tag.
+     *
+     * @param entity the entity to inspect
+     * @return the matching team, or {@code null}
+     */
+    public static SwordTeam fromEntity(LivingEntity entity) {
+        for (SwordTeam team : values()) {
+            if (entity.getScoreboardTags().contains(team.tag)) {
+                return team;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/btm/sword/system/entity/base/SwordEntity.java
+++ b/src/main/java/btm/sword/system/entity/base/SwordEntity.java
@@ -42,6 +42,7 @@ import btm.sword.system.control.PredicateRunnablePair;
 import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.SwordEntityArbiter;
+import btm.sword.system.entity.SwordTeam;
 import btm.sword.system.entity.aspect.AspectType;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
@@ -544,6 +545,11 @@ public abstract class SwordEntity {
                     float baseSoulfireReduction,
                     Vector knockbackVelocity,
                     Affliction... afflictions) {
+        SwordTeam attackerTeam = SwordTeam.fromEntity(source.self());
+        if (attackerTeam != null && attackerTeam == SwordTeam.fromEntity(self)) {
+            return;
+        }
+
         if (hit)
             return;
         else
@@ -678,6 +684,29 @@ public abstract class SwordEntity {
      */
     public void displayShardLoss() {
         // TODO: later
+    }
+
+    /**
+     * Assigns this entity to the given {@link SwordTeam} by updating its Bukkit scoreboard tags.
+     * Any previously held sword team tag is removed first.
+     *
+     * @param team the team to join
+     */
+    public void joinTeam(SwordTeam team) {
+        for (SwordTeam existing : SwordTeam.values()) {
+            self.removeScoreboardTag(existing.tag());
+        }
+        self.addScoreboardTag(team.tag());
+    }
+
+    /**
+     * Returns this entity's current {@link SwordTeam} by reading its Bukkit scoreboard tags,
+     * or {@code null} if no sword team tag is present.
+     *
+     * @return the team, or {@code null}
+     */
+    public SwordTeam getTeam() {
+        return SwordTeam.fromEntity(self);
     }
 
     /**

--- a/src/main/java/btm/sword/system/entity/display/DisplayRig.java
+++ b/src/main/java/btm/sword/system/entity/display/DisplayRig.java
@@ -112,10 +112,26 @@ public class DisplayRig {
             return null;
         }
 
-        SpawnedDisplayEntityGroup group = def.spawn(mob.getLocation(), GroupSpawnedEvent.SpawnReason.CUSTOM);
+        SpawnedDisplayEntityGroup group;
+        try {
+            group = def.spawn(mob.getLocation(), GroupSpawnedEvent.SpawnReason.CUSTOM);
+        } catch (Exception e) {
+            Sword.getInstance().getLogger().warning(
+                "[DisplayRig] Exception while spawning group '" + groupTag + "': " + e.getMessage()
+            );
+            return null;
+        }
         if (group == null) return null;
 
-        group.rideEntity(mob);
+        try {
+            group.rideEntity(mob);
+        } catch (Exception e) {
+            Sword.getInstance().getLogger().warning(
+                "[DisplayRig] Exception while mounting group '" + groupTag + "' to mob: " + e.getMessage()
+            );
+            group.unregister(true, true);
+            return null;
+        }
 
         for (Display display : group.getPartEntities(Display.class)) {
             display.setTeleportDuration(Config.Hostile.DISPLAY_TELEPORT_DURATION);
@@ -296,7 +312,13 @@ public class DisplayRig {
         DEUAnimationHook.untrack(group);
         clearWeaponDisplay();
         stateMachine.removeGroup(group);
-        group.unregister(true, true);
+        try {
+            group.unregister(true, true);
+        } catch (Exception e) {
+            Sword.getInstance().getLogger().warning(
+                "[DisplayRig] Exception while unregistering display group — entities may not have been removed cleanly: " + e.getMessage()
+            );
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/src/main/java/btm/sword/system/entity/display/DisplayRig.java
+++ b/src/main/java/btm/sword/system/entity/display/DisplayRig.java
@@ -1,6 +1,7 @@
 package btm.sword.system.entity.display;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Display;
@@ -13,8 +14,10 @@ import org.joml.Vector3f;
 
 import btm.sword.Sword;
 import btm.sword.config.Config;
+import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.mob.AnimationSlots;
+import btm.sword.utility.SwordTimeUnit;
 import net.donnypz.displayentityutils.events.GroupSpawnedEvent;
 import net.donnypz.displayentityutils.managers.DisplayGroupManager;
 import net.donnypz.displayentityutils.managers.LoadMethod;
@@ -307,18 +310,24 @@ public class DisplayRig {
     /**
      * Removes the spawned group from the world and unregisters the state machine.
      * Must be called when the mob dies or is removed.
+     *
+     * <p>State-machine and packet-hook teardown happens synchronously so no further
+     * animation or weapon-override packets are sent.  The actual entity removal
+     * ({@code group.unregister}) is deferred one tick because this method is often
+     * invoked during {@code EntityRemoveFromWorldEvent}, at which point Paper's chunk
+     * system may have the section locked and will silently drop any {@code entity.remove()}
+     * calls made on the same tick.</p>
      */
     public void despawn() {
         DEUAnimationHook.untrack(group);
         clearWeaponDisplay();
         stateMachine.removeGroup(group);
-        try {
-            group.unregister(true, true);
-        } catch (Exception e) {
-            Sword.getInstance().getLogger().warning(
-                "[DisplayRig] Exception while unregistering display group — entities may not have been removed cleanly: " + e.getMessage()
-            );
-        }
+        SpawnedDisplayEntityGroup groupRef = this.group;
+        SwordScheduler.runBukkitTaskLater(
+            () -> groupRef.unregister(true, true),
+            SwordTimeUnit.MILLISECONDS_PER_TICK,
+            TimeUnit.MILLISECONDS
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/src/main/java/btm/sword/system/entity/impl/Hostile.java
+++ b/src/main/java/btm/sword/system/entity/impl/Hostile.java
@@ -212,6 +212,7 @@ public class Hostile extends Combatant {
     @Override
     public void onSpawn() {
         super.onSpawn();
+        joinTeam(btm.sword.system.entity.SwordTeam.RED);
         ((Resource) aspects.getAspect(AspectType.SHARDS)).stopRegenTask(); // prevent regen of shards
         MobGoalArbiter.GOALS.removeAllGoals(mob); // clear all vanilla goals before starting custom AI
         aiStateMachine = new HostileStateMachine(this, new IdleState());

--- a/src/main/java/btm/sword/system/entity/impl/Hostile.java
+++ b/src/main/java/btm/sword/system/entity/impl/Hostile.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.bukkit.GameMode;
@@ -26,6 +27,7 @@ import com.destroystokyo.paper.entity.ai.GoalType;
 
 import btm.sword.system.action.throwing.types.DroppedItem;
 import btm.sword.system.action.throwing.types.ThrownItem;
+import btm.sword.system.combat.Affliction;
 import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.entity.ai.HostileStateMachine;
 import btm.sword.system.entity.ai.MobGoalArbiter;
@@ -41,6 +43,7 @@ import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.display.DisplayRig;
 import btm.sword.system.entity.mob.MobTypeDefinition;
 import btm.sword.system.entity.mob.MobTypeRegistry;
+import btm.sword.system.item.SwordItemType;
 import btm.sword.system.item.weapon.WeaponType;
 import btm.sword.utility.Debug;
 import lombok.Getter;
@@ -77,6 +80,12 @@ public class Hostile extends Combatant {
 
     /** Per-ability cooldown counters (ticks remaining). Decremented each tick; removed at 0. */
     private final Map<String, Integer> abilityCooldowns;
+
+    /**
+     * Log of every hit this mob received from a player, accumulated over its lifetime.
+     * Each entry records the attacker, weapon used, and damage split by type.
+     */
+    private final List<DamageEntry> damageLog = new ArrayList<>();
 
     /** {@code true} while this mob is grabbed — suppresses AI movement and attack execution. */
     private boolean incapacitated;
@@ -412,4 +421,50 @@ public class Hostile extends Combatant {
     public Location getOrigin() {
         return this.origin.clone();
     }
+
+    /**
+     * Records damage to {@link #damageLog} when the hit actually lands (i.e. not filtered by
+     * the invulnerability window), then delegates to the superclass implementation.
+     *
+     * @param source                   the {@link Combatant} dealing the hit
+     * @param reapedSoulfire           soulfire transferred from this entity to the attacker
+     * @param hitInvulnerableTickDuration invulnerability frames granted after this hit
+     * @param baseNumShards            raw shard (HP) damage
+     * @param baseToughnessDamage      raw toughness damage
+     * @param baseSoulfireReduction    soulfire drained from this entity
+     * @param knockbackVelocity        velocity to apply as knockback
+     * @param afflictions              optional afflictions to apply
+     */
+    @Override
+    public void hit(Combatant source,
+                    float reapedSoulfire,
+                    long hitInvulnerableTickDuration,
+                    int baseNumShards,
+                    float baseToughnessDamage,
+                    float baseSoulfireReduction,
+                    Vector knockbackVelocity,
+                    Affliction... afflictions) {
+        if (!isHit() && source instanceof SwordPlayer sp) {
+            SwordItemType weapon = SwordItemType.fromString(sp.getItemStackInHand(true));
+            damageLog.add(new DamageEntry(sp.player().getUniqueId(), sp.player().getName(), weapon, baseNumShards, baseToughnessDamage));
+        }
+        super.hit(source, reapedSoulfire, hitInvulnerableTickDuration, baseNumShards, baseToughnessDamage, baseSoulfireReduction, knockbackVelocity, afflictions);
+    }
+
+    /**
+     * A single damage event recorded against this mob.
+     *
+     * @param attackerUuid    UUID of the attacking player
+     * @param attackerName    display name of the attacking player at time of hit
+     * @param weapon          the {@link SwordItemType} held by the attacker
+     * @param shardDamage     raw shard (HP) damage dealt
+     * @param toughnessDamage raw toughness damage dealt
+     */
+    public record DamageEntry(
+        UUID attackerUuid,
+        String attackerName,
+        SwordItemType weapon,
+        int shardDamage,
+        float toughnessDamage
+    ) {}
 }

--- a/src/main/java/btm/sword/system/entity/impl/Passive.java
+++ b/src/main/java/btm/sword/system/entity/impl/Passive.java
@@ -14,7 +14,7 @@ public class Passive extends SwordEntity {
     @Override
     public void onSpawn() {
         super.onSpawn();
-
+        joinTeam(btm.sword.system.entity.SwordTeam.GREEN);
     }
 
     @Override

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -393,6 +393,7 @@ public class SwordPlayer extends Combatant {
     @Override
     public void onSpawn() {
         super.onSpawn();
+        joinTeam(btm.sword.system.entity.SwordTeam.BLUE);
     }
 
     /**

--- a/src/main/java/btm/sword/system/input/InputRegistrar.java
+++ b/src/main/java/btm/sword/system/input/InputRegistrar.java
@@ -518,7 +518,7 @@ public class InputRegistrar {
                         .displayDisabled(true)
                         .resetIfCannotPerform(false)
                         .build(),
-                    SwordPlayer::normalNonAbilityState),
+                    SwordPlayer::umbralBladeState),
                 new InputExecutionTree.ActionContextPair(
                     () -> InputAction.builder()
                         .action(executor -> UmbralBladeAction.basicAttackWithLink(executor, comboStep))
@@ -530,7 +530,7 @@ public class InputRegistrar {
                         .displayDisabled(true)
                         .resetIfCannotPerform(!isLast)
                         .build(),
-                    SwordPlayer::normalNonAbilityState),
+                    SwordPlayer::soulLinkState),
                 new InputExecutionTree.ActionContextPair(
                     () -> InputAction.builder()
                         .action(executor -> AttackAction.basicAttack(executor, comboStep))

--- a/src/main/java/btm/sword/system/inventory/InventoryMenuManager.java
+++ b/src/main/java/btm/sword/system/inventory/InventoryMenuManager.java
@@ -8,22 +8,23 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import btm.sword.system.entity.impl.SwordPlayer;
-import btm.sword.system.inventory.menu.AnimationBrowserMenu;
 import btm.sword.system.inventory.menu.ArtifactPouchMenu;
 import btm.sword.system.inventory.menu.CharacterMenu;
-import btm.sword.system.inventory.menu.ConfigMenu;
-import btm.sword.system.inventory.menu.CreativeInventoryMenu;
 import btm.sword.system.inventory.menu.CurrencyMenu;
-import btm.sword.system.inventory.menu.DEUBDEMenu;
-import btm.sword.system.inventory.menu.DeuGroupBrowserMenu;
-import btm.sword.system.inventory.menu.DevMenu;
 import btm.sword.system.inventory.menu.DevStatEditorMenu;
 import btm.sword.system.inventory.menu.ItemLibraryMenu;
 import btm.sword.system.inventory.menu.MainMenu;
 import btm.sword.system.inventory.menu.MaterialPouchMenu;
 import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.inventory.menu.MovesetMenu;
-import btm.sword.system.inventory.menu.WeaponDisplayEditorMenu;
+import btm.sword.system.inventory.menu.dev.AnimationBrowserMenu;
+import btm.sword.system.inventory.menu.dev.ConfigMenu;
+import btm.sword.system.inventory.menu.dev.CreativeInventoryMenu;
+import btm.sword.system.inventory.menu.dev.DEUBDEMenu;
+import btm.sword.system.inventory.menu.dev.DeuGroupBrowserMenu;
+import btm.sword.system.inventory.menu.dev.DevMenu;
+import btm.sword.system.inventory.menu.dev.TestingMenu;
+import btm.sword.system.inventory.menu.dev.WeaponDisplayEditorMenu;
 
 public class InventoryMenuManager {
     private static final Map<Class<? extends Menu>, Function<SwordPlayer, ? extends Menu>> MENU_REGISTRY = new ConcurrentHashMap<>();
@@ -48,6 +49,7 @@ public class InventoryMenuManager {
         register(ArtifactPouchMenu.class, ArtifactPouchMenu::new);
         register(ItemLibraryMenu.class, ItemLibraryMenu::new);
         register(WeaponDisplayEditorMenu.class, WeaponDisplayEditorMenu::new);
+        register(TestingMenu.class, TestingMenu::new);
         // SkillSelectionMenu is constructed with a slot index and is opened directly
     }
 

--- a/src/main/java/btm/sword/system/inventory/menu/DevMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/DevMenu.java
@@ -10,6 +10,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import btm.sword.config.Config;
+import btm.sword.gamemode.QueueManager;
 import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.display.BossBarManager;
 import btm.sword.system.display.ScoreboardManager;
@@ -207,6 +208,20 @@ public class DevMenu extends Menu {
             click -> new WeaponDisplayEditorMenu(swordPlayer).open()
         );
 
+        SimpleItem ctfDebug = new SimpleItem(
+            new ItemStackBuilder(Material.WHITE_BANNER)
+                .name(Component.text("Start CTF (Solo Debug)", NamedTextColor.AQUA, TextDecoration.BOLD))
+                .lore(List.of(
+                    Component.text("Launch a CTF instance instantly", NamedTextColor.DARK_GRAY),
+                    Component.text("Bypasses 2-player queue requirement", NamedTextColor.DARK_GRAY)
+                ))
+                .build(),
+            click -> {
+                QueueManager.startCtfDebug(swordPlayer);
+                swordPlayer.message(Component.text("CTF debug session started!", NamedTextColor.GREEN));
+            }
+        );
+
         SimpleItem bossBarTest = new SimpleItem(
             new ItemStackBuilder(Material.ORANGE_BANNER)
                 .name(Component.text("Boss Bar Fill Test", NamedTextColor.GOLD, TextDecoration.BOLD))
@@ -271,7 +286,7 @@ public class DevMenu extends Menu {
             .setStructure(
                 "# # # # # # # # #",
                 "# J N S F A L C #",
-                "# P X B K . H E #",
+                "# P X B K D H E #",
                 "# R I . T . M W #",
                 "# # # < . > # # #")
             .addIngredient('#', BORDER)
@@ -287,6 +302,7 @@ public class DevMenu extends Menu {
             .addIngredient('X', joinCutscene)
             .addIngredient('B', bossBarTest)
             .addIngredient('K', scoreboardTest)
+            .addIngredient('D', ctfDebug)
             .addIngredient('C', creativeInventory)
             .addIngredient('W', woodenAxe)
             .addIngredient('E', witherSkeletonEgg)

--- a/src/main/java/btm/sword/system/inventory/menu/MainMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/MainMenu.java
@@ -19,6 +19,7 @@ import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.impl.Dummy;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.inventory.InventoryMenuManager;
+import btm.sword.system.inventory.menu.dev.DevMenu;
 import btm.sword.system.item.ItemStackBuilder;
 import btm.sword.system.item.special.NonMovableItem;
 import net.kyori.adventure.text.Component;
@@ -182,7 +183,7 @@ public class MainMenu extends Menu {
                 ". . . D Q R S . .",
                 ". . . . . . . . .",
                 "# T . . H . M . #",
-                "# # # < V > # # #")
+                "< > # . V . # # #")
             .addIngredient('#', BORDER)
             .addIngredient('Q', queueForCTF)
             .addIngredient('R', queueForRoguelike)

--- a/src/main/java/btm/sword/system/inventory/menu/MainMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/MainMenu.java
@@ -179,7 +179,7 @@ public class MainMenu extends Menu {
             .setStructure(
                 "# # # . . . # # #",
                 "# . . . P . . . #",
-                ". . . D Q R . . .",
+                ". . . D Q R S . .",
                 ". . . . . . . . .",
                 "# T . . H . M . #",
                 "# # # < V > # # #")
@@ -200,6 +200,31 @@ public class MainMenu extends Menu {
                     .name(Component.text("Dev Menu", Config.SwordColor.TEXT_COOL, TextDecoration.BOLD))
                     .build(),
                 click -> InventoryMenuManager.openMenu(DevMenu.class, swordPlayer)
+            ));
+
+            builder.addIngredient('S', new SimpleItem(
+                new ItemStackBuilder(Material.RED_CONCRETE)
+                    .name(Component.text("Stop Roguelike [DEV]", Config.SwordColor.TEXT_COOL, TextDecoration.BOLD))
+                    .lore(List.of(
+                        Component.text("Force-stops the active roguelike run.", Config.SwordColor.TEXT_ITEM_BASE),
+                        Component.text("Despawns wave enemies and clears all players.", Config.SwordColor.TEXT_ITEM_BASE)
+                    ))
+                    .build(),
+                click -> {
+                    List<RoguelikeRun> runs = QueueManager.getActiveRoguelikeRuns();
+                    if (runs.isEmpty()) {
+                        SwordPlayer clicker = (SwordPlayer) SwordEntityArbiter.getOrAdd(click.getPlayer());
+                        if (clicker != null) {
+                            clicker.message("No active roguelike run found.");
+                        }
+                        return;
+                    }
+                    List.copyOf(runs).forEach(RoguelikeRun::stop);
+                    SwordPlayer clicker = (SwordPlayer) SwordEntityArbiter.getOrAdd(click.getPlayer());
+                    if (clicker != null) {
+                        clicker.message("Roguelike stopped.");
+                    }
+                }
             ));
         }
 

--- a/src/main/java/btm/sword/system/inventory/menu/MainMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/MainMenu.java
@@ -13,6 +13,7 @@ import org.bukkit.inventory.ItemStack;
 import btm.sword.config.Config;
 import btm.sword.gamemode.QueueManager;
 import btm.sword.gamemode.type.CaptureTheFlag1v1;
+import btm.sword.gamemode.type.RoguelikeRun;
 import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.impl.Dummy;
@@ -99,6 +100,14 @@ public class MainMenu extends Menu {
             )
         );
 
+        SimpleItem queueForRoguelike = new SimpleItem(
+            new ItemBuilder(Material.WITHER_SKELETON_SKULL)
+                .setDisplayName("Enter the Roguelike!"),
+            click -> QueueManager.enqueue(
+                RoguelikeRun.class, (SwordPlayer) SwordEntityArbiter.getOrAdd(click.getPlayer())
+            )
+        );
+
         SimpleItem spawnDummy = new SimpleItem(
             new ItemBuilder(Material.ARMOR_STAND)
                 .setDisplayName("Spawn a Training Dummy (max: 3 per player)"),
@@ -162,12 +171,13 @@ public class MainMenu extends Menu {
             .setStructure(
                 "# # # . . . # # #",
                 "# . . . P . . . #",
-                ". . . . D Q . . .",
+                ". . . D Q R . . .",
                 ". . . . . . . . .",
                 "# T . . H . M . #",
                 "# # # < V > # # #")
             .addIngredient('#', BORDER)
             .addIngredient('Q', queueForCTF)
+            .addIngredient('R', queueForRoguelike)
             .addIngredient('H', playerInfo)
             .addIngredient('P', HOW_TO_PLAY_ITEM)
             .addIngredient('D', spawnDummy)

--- a/src/main/java/btm/sword/system/inventory/menu/MovesetMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/MovesetMenu.java
@@ -153,7 +153,7 @@ public class MovesetMenu extends Menu {
                 ". . . . . . . . .",
                 ". F G H . I . . .",
                 "# . . . . . . . #",
-                "# # # < . > # # #")
+                "< > # . . . # # #")
             .addIngredient('#', BORDER)
             .addIngredient('A', basicAttack)
             .addIngredient('B', grab)

--- a/src/main/java/btm/sword/system/inventory/menu/dev/AnimationBrowserMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/AnimationBrowserMenu.java
@@ -1,4 +1,4 @@
-package btm.sword.system.inventory.menu;
+package btm.sword.system.inventory.menu.dev;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +24,7 @@ import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.inventory.item.ConfigEntryItem;
 import btm.sword.system.inventory.item.ForwardItem;
 import btm.sword.system.inventory.item.PreviousItem;
+import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.item.ItemStackBuilder;
 import btm.sword.system.scene.CameraSystem;
 import btm.sword.system.scene.DEUAnimationController;

--- a/src/main/java/btm/sword/system/inventory/menu/dev/ConfigMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/ConfigMenu.java
@@ -1,4 +1,4 @@
-package btm.sword.system.inventory.menu;
+package btm.sword.system.inventory.menu.dev;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -15,6 +15,7 @@ import btm.sword.config.ConfigManager;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.inventory.item.ForwardItem;
 import btm.sword.system.inventory.item.PreviousItem;
+import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.item.ItemStackBuilder;
 import btm.sword.utility.ChatInputCapture;
 import net.kyori.adventure.text.Component;

--- a/src/main/java/btm/sword/system/inventory/menu/dev/ConfigSectionMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/ConfigSectionMenu.java
@@ -1,4 +1,4 @@
-package btm.sword.system.inventory.menu;
+package btm.sword.system.inventory.menu.dev;
 
 import java.util.List;
 
@@ -10,6 +10,7 @@ import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.inventory.item.ConfigEntryItem;
 import btm.sword.system.inventory.item.ForwardItem;
 import btm.sword.system.inventory.item.PreviousItem;
+import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.item.ItemStackBuilder;
 import btm.sword.utility.ChatInputCapture;
 import net.kyori.adventure.text.Component;

--- a/src/main/java/btm/sword/system/inventory/menu/dev/CreativeInventoryMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/CreativeInventoryMenu.java
@@ -1,4 +1,4 @@
-package btm.sword.system.inventory.menu;
+package btm.sword.system.inventory.menu.dev;
 
 import java.util.Arrays;
 import java.util.List;
@@ -11,6 +11,7 @@ import org.bukkit.inventory.ItemStack;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.inventory.item.ForwardItem;
 import btm.sword.system.inventory.item.PreviousItem;
+import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.item.ItemStackBuilder;
 import btm.sword.utility.ChatInputCapture;
 import btm.sword.utility.Prefab;

--- a/src/main/java/btm/sword/system/inventory/menu/dev/DEUBDEMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/DEUBDEMenu.java
@@ -1,4 +1,4 @@
-package btm.sword.system.inventory.menu;
+package btm.sword.system.inventory.menu.dev;
 
 import java.util.List;
 
@@ -12,6 +12,7 @@ import org.bukkit.entity.Player;
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.item.ItemStackBuilder;
 import btm.sword.system.scene.CameraSystem;
 import net.kyori.adventure.text.Component;

--- a/src/main/java/btm/sword/system/inventory/menu/dev/DeuGroupBrowserMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/DeuGroupBrowserMenu.java
@@ -1,4 +1,4 @@
-package btm.sword.system.inventory.menu;
+package btm.sword.system.inventory.menu.dev;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -10,6 +10,7 @@ import org.bukkit.entity.Player;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.inventory.item.ForwardItem;
 import btm.sword.system.inventory.item.PreviousItem;
+import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.item.ItemStackBuilder;
 import net.donnypz.displayentityutils.events.GroupSpawnedEvent;
 import net.donnypz.displayentityutils.managers.DisplayGroupManager;

--- a/src/main/java/btm/sword/system/inventory/menu/dev/DevMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/DevMenu.java
@@ -1,28 +1,15 @@
-package btm.sword.system.inventory.menu;
+package btm.sword.system.inventory.menu.dev;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
-import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import btm.sword.config.Config;
-import btm.sword.gamemode.QueueManager;
-import btm.sword.system.control.SwordScheduler;
-import btm.sword.system.display.BossBarManager;
-import btm.sword.system.display.ScoreboardManager;
-import btm.sword.system.display.SwordBossBar;
-import btm.sword.system.display.SwordScoreboard;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.inventory.menu.ItemLibraryMenu;
+import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.item.ItemStackBuilder;
-import btm.sword.system.scene.DEUAnimationController;
-import btm.sword.system.scene.SceneManager;
-import btm.sword.system.scene.animation.AnimationDef;
-import btm.sword.system.scene.animation.AnimationRegistry;
-import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -78,6 +65,13 @@ public class DevMenu extends Menu {
             click -> new ConfigMenu(swordPlayer).open()
         );
 
+        SimpleItem testing = new SimpleItem(
+            new ItemStackBuilder(Material.ARMOR_STAND)
+                .name(Component.text("Testing Actions", NamedTextColor.GOLD, TextDecoration.BOLD))
+                .build(),
+            click -> new TestingMenu(swordPlayer).open()
+        );
+
         SimpleItem woodenAxe = giveItem(Material.WOODEN_AXE, "Wooden Axe");
         SimpleItem witherSkeletonEgg = giveItem(Material.WITHER_SKELETON_SPAWN_EGG, "Wither Skeleton Spawn Egg");
 
@@ -123,62 +117,12 @@ public class DevMenu extends Menu {
             }
         );
 
-        SimpleItem staticScene = new SimpleItem(
-            new ItemStackBuilder(Material.SPYGLASS)
-                .name(Component.text("Static Scene Test", NamedTextColor.LIGHT_PURPLE, TextDecoration.BOLD))
-                .lore(List.of(Component.text("Play: " + Config.Animation.STATIC_MENU_ANIMATION_KEY, NamedTextColor.DARK_GRAY)))
-                .build(),
-            click -> {
-                String animKey = Config.Animation.STATIC_MENU_ANIMATION_KEY;
-                AnimationDef def = AnimationRegistry.get(animKey).orElse(null);
-                if (def == null) {
-                    swordPlayer.message(Component.text("Animation not found: " + animKey, NamedTextColor.RED));
-                    return;
-                }
-                new DEUAnimationController(def, true, true).start(swordPlayer);
-            }
-        );
-
-        double fakePlayerDist = Config.Scene.FAKE_PLAYER_DISTANCE;
-        String animKeyLabel = Config.Animation.STATIC_MENU_ANIMATION_KEY;
-        SimpleItem fakePlayerScene = new SimpleItem(
-            new ItemStackBuilder(Material.PLAYER_HEAD)
-                .name(Component.text("Fake Player Scene Test", NamedTextColor.LIGHT_PURPLE, TextDecoration.BOLD))
-                .lore(List.of(
-                    Component.text("Spawn NPC " + fakePlayerDist + " blocks ahead, fixed camera", NamedTextColor.DARK_GRAY),
-                    Component.text("Animation: " + animKeyLabel, NamedTextColor.DARK_GRAY)
-                ))
-                .build(),
-            click -> {
-                Location playerLoc = swordPlayer.player().getLocation();
-                Location displayPosition = playerLoc.clone()
-                    .add(playerLoc.getDirection().multiply(Config.Scene.FAKE_PLAYER_DISTANCE));
-                SceneManager.enterStaticMenuScene(swordPlayer, displayPosition);
-            }
-        );
-
         SimpleItem deuTools = new SimpleItem(
             new ItemStackBuilder(Material.ITEM_FRAME)
                 .name(Component.text("DisplayEntityUtils", NamedTextColor.LIGHT_PURPLE, TextDecoration.BOLD))
                 .lore(List.of(Component.text("Animations, groups, despawn tools", NamedTextColor.DARK_GRAY)))
                 .build(),
             click -> new DEUBDEMenu(swordPlayer).open()
-        );
-
-        SimpleItem packetTests = new SimpleItem(
-            new ItemStackBuilder(Material.COMMAND_BLOCK)
-                .name(Component.text("Packet Tests", NamedTextColor.LIGHT_PURPLE, TextDecoration.BOLD))
-                .lore(List.of(Component.text("Fake player packet test harness", NamedTextColor.DARK_GRAY)))
-                .build(),
-            click -> new PacketTestMenu(swordPlayer).open()
-        );
-
-        SimpleItem joinCutscene = new SimpleItem(
-            new ItemStackBuilder(Material.LIGHTNING_ROD)
-                .name(Component.text("Initial Join Cutscene", NamedTextColor.LIGHT_PURPLE, TextDecoration.BOLD))
-                .lore(List.of(Component.text("Play the first-time join sequence", NamedTextColor.DARK_GRAY)))
-                .build(),
-            click -> btm.sword.system.join.InitialJoinCutscene.play(swordPlayer)
         );
 
         SimpleItem skillEquip = new SimpleItem(
@@ -208,101 +152,22 @@ public class DevMenu extends Menu {
             click -> new WeaponDisplayEditorMenu(swordPlayer).open()
         );
 
-        SimpleItem ctfDebug = new SimpleItem(
-            new ItemStackBuilder(Material.WHITE_BANNER)
-                .name(Component.text("Start CTF (Solo Debug)", NamedTextColor.AQUA, TextDecoration.BOLD))
-                .lore(List.of(
-                    Component.text("Launch a CTF instance instantly", NamedTextColor.DARK_GRAY),
-                    Component.text("Bypasses 2-player queue requirement", NamedTextColor.DARK_GRAY)
-                ))
-                .build(),
-            click -> {
-                QueueManager.startCtfDebug(swordPlayer);
-                swordPlayer.message(Component.text("CTF debug session started!", NamedTextColor.GREEN));
-            }
-        );
-
-        SimpleItem bossBarTest = new SimpleItem(
-            new ItemStackBuilder(Material.ORANGE_BANNER)
-                .name(Component.text("Boss Bar Fill Test", NamedTextColor.GOLD, TextDecoration.BOLD))
-                .lore(List.of(Component.text("Spawns a bar that fills over 5 seconds", NamedTextColor.DARK_GRAY)))
-                .build(),
-            click -> {
-                SwordBossBar bar = BossBarManager.create(
-                    Component.text("Charging...", NamedTextColor.YELLOW),
-                    0f,
-                    BossBar.Color.YELLOW,
-                    BossBar.Overlay.NOTCHED_10
-                );
-                bar.addViewer(player);
-                int steps = 20;
-                int intervalMs = 250;
-                for (int i = 1; i <= steps; i++) {
-                    final float progress = (float) i / steps;
-                    SwordScheduler.runBukkitTaskLater(() -> bar.setProgress(progress), i * intervalMs, TimeUnit.MILLISECONDS);
-                }
-                SwordScheduler.runBukkitTaskLater(() -> {
-                    bar.setTitle(Component.text("Charged!", NamedTextColor.GREEN));
-                    bar.setColor(BossBar.Color.GREEN);
-                }, steps * intervalMs, TimeUnit.MILLISECONDS);
-                SwordScheduler.runBukkitTaskLater(bar::remove, steps * intervalMs + 1000, TimeUnit.MILLISECONDS);
-            }
-        );
-
-        boolean hasScoreboard = ScoreboardManager.get(player).isPresent();
-        SimpleItem scoreboardTest = new SimpleItem(
-            new ItemStackBuilder(hasScoreboard ? Material.LIME_BANNER : Material.WHITE_BANNER)
-                .name(Component.text("Scoreboard Test", NamedTextColor.GREEN, TextDecoration.BOLD))
-                .lore(List.of(Component.text(
-                    hasScoreboard ? "Click to remove the test scoreboard" : "Click to show a test scoreboard",
-                    NamedTextColor.DARK_GRAY
-                )))
-                .build(),
-            click -> {
-                Optional<SwordScoreboard> existing = ScoreboardManager.get(player);
-                if (existing.isPresent()) {
-                    ScoreboardManager.remove(player);
-                    swordPlayer.message(Component.text("Scoreboard removed.", NamedTextColor.YELLOW));
-                } else {
-                    SwordScoreboard board = ScoreboardManager.create(
-                        player,
-                        Component.text("✦ Sword Test", NamedTextColor.GOLD, TextDecoration.BOLD)
-                    );
-                    board.setLine(1, Component.text("HP", NamedTextColor.RED)
-                        .append(Component.text(": 100", NamedTextColor.WHITE)));
-                    board.setLine(2, Component.empty());
-                    board.setLine(3, Component.text("Soulfire", NamedTextColor.AQUA)
-                        .append(Component.text(": 75", NamedTextColor.WHITE)));
-                    board.setLine(4, Component.empty());
-                    board.setLine(5, Component.text("Toughness", NamedTextColor.GRAY)
-                        .append(Component.text(": 50", NamedTextColor.WHITE)));
-                    board.show();
-                    swordPlayer.message(Component.text("Scoreboard shown. Click again to remove.", NamedTextColor.GREEN));
-                }
-            }
-        );
-
         Gui gui = Gui.normal()
             .setStructure(
-                "# # # # # # # # #",
-                "# J N S F A L C #",
-                "# P X B K D H E #",
-                "# R I . T . M W #",
-                "# # # < . > # # #")
+                "# # # . . . # # #",
+                "# J N . T . L C #",
+                ". H . . ? . . E .",
+                ". . . . A . . W .",
+                "# R I . . . M . #",
+                "< > # . . . # # #")
             .addIngredient('#', BORDER)
             .addIngredient('T', toggles)
-            .addIngredient('P', packetTests)
             .addIngredient('R', reloadInventoryButtons)
             .addIngredient('J', configEditor)
+            .addIngredient('?', testing)
             .addIngredient('N', deuTools)
-            .addIngredient('S', staticScene)
-            .addIngredient('F', fakePlayerScene)
             .addIngredient('A', skillEquip)
             .addIngredient('L', itemLibrary)
-            .addIngredient('X', joinCutscene)
-            .addIngredient('B', bossBarTest)
-            .addIngredient('K', scoreboardTest)
-            .addIngredient('D', ctfDebug)
             .addIngredient('C', creativeInventory)
             .addIngredient('W', woodenAxe)
             .addIngredient('E', witherSkeletonEgg)

--- a/src/main/java/btm/sword/system/inventory/menu/dev/DevSkillEquipMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/DevSkillEquipMenu.java
@@ -1,4 +1,4 @@
-package btm.sword.system.inventory.menu;
+package btm.sword.system.inventory.menu.dev;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,6 +10,7 @@ import btm.sword.system.action.skill.SkillRegistry;
 import btm.sword.system.action.skill.container.PlayerSkillContainer;
 import btm.sword.system.action.skill.container.SkillSlot;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.item.ItemStackBuilder;
 import btm.sword.system.item.special.AbilitySlotManager;
 import net.kyori.adventure.text.Component;

--- a/src/main/java/btm/sword/system/inventory/menu/dev/TestingMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/TestingMenu.java
@@ -1,0 +1,225 @@
+package btm.sword.system.inventory.menu.dev;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+import btm.sword.config.Config;
+import btm.sword.gamemode.QueueManager;
+import btm.sword.gamemode.type.CaptureTheFlag1v1;
+import btm.sword.system.control.SwordScheduler;
+import btm.sword.system.display.BossBarManager;
+import btm.sword.system.display.ScoreboardManager;
+import btm.sword.system.display.SwordBossBar;
+import btm.sword.system.display.SwordScoreboard;
+import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.inventory.menu.Menu;
+import btm.sword.system.inventory.menu.PacketTestMenu;
+import btm.sword.system.item.ItemStackBuilder;
+import btm.sword.system.scene.DEUAnimationController;
+import btm.sword.system.scene.SceneManager;
+import btm.sword.system.scene.animation.AnimationDef;
+import btm.sword.system.scene.animation.AnimationRegistry;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import xyz.xenondevs.invui.gui.Gui;
+import xyz.xenondevs.invui.item.impl.SimpleItem;
+import xyz.xenondevs.invui.window.Window;
+
+public class TestingMenu extends Menu {
+
+    /**
+     * Creates a Menu instance bound to the given player.
+     *
+     * @param player the player this menu belongs to
+     */
+    public TestingMenu(SwordPlayer player) {
+        super(player);
+    }
+
+    @Override
+    public void open() {
+        Player player = swordPlayer.player();
+
+        SimpleItem staticScene = new SimpleItem(
+            new ItemStackBuilder(Material.SPYGLASS)
+                .name(Component.text("Static Scene Test", NamedTextColor.LIGHT_PURPLE, TextDecoration.BOLD))
+                .lore(List.of(Component.text("Play: " + Config.Animation.STATIC_MENU_ANIMATION_KEY, NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> {
+                String animKey = Config.Animation.STATIC_MENU_ANIMATION_KEY;
+                AnimationDef def = AnimationRegistry.get(animKey).orElse(null);
+                if (def == null) {
+                    swordPlayer.message(Component.text("Animation not found: " + animKey, NamedTextColor.RED));
+                    return;
+                }
+                new DEUAnimationController(def, true, true).start(swordPlayer);
+            }
+        );
+
+        double fakePlayerDist = Config.Scene.FAKE_PLAYER_DISTANCE;
+        String animKeyLabel = Config.Animation.STATIC_MENU_ANIMATION_KEY;
+        SimpleItem fakePlayerScene = new SimpleItem(
+            new ItemStackBuilder(Material.PLAYER_HEAD)
+                .name(Component.text("Fake Player Scene Test", NamedTextColor.LIGHT_PURPLE, TextDecoration.BOLD))
+                .lore(List.of(
+                    Component.text("Spawn NPC " + fakePlayerDist + " blocks ahead, fixed camera", NamedTextColor.DARK_GRAY),
+                    Component.text("Animation: " + animKeyLabel, NamedTextColor.DARK_GRAY)
+                ))
+                .build(),
+            click -> {
+                Location playerLoc = swordPlayer.player().getLocation();
+                Location displayPosition = playerLoc.clone()
+                    .add(playerLoc.getDirection().multiply(Config.Scene.FAKE_PLAYER_DISTANCE));
+                SceneManager.enterStaticMenuScene(swordPlayer, displayPosition);
+            }
+        );
+
+        SimpleItem packetTests = new SimpleItem(
+            new ItemStackBuilder(Material.COMMAND_BLOCK)
+                .name(Component.text("Packet Tests", NamedTextColor.LIGHT_PURPLE, TextDecoration.BOLD))
+                .lore(List.of(Component.text("Fake player packet test harness", NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> new PacketTestMenu(swordPlayer).open()
+        );
+
+        SimpleItem joinCutscene = new SimpleItem(
+            new ItemStackBuilder(Material.LIGHTNING_ROD)
+                .name(Component.text("Initial Join Cutscene", NamedTextColor.LIGHT_PURPLE, TextDecoration.BOLD))
+                .lore(List.of(Component.text("Play the first-time join sequence", NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> btm.sword.system.join.InitialJoinCutscene.play(swordPlayer)
+        );
+
+        SimpleItem ctfDebug = new SimpleItem(
+            new ItemStackBuilder(Material.WHITE_BANNER)
+                .name(Component.text("Start CTF (Solo Debug)", NamedTextColor.AQUA, TextDecoration.BOLD))
+                .lore(List.of(
+                    Component.text("Launch a CTF instance instantly", NamedTextColor.DARK_GRAY),
+                    Component.text("Bypasses 2-player queue requirement", NamedTextColor.DARK_GRAY)
+                ))
+                .build(),
+            click -> {
+                QueueManager.startCtfDebug(swordPlayer);
+                swordPlayer.message(Component.text("CTF debug session started!", NamedTextColor.GREEN));
+            }
+        );
+
+        CaptureTheFlag1v1 activeCtf =
+            QueueManager.getActiveCtfMatch(player.getUniqueId());
+        SimpleItem ctfStop = new SimpleItem(
+            new ItemStackBuilder(activeCtf != null ? Material.RED_BANNER : Material.GRAY_BANNER)
+                .name(Component.text("Stop CTF Match", NamedTextColor.RED, TextDecoration.BOLD))
+                .lore(List.of(
+                    activeCtf != null
+                        ? Component.text("Force-end your active CTF match", NamedTextColor.DARK_GRAY)
+                        : Component.text("No active CTF match", NamedTextColor.DARK_GRAY)
+                ))
+                .build(),
+            click -> {
+                CaptureTheFlag1v1 match =
+                    QueueManager.getActiveCtfMatch(click.getPlayer().getUniqueId());
+                if (match == null) {
+                    swordPlayer.message(Component.text("No active CTF match to stop.", NamedTextColor.RED));
+                    return;
+                }
+                match.stop();
+                swordPlayer.message(Component.text("CTF match stopped.", NamedTextColor.YELLOW));
+            }
+        );
+
+        SimpleItem bossBarTest = new SimpleItem(
+            new ItemStackBuilder(Material.ENDER_DRAGON_SPAWN_EGG)
+                .name(Component.text("Boss Bar Fill Test", NamedTextColor.GOLD, TextDecoration.BOLD))
+                .lore(List.of(Component.text("Spawns a bar that fills over 5 seconds", NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> {
+                SwordBossBar bar = BossBarManager.create(
+                    Component.text("Charging...", NamedTextColor.YELLOW),
+                    0f,
+                    BossBar.Color.YELLOW,
+                    BossBar.Overlay.NOTCHED_10
+                );
+                bar.addViewer(player);
+                int steps = 20;
+                int intervalMs = 250;
+                for (int i = 1; i <= steps; i++) {
+                    final float progress = (float) i / steps;
+                    SwordScheduler.runBukkitTaskLater(() -> bar.setProgress(progress), i * intervalMs, TimeUnit.MILLISECONDS);
+                }
+                SwordScheduler.runBukkitTaskLater(() -> {
+                    bar.setTitle(Component.text("Charged!", NamedTextColor.GREEN));
+                    bar.setColor(BossBar.Color.GREEN);
+                }, steps * intervalMs, TimeUnit.MILLISECONDS);
+                SwordScheduler.runBukkitTaskLater(bar::remove, steps * intervalMs + 1000, TimeUnit.MILLISECONDS);
+            }
+        );
+
+        boolean hasScoreboard = ScoreboardManager.get(player).isPresent();
+        SimpleItem scoreboardTest = new SimpleItem(
+            new ItemStackBuilder(hasScoreboard ? Material.GLOW_ITEM_FRAME : Material.ITEM_FRAME)
+                .name(Component.text("Scoreboard Test", NamedTextColor.GREEN, TextDecoration.BOLD))
+                .lore(List.of(Component.text(
+                    hasScoreboard ? "Click to remove the test scoreboard" : "Click to show a test scoreboard",
+                    NamedTextColor.DARK_GRAY
+                )))
+                .build(),
+            click -> {
+                Optional<SwordScoreboard> existing = ScoreboardManager.get(player);
+                if (existing.isPresent()) {
+                    ScoreboardManager.remove(player);
+                    swordPlayer.message(Component.text("Scoreboard removed.", NamedTextColor.YELLOW));
+                } else {
+                    SwordScoreboard board = ScoreboardManager.create(
+                        player,
+                        Component.text("✦ Sword Test", NamedTextColor.GOLD, TextDecoration.BOLD)
+                    );
+                    board.setLine(1, Component.text("HP", NamedTextColor.RED)
+                        .append(Component.text(": 100", NamedTextColor.WHITE)));
+                    board.setLine(2, Component.empty());
+                    board.setLine(3, Component.text("Soulfire", NamedTextColor.AQUA)
+                        .append(Component.text(": 75", NamedTextColor.WHITE)));
+                    board.setLine(4, Component.empty());
+                    board.setLine(5, Component.text("Toughness", NamedTextColor.GRAY)
+                        .append(Component.text(": 50", NamedTextColor.WHITE)));
+                    board.show();
+                    swordPlayer.message(Component.text("Scoreboard shown. Click again to remove.", NamedTextColor.GREEN));
+                }
+            }
+        );
+
+        Gui gui = Gui.normal()
+            .setStructure(
+                "# # # . . . # # #",
+                "# P X . F . B K #",
+                ". D . . . . . . .",
+                "# O . . . . . . #",
+                "< > # . . . # # #")
+            .addIngredient('#', BORDER)
+            .addIngredient('P', packetTests)
+            .addIngredient('S', staticScene)
+            .addIngredient('F', fakePlayerScene)
+            .addIngredient('X', joinCutscene)
+            .addIngredient('B', bossBarTest)
+            .addIngredient('K', scoreboardTest)
+            .addIngredient('D', ctfDebug)
+            .addIngredient('O', ctfStop)
+            .addIngredient('<', generatePreviousButtonOrDefault())
+            .addIngredient('>', generateForwardPreviousButtonOrDefault())
+            .build();
+
+        Window window = Window.single()
+            .setViewer(player)
+            .setTitle("Dev Menu")
+            .setGui(gui)
+            .build();
+
+        window.open();
+    }
+}

--- a/src/main/java/btm/sword/system/inventory/menu/dev/TogglesMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/TogglesMenu.java
@@ -1,4 +1,4 @@
-package btm.sword.system.inventory.menu;
+package btm.sword.system.inventory.menu.dev;
 
 import java.util.List;
 
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player;
 import btm.sword.config.Config;
 import btm.sword.config.ConfigManager;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.item.ItemStackBuilder;
 import btm.sword.system.playerdata.PlayerData;
 import btm.sword.system.playerdata.PlayerDataManager;

--- a/src/main/java/btm/sword/system/inventory/menu/dev/WeaponDisplayEditorMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/WeaponDisplayEditorMenu.java
@@ -1,4 +1,4 @@
-package btm.sword.system.inventory.menu;
+package btm.sword.system.inventory.menu.dev;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,6 +12,7 @@ import org.bukkit.inventory.ItemStack;
 import btm.sword.system.entity.display.WeaponDisplayRegistry;
 import btm.sword.system.entity.display.WeaponDisplayTransform;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.item.ItemStackBuilder;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;

--- a/src/main/java/btm/sword/utility/Prefab.java
+++ b/src/main/java/btm/sword/utility/Prefab.java
@@ -272,6 +272,12 @@ public class Prefab {
             new PotionEffectWrapper(PotionEffectType.SPEED, Config.Movement.SPEED_DURATION, Config.Movement.SPEED_AMPLIFIER);
         public static final PotionEffectWrapper HEAL_CHANNEL_SLOW =
             new PotionEffectWrapper(PotionEffectType.SLOWNESS, Config.Combat.HEAL_CHANNEL_SLOW_DURATION, Config.Combat.HEAL_CHANNEL_SLOW_AMPLIFIER);
+        /** Applied to a player carrying a CTF flag. Effectively permanent; removed on drop/capture/match end. */
+        public static final PotionEffectWrapper FLAG_CARRIER_SLOW =
+            new PotionEffectWrapper(() -> PotionEffectType.SLOWNESS,
+                () -> Config.Ctf.FLAG_CARRIER_SLOW_DURATION,
+                () -> Config.Ctf.FLAG_CARRIER_SLOW_AMPLIFIER,
+                () -> false, () -> false, () -> false);
     }
 
     /** Pre-built lore/description {@link net.kyori.adventure.text.Component} lists for special items. */

--- a/src/main/resources/animations.yml
+++ b/src/main/resources/animations.yml
@@ -1,20 +1,4 @@
 animations:
-  creep_test:
-    anims:
-      creep_test_default:
-        loop: true
-  player:
-    anims:
-      player_default:
-        loop: true
-  slash_test:
-    anims:
-      slash_test_default:
-        loop: true
-  gentle_v2:
-    anims:
-      gentle_v2_default:
-        loop: true
   witha:
     anims:
       witha_die:

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -328,29 +328,16 @@ world:
 
 
 debug:
-
-  # General / fallback debug output
-  logging_verbose_debug: false
-
-  # Per-system verbose logging
+  
   logging_verbose_combat: false
   logging_verbose_movement: false
-  logging_verbose_inventory: false
-  logging_verbose_system: false
-  logging_verbose_umbral: false
-  logging_verbose_hostile: false
-  logging_verbose_listener: false
+  
+  logging_verbose_config: false
   logging_verbose_animation: false
-  logging_verbose_input: false
-  logging_verbose_skill: false
-  logging_verbose_ability: false
-  logging_verbose_grab: false
-  logging_verbose_attack: false
-  logging_verbose_throwing: false
-
+  
   visualization_show_hitboxes: false
   visualization_show_raytraces: false
-
+  
   skip_data_load: false
   skip_data_save: false
 
@@ -387,12 +374,12 @@ hostile:
   pre_attack_ticks: 24
   retreat_ticks: 40
   flee_health_fraction: 0.2
-  display_group: "witha"
+  display_group: witha
   display_ride_offset_y: 0.0
-  display_anim_idle: "idle"
-  display_anim_walk: "walk"
-  display_anim_fall: "fall"
-  display_anim_melee: "melee"
+  display_anim_idle: idle
+  display_anim_walk: walk
+  display_anim_fall: fall
+  display_anim_melee: melee
   mob_throw_weight: 0.3
   mob_retrieve_pickup_range: 2.0
   display_teleport_duration: 3
@@ -427,13 +414,13 @@ menu_grid:
   cols: 11
   loading_wait_ms: 1500
 roguelike:
-
-  spawn_world: "world"
-  spawn_x: 0.0
+  
+  spawn_world: world
+  spawn_x: -129.0
   spawn_y: 64.0
-  spawn_z: 0.0
+  spawn_z: 138.0
   spawn_radius: 8.0
-
+  
   wave_1_pillagers: 3
   wave_2_wither_skeletons: 3
   wave_3_pillagers: 2
@@ -443,18 +430,7 @@ roguelike:
 join_sequence:
   opening_x: -186.5
   opening_z: -1058.5
-
 ctf:
-  spawn_world: "world"
-  red_spawn_x: 15.0
-  red_spawn_y: 64.0
-  red_spawn_z: 0.0
-  blue_spawn_x: -15.0
-  blue_spawn_y: 64.0
-  blue_spawn_z: 0.0
-  flag_return_timer_seconds: 30
-  respawn_delay_seconds: 5
-  captures_to_win: 3
-  capture_radius: 3.0
-  flag_carrier_slow_duration: 999999
-  flag_carrier_slow_amplifier: 1
+  red_spawn_x: -81.0
+  red_spawn_z: 315.0
+  red_spawn_y: 92.0

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -413,6 +413,20 @@ menu_grid:
   rows: 11
   cols: 11
   loading_wait_ms: 1500
+roguelike:
+
+  spawn_world: "world"
+  spawn_x: 0.0
+  spawn_y: 64.0
+  spawn_z: 0.0
+  spawn_radius: 8.0
+
+  wave_1_pillagers: 3
+  wave_2_wither_skeletons: 3
+  wave_3_pillagers: 2
+  wave_3_wither_skeletons: 3
+
+
 join_sequence:
   opening_x: -186.5
   opening_z: -1058.5

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -443,3 +443,18 @@ roguelike:
 join_sequence:
   opening_x: -186.5
   opening_z: -1058.5
+
+ctf:
+  spawn_world: "world"
+  red_spawn_x: 15.0
+  red_spawn_y: 64.0
+  red_spawn_z: 0.0
+  blue_spawn_x: -15.0
+  blue_spawn_y: 64.0
+  blue_spawn_z: 0.0
+  flag_return_timer_seconds: 30
+  respawn_delay_seconds: 5
+  captures_to_win: 3
+  capture_radius: 3.0
+  flag_carrier_slow_duration: 999999
+  flag_carrier_slow_amplifier: 1


### PR DESCRIPTION
## Summary

This PR implements a complete roguelike wave-run gamemode with capture-the-flag (CTF) infrastructure. The branch brings together 14 commits featuring:

- **Roguelike wave-run system** (#268): Core prototype with 5-minute timeout and per-mob damage logging
- **CTF full infrastructure** (#280): Flag entity management, team-based respawn, scoring system, and banner displays
- **Gamemode improvements**: Fixed timer (now 1000ms period), null score handling, and friendly fire suppression via scoreboard tags
- **Error handling**: New ErrorListener with safe remove and display spawning/removal safeguards
- **Bug fixes**: NaN boss bar progress, display group unregister timing, combo registration predicates
- **Menu refactoring**: Reorganized dev menus into dedicated `/dev` folder with stop-run button in MainMenu

## Related Issues

- Closes #268 (Roguelike wave-run prototype)
- Closes #280 (CTF full infrastructure)
- Relates to #297 (Flag carrying constraints)

## Testing

Manual testing via `/gradlew runServer` — verify:
- Roguelike wave runs start/end correctly and log mob damage
- CTF flag picking, dropping, scoring, and team respawn work
- MainMenu displays stop-run button when roguelike active
- Display groups unregister without Paper chunk-lock warnings