### PR TITLE
Refactor: ThrowPhase/InventoryMode enums, gate debug scans (#304 #305 #306)

### DIFF
--- a/src/main/java/btm/sword/listeners/InputListener.java
+++ b/src/main/java/btm/sword/listeners/InputListener.java
@@ -23,6 +23,7 @@ import btm.sword.system.action.throwing.ThrowAction;
 import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.entity.impl.ThrowPhase;
 import btm.sword.system.input.InputType;
 import btm.sword.system.item.ItemClassifier;
 import btm.sword.utility.entity.InputUtil;
@@ -291,7 +292,7 @@ public class InputListener implements Listener {
             swordPlayer.resetTree();
         }
 
-        if (swordPlayer.isAttemptingThrow()) {
+        if (swordPlayer.getThrowPhase() == ThrowPhase.THROWING) {
             ThrowAction.throwCancel(swordPlayer);
         }
 

--- a/src/main/java/btm/sword/system/action/throwing/ThrowAction.java
+++ b/src/main/java/btm/sword/system/action/throwing/ThrowAction.java
@@ -14,6 +14,7 @@ import btm.sword.system.action.throwing.types.ThrownItem;
 import btm.sword.system.action.throwing.types.VisualProjectile;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.entity.impl.ThrowPhase;
 import btm.sword.system.input.ActivationContext;
 
 /**
@@ -66,9 +67,7 @@ public class ThrowAction extends SwordAction {
      * @param itemOverride the explicit item to throw, or {@code null} to derive from the executor's hand
      */
     public static void throwReady(Combatant executor, @Nullable ItemStack itemOverride) {
-        executor.setAttemptingThrow(true);
-        executor.setThrowCancelled(false);
-        executor.setThrowSuccessful(false);
+        executor.setThrowPhase(ThrowPhase.THROWING);
         if (executor instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.THROWING);
 
         Consumer<ItemDisplay> setupInstructions;
@@ -126,9 +125,7 @@ public class ThrowAction extends SwordAction {
      * @param velocity     the initial velocity magnitude passed to {@link ThrownItem#onRelease(double)}
      */
     public static void throwDirect(Combatant executor, ItemStack item, Vector3f displayScale, double velocity) {
-        executor.setAttemptingThrow(true);
-        executor.setThrowCancelled(false);
-        executor.setThrowSuccessful(false);
+        executor.setThrowPhase(ThrowPhase.THROWING);
         if (executor instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.THROWING);
 
         ThrownItem thrownItem = new ThrownItem(executor, display -> display.setItemStack(item), 1);
@@ -147,8 +144,7 @@ public class ThrowAction extends SwordAction {
                 if (thrownItem.getDisplay() == null) {
                     misses++;
                 } else {
-                    executor.setAttemptingThrow(false);
-                    executor.setThrowSuccessful(true);
+                    executor.setThrowPhase(ThrowPhase.SUCCESS);
                     if (executor instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.NORMAL);
                     thrownItem.onRelease(velocity);
                     cancel();
@@ -193,9 +189,7 @@ public class ThrowAction extends SwordAction {
      */
     public static void throwCancel(Combatant executor) {
         Sword.getInstance().getLogger().info("\nThrow was <CANCELED>\n");
-        executor.setAttemptingThrow(false);
-        executor.setThrowCancelled(true);
-        executor.setThrowSuccessful(false);
+        executor.setThrowPhase(ThrowPhase.CANCELLED);
         if (executor instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.NORMAL);
 
         if (executor instanceof SwordPlayer sp) {
@@ -222,10 +216,9 @@ public class ThrowAction extends SwordAction {
      * @param executor The combatant performing the throw.
      */
     public static void throwItem(Combatant executor) {
-        if (executor.isThrowCancelled()) return;
+        if (executor.getThrowPhase() == ThrowPhase.CANCELLED) return;
 
-        executor.setAttemptingThrow(false);
-        executor.setThrowSuccessful(true);
+        executor.setThrowPhase(ThrowPhase.SUCCESS);
         if (executor instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.NORMAL);
 
         if (executor.getThrownItem() != null) executor.getThrownItem().onRelease(2);

--- a/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
@@ -36,6 +36,7 @@ import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.entity.impl.ThrowPhase;
 import btm.sword.system.input.ActivationContext;
 import btm.sword.system.item.ItemUsageManager;
 import btm.sword.system.item.KeyRegistry;
@@ -157,9 +158,8 @@ public class ThrownItem extends VisualProjectile {
             sp.setThrownItemIndex();
 
             if (sp.isInteractingWithEntity()) {
-                sp.setAttemptingThrow(false);
+                sp.setThrowPhase(ThrowPhase.SUCCESS);
                 sp.setActivationContext(ActivationContext.NORMAL);
-                sp.setThrowSuccessful(true);
                 sp.getThrownItem().onRelease(2);
                 thrower.setItemTypeInHand(Material.AIR, true);
                 sp.endHoldingRight();
@@ -196,7 +196,7 @@ public class ThrownItem extends VisualProjectile {
             0, 50,
             ThrownItem.class, "onReady",
             new PredicateRunnablePair(
-                thrower::isThrowCancelled,
+                () -> thrower.getThrowPhase() == ThrowPhase.CANCELLED,
                 () -> {
                     display.remove();
                     ThrowAction.throwCancel(thrower);
@@ -204,7 +204,7 @@ public class ThrownItem extends VisualProjectile {
                 }
             ),
             new PredicateRunnablePair(
-                thrower::isThrowSuccessful,
+                () -> thrower.getThrowPhase() == ThrowPhase.SUCCESS,
                 () -> thrower.setItemTypeInHand(Material.AIR, true)
             )
         );

--- a/src/main/java/btm/sword/system/action/utility/GrabAction.java
+++ b/src/main/java/btm/sword/system/action/utility/GrabAction.java
@@ -23,6 +23,7 @@ import btm.sword.system.entity.aspect.AspectType;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.entity.impl.ThrowPhase;
 import btm.sword.utility.Prefab;
 import btm.sword.utility.SwordTimeUnit;
 import btm.sword.utility.entity.HitboxUtil;
@@ -123,7 +124,9 @@ public class GrabAction extends SwordAction {
         SwordEntity swordTarget = SwordEntityArbiter.getOrAdd(target);
         if (swordTarget == null || swordTarget.isHit()) return;
 
-        if (swordTarget instanceof Combatant c && c.isAttemptingThrow()) c.setThrowCancelled(true);
+        if (swordTarget instanceof Combatant c && c.getThrowPhase() == ThrowPhase.THROWING) {
+            c.setThrowPhase(ThrowPhase.CANCELLED);
+        }
 
         if (executor instanceof SwordPlayer swordPlayer) {
             swordPlayer.setTargetedEntity(swordTarget);

--- a/src/main/java/btm/sword/system/entity/ai/HostileStateMachine.java
+++ b/src/main/java/btm/sword/system/entity/ai/HostileStateMachine.java
@@ -18,6 +18,7 @@ import btm.sword.system.entity.ai.state.RetreatState;
 import btm.sword.system.entity.ai.state.RetrieveWeaponState;
 import btm.sword.system.entity.ai.state.SurroundState;
 import btm.sword.system.entity.impl.Hostile;
+import btm.sword.system.entity.impl.ThrowPhase;
 import btm.sword.utility.statemachine.State;
 import btm.sword.utility.statemachine.StateMachine;
 import btm.sword.utility.statemachine.Transition;
@@ -94,7 +95,7 @@ public class HostileStateMachine extends StateMachine<Hostile> {
             h -> {
                 if (h.getAiStateMachine().getState() instanceof RetrieveWeaponState) return false;
                 if (h.getAiStateMachine().getState() instanceof FleeState) return false;
-                if (h.isAttemptingThrow()) return false;
+                if (h.getThrowPhase() == ThrowPhase.THROWING) return false;
                 return h.getLodgedThrowItem() != null
                     && h.getLodgedThrowItem().getDisplay() != null
                     && h.getLodgedThrowItem().getDisplay().isValid();

--- a/src/main/java/btm/sword/system/entity/ai/ability/MobThrowAbility.java
+++ b/src/main/java/btm/sword/system/entity/ai/ability/MobThrowAbility.java
@@ -14,6 +14,7 @@ import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.entity.ai.MobGoalArbiter;
 import btm.sword.system.entity.ai.goal.LookAtTargetGoal;
 import btm.sword.system.entity.impl.Hostile;
+import btm.sword.system.entity.impl.ThrowPhase;
 
 /**
  * A ranged throwing ability for hostile mobs.
@@ -62,7 +63,7 @@ public class MobThrowAbility implements MobAbility {
         // Guard: combo re-entry (roll=2) re-calls execute() before the first throw's delayed
         // throwItem() fires. Without this check, a second ThrownItem is created and the first
         // one's display + landing marker are orphaned and never cleaned up.
-        if (h.isAttemptingThrow()) return;
+        if (h.getThrowPhase() == ThrowPhase.THROWING) return;
 
         MobGoalArbiter.GOALS.addGoal(h.mob(), 1, new LookAtTargetGoal(h.mob(), h));
 
@@ -107,7 +108,7 @@ public class MobThrowAbility implements MobAbility {
      */
     private void executeDirtThrow(Hostile h, Vector toTarget) {
         // Prevent re-entry during the animation window
-        h.setAttemptingThrow(true);
+        h.setThrowPhase(ThrowPhase.THROWING);
 
         float yaw = h.mob().getLocation().getYaw();
         h.mob().setRotation(yaw, 70f);
@@ -122,7 +123,7 @@ public class MobThrowAbility implements MobAbility {
         SwordScheduler.runBukkitTaskLater(() -> {
             if (!h.self().isValid() || h.getCurrentTarget() == null
                     || !h.getCurrentTarget().self().isValid()) {
-                h.setAttemptingThrow(false);
+                h.setThrowPhase(ThrowPhase.IDLE);
                 return;
             }
 

--- a/src/main/java/btm/sword/system/entity/impl/Combatant.java
+++ b/src/main/java/btm/sword/system/entity/impl/Combatant.java
@@ -64,9 +64,7 @@ public abstract class Combatant extends SwordEntity {
     private ThrownItem thrownItem;
     private ItemStack offHandItemStackDuringThrow;
     private ItemStack mainHandItemStackDuringThrow;
-    private boolean attemptingThrow;
-    private boolean throwCancelled;
-    private boolean throwSuccessful;
+    private ThrowPhase throwPhase = ThrowPhase.IDLE;
 
     private final AttributeInstance attrHealth;
     private final AttributeInstance attrAbsorption;

--- a/src/main/java/btm/sword/system/entity/impl/InventoryMode.java
+++ b/src/main/java/btm/sword/system/entity/impl/InventoryMode.java
@@ -1,0 +1,18 @@
+package btm.sword.system.entity.impl;
+
+/**
+ * Encodes the mutually exclusive inventory interaction modes of a {@link SwordPlayer}.
+ *
+ * <p>Replaces the three boolean fields ({@code swappingInInv}, {@code droppingInInv},
+ * {@code inInventorySession}) that previously allowed illegal combinations.</p>
+ */
+public enum InventoryMode {
+    /** No inventory interaction is active. */
+    NONE,
+    /** The player is momentarily swapping items (clears after ~1 tick). */
+    SWAPPING,
+    /** The player is momentarily dropping items (clears after ~2 ticks). */
+    DROPPING,
+    /** The player has an inventory screen open. */
+    SESSION
+}

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -201,10 +201,7 @@ public class SwordPlayer extends Combatant {
 
     private int thrownItemIndex;
 
-    private boolean swappingInInv;
-    private boolean droppingInInv;
-    @Setter
-    private boolean inInventorySession;
+    private InventoryMode inventoryMode = InventoryMode.NONE;
 
     /** True while the scene overlay (glass-pane fill + invisibility) is active. Suppresses inventory upkeep. */
     private boolean inSceneOverlay = false;
@@ -344,9 +341,7 @@ public class SwordPlayer extends Combatant {
 
         thrownItemIndex = -1;
 
-        swappingInInv = false;
-        droppingInInv = false;
-        inInventorySession = false;
+        inventoryMode = InventoryMode.NONE;
     }
 
     /**
@@ -1624,32 +1619,50 @@ public class SwordPlayer extends Combatant {
 
     /**
      * Marks that the player is currently swapping items in inventory.
-     * Resets the flag shortly after (1 tick).
+     * Resets to {@link InventoryMode#NONE} after ~1 tick.
      */
     public void setSwappingInInv() {
-        swappingInInv = true;
-
+        inventoryMode = InventoryMode.SWAPPING;
         SwordScheduler.runBukkitTaskLater(
-            () -> swappingInInv = false,
+            () -> { if (inventoryMode == InventoryMode.SWAPPING) inventoryMode = InventoryMode.NONE; },
             50, TimeUnit.MILLISECONDS
         );
     }
 
     /**
      * Marks that the player is currently dropping items in inventory.
-     * Resets the flag shortly after (1 tick).
+     * Resets to {@link InventoryMode#NONE} after ~2 ticks.
      */
     public void setDroppingInInv() {
         Debug.inventory(">> set dropping in inv");
-
-        droppingInInv = true;
+        inventoryMode = InventoryMode.DROPPING;
         SwordScheduler.runBukkitTaskLater(
             () -> {
                 Debug.inventory(">> no longer dropping in inv");
-                droppingInInv = false;
+                if (inventoryMode == InventoryMode.DROPPING) inventoryMode = InventoryMode.NONE;
             },
             100, TimeUnit.MILLISECONDS
         );
+    }
+
+    /** Sets the inventory mode to {@link InventoryMode#SESSION} when the player opens a screen. */
+    public void setInInventorySession(boolean active) {
+        inventoryMode = active ? InventoryMode.SESSION : InventoryMode.NONE;
+    }
+
+    /** Returns {@code true} if the player currently has an inventory screen open. */
+    public boolean isInInventorySession() {
+        return inventoryMode == InventoryMode.SESSION;
+    }
+
+    /** Returns {@code true} if the player is in a momentary item-drop action. */
+    public boolean isDroppingInInv() {
+        return inventoryMode == InventoryMode.DROPPING;
+    }
+
+    /** Returns {@code true} if the player is in a momentary item-swap action. */
+    public boolean isSwappingInInv() {
+        return inventoryMode == InventoryMode.SWAPPING;
     }
 
     public void setPerformedDropAction() {
@@ -1658,11 +1671,6 @@ public class SwordPlayer extends Combatant {
             () -> performedDropAction = false,
             100, TimeUnit.MILLISECONDS
         );
-    }
-
-    @SuppressWarnings("all")
-    public boolean isInInventorySession() {
-        return inInventorySession;
     }
 
     public void incrementNumDummies() {

--- a/src/main/java/btm/sword/system/entity/impl/ThrowPhase.java
+++ b/src/main/java/btm/sword/system/entity/impl/ThrowPhase.java
@@ -1,0 +1,18 @@
+package btm.sword.system.entity.impl;
+
+/**
+ * Encodes the mutually exclusive phases of a {@link Combatant}'s throw lifecycle.
+ *
+ * <p>Replaces the three boolean fields ({@code attemptingThrow}, {@code throwCancelled},
+ * {@code throwSuccessful}) that previously allowed illegal combinations.</p>
+ */
+public enum ThrowPhase {
+    /** No throw is in progress. */
+    IDLE,
+    /** A throw has been initiated but not yet released or cancelled. */
+    THROWING,
+    /** The throw was interrupted before the item left the hand. */
+    CANCELLED,
+    /** The item was successfully released. */
+    SUCCESS
+}


### PR DESCRIPTION
## Summary

This PR introduces `ThrowPhase` and `InventoryMode` enums to replace boolean throw/inventory state flags on `Combatant`/`SwordPlayer`, gates hostile debug scans behind `LOGGING_VERBOSE_HOSTILE` (no world scan on every transition), and uses `ThrowPhase.THROWING` in `InputListener` and `GrabAction` in place of `isAttemptingThrow()`. 

Cleanly rebased onto `opt/optimization-apis` with no conflicts.

## Issues
Closes #304 
Closes #305 
Closes #306