### PR TITLE
[Perf] Combat performance pass and throw system cleanup

### DIFF
--- a/src/main/java/btm/sword/Sword.java
+++ b/src/main/java/btm/sword/Sword.java
@@ -12,6 +12,7 @@ import com.comphenix.protocol.ProtocolManager;
 
 import btm.sword.commands.SwordCommands;
 import btm.sword.config.ConfigManager;
+import btm.sword.listeners.CustomInteractionListener;
 import btm.sword.listeners.EntityListener;
 import btm.sword.listeners.ErrorListener;
 import btm.sword.listeners.InputListener;
@@ -29,6 +30,7 @@ import btm.sword.system.entity.display.DEUAnimationHook;
 import btm.sword.system.entity.display.WeaponAnchorPacketHook;
 import btm.sword.system.entity.display.WeaponDisplayRegistry;
 import btm.sword.system.entity.mob.MobTypeRegistry;
+import btm.sword.system.interaction.CustomInteractionManager;
 import btm.sword.system.inventory.InventoryMenuManager;
 import btm.sword.system.join.MenuSlotGrid;
 import btm.sword.system.join.ServerJoinArbiter;
@@ -72,6 +74,7 @@ public final class Sword extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new ErrorListener(), this);
         getServer().getPluginManager().registerEvents(new InputListener(), this);
         getServer().getPluginManager().registerEvents(new PlayerListener(), this);
+        getServer().getPluginManager().registerEvents(new CustomInteractionListener(), this);
         getServer().getPluginManager().registerEvents(new ServerJoinArbiter(), this);
         getServer().getPluginManager().registerEvents(new EntityListener(), this);
         getServer().getPluginManager().registerEvents(new DEUAnimationHook(), this);
@@ -96,6 +99,7 @@ public final class Sword extends JavaPlugin {
         ProjectileManager.startTicking();
 
         InventoryMenuManager.registerAll();
+        CustomInteractionManager.initialize();
 
         AnimationRegistry.initialize(this);
         MobTypeRegistry.initialize(this);

--- a/src/main/java/btm/sword/gamemode/ctf/CtfTeam.java
+++ b/src/main/java/btm/sword/gamemode/ctf/CtfTeam.java
@@ -6,12 +6,14 @@ import org.bukkit.Bukkit;
 import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.banner.Pattern;
 import org.bukkit.block.banner.PatternType;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BannerMeta;
 
 import btm.sword.config.Config;
+import lombok.Getter;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -33,32 +35,24 @@ public enum CtfTeam {
     /** The blue team. Spawn located at {@code Config.Ctf.BLUE_SPAWN_*}. */
     BLUE(DyeColor.BLUE, Material.BLUE_BANNER, NamedTextColor.BLUE);
 
+    /**
+     * -- GETTER --
+     *  Returns the DyeColor associated with this team.
+     */
+    @Getter
     private final DyeColor dyeColor;
     private final Material bannerMaterial;
+    /**
+     * -- GETTER --
+     *  Returns the Adventure text colour for this team, used in chat/title messages.
+     */
+    @Getter
     private final NamedTextColor textColor;
 
     CtfTeam(DyeColor dyeColor, Material bannerMaterial, NamedTextColor textColor) {
         this.dyeColor = dyeColor;
         this.bannerMaterial = bannerMaterial;
         this.textColor = textColor;
-    }
-
-    /**
-     * Returns the DyeColor associated with this team.
-     *
-     * @return team dye colour
-     */
-    public DyeColor getDyeColor() {
-        return dyeColor;
-    }
-
-    /**
-     * Returns the Adventure text colour for this team, used in chat/title messages.
-     *
-     * @return team text colour
-     */
-    public NamedTextColor getTextColor() {
-        return textColor;
     }
 
     /**
@@ -79,8 +73,8 @@ public enum CtfTeam {
      * @return team spawn {@link Location}
      */
     public Location getSpawnLocation() {
-        org.bukkit.World world = Bukkit.getWorld(Config.Ctf.SPAWN_WORLD);
-        if (world == null) world = Bukkit.getWorlds().get(0);
+        World tryWorld = Bukkit.getWorld(Config.Ctf.SPAWN_WORLD);
+        World world = tryWorld == null ? Bukkit.getWorlds().getFirst() : tryWorld;
 
         if (this == RED) {
             return new Location(world, Config.Ctf.RED_SPAWN_X, Config.Ctf.RED_SPAWN_Y, Config.Ctf.RED_SPAWN_Z);
@@ -99,7 +93,7 @@ public enum CtfTeam {
      * @return a named, patterned banner item
      */
     public ItemStack createFlagItem() {
-        ItemStack banner = new ItemStack(bannerMaterial);
+        ItemStack banner = ItemStack.of(bannerMaterial);
         BannerMeta meta = (BannerMeta) banner.getItemMeta();
 
         if (this == RED) {
@@ -114,7 +108,7 @@ public enum CtfTeam {
             ));
         }
 
-        meta.displayName(Component.text(name() + " FLAG", textColor, TextDecoration.BOLD)
+        meta.customName(Component.text(name() + " FLAG", textColor, TextDecoration.BOLD)
             .decoration(TextDecoration.ITALIC, false));
         banner.setItemMeta(meta);
         return banner;

--- a/src/main/java/btm/sword/listeners/CustomInteractionListener.java
+++ b/src/main/java/btm/sword/listeners/CustomInteractionListener.java
@@ -1,0 +1,86 @@
+package btm.sword.listeners;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.inventory.PrepareSmithingEvent;
+import org.bukkit.inventory.ItemStack;
+
+import btm.sword.system.hud.HudOverrideManager;
+import btm.sword.system.interaction.CustomInteractionContext;
+import btm.sword.system.interaction.CustomInteractionManager;
+import btm.sword.system.interaction.CustomInventoryInteraction;
+
+/**
+ * Bridges custom inventory interactions into Bukkit inventory events.
+ */
+public class CustomInteractionListener implements Listener {
+
+    @EventHandler
+    public void onInventoryOpen(InventoryOpenEvent event) {
+        if (event.getInventory().getType() == InventoryType.SMITHING && event.getPlayer() instanceof Player player) {
+            HudOverrideManager.enableCustomInteractionOverride(player);
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (event.getInventory().getType() == InventoryType.SMITHING && event.getPlayer() instanceof Player player) {
+            HudOverrideManager.disableCustomInteractionOverride(player);
+        }
+    }
+
+    @EventHandler
+    public void onPrepareSmithing(PrepareSmithingEvent event) {
+        if (!(event.getView().getPlayer() instanceof Player player)) {
+            return;
+        }
+
+        CustomInteractionContext context = new CustomInteractionContext(player, event.getView());
+        CustomInventoryInteraction interaction = CustomInteractionManager.find(context);
+        if (interaction != null) {
+            event.setResult(interaction.createResult(context));
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        if (event.getView().getTopInventory().getType() != InventoryType.SMITHING) {
+            return;
+        }
+        if (event.getRawSlot() != CustomInteractionContext.SMITHING_RESULT_SLOT) {
+            return;
+        }
+
+        CustomInteractionContext context = new CustomInteractionContext(player, event.getView());
+        CustomInventoryInteraction interaction = CustomInteractionManager.find(context);
+        if (interaction == null) {
+            return;
+        }
+
+        ItemStack result = interaction.createResult(context);
+        if (!canPlaceResult(event.getCursor(), result)) {
+            event.setCancelled(true);
+            return;
+        }
+
+        event.setCancelled(true);
+        interaction.consumeInputs(context);
+        event.getView().setCursor(result);
+        context.setTopItem(CustomInteractionContext.SMITHING_RESULT_SLOT, ItemStack.of(Material.AIR));
+        player.updateInventory();
+    }
+
+    private boolean canPlaceResult(ItemStack cursor, ItemStack result) {
+        return cursor == null || cursor.isEmpty()
+            || (cursor.isSimilar(result) && cursor.getAmount() + result.getAmount() <= cursor.getMaxStackSize());
+    }
+}

--- a/src/main/java/btm/sword/listeners/InputListener.java
+++ b/src/main/java/btm/sword/listeners/InputListener.java
@@ -23,6 +23,7 @@ import btm.sword.system.action.throwing.ThrowAction;
 import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.entity.impl.ThrowPhase;
 import btm.sword.system.input.InputType;
 import btm.sword.system.item.ItemClassifier;
 import btm.sword.utility.entity.InputUtil;
@@ -291,7 +292,7 @@ public class InputListener implements Listener {
             swordPlayer.resetTree();
         }
 
-        if (swordPlayer.isAttemptingThrow()) {
+        if (swordPlayer.getThrowPhase() == ThrowPhase.THROWING) {
             ThrowAction.throwCancel(swordPlayer);
         }
 

--- a/src/main/java/btm/sword/listeners/PlayerListener.java
+++ b/src/main/java/btm/sword/listeners/PlayerListener.java
@@ -281,7 +281,7 @@ public class PlayerListener implements Listener {
                 }
 
                 sp.spawnInventoryDrop(current);
-                sp.setItemAtIndex(new ItemStack(Material.AIR), slot);
+                sp.setItemAtIndex(ItemStack.of(Material.AIR), slot);
 
                 event.setCancelled(true);
             }

--- a/src/main/java/btm/sword/listeners/packet/MovementListener.java
+++ b/src/main/java/btm/sword/listeners/packet/MovementListener.java
@@ -13,6 +13,7 @@ import com.comphenix.protocol.events.PacketEvent;
 import com.comphenix.protocol.events.PacketListener;
 
 import btm.sword.Sword;
+import btm.sword.config.Config;
 import btm.sword.utility.Debug;
 
 /**
@@ -73,7 +74,9 @@ public class MovementListener implements PacketListener {
             event.getPacketType() == PacketType.Play.Client.GROUND ||
             event.getPacketType() == PacketType.Play.Client.ARM_ANIMATION) {
 
-            Debug.listener("Received a packet.\nPacketType=" + event.getPacketType());
+            if (Config.Debug.LOGGING_VERBOSE_LISTENER) {
+                Debug.listener("Received a packet.\nPacketType=" + event.getPacketType());
+            }
 
             if (!LOCKED_PLAYERS.contains(player.getUniqueId())) return;
 

--- a/src/main/java/btm/sword/system/action/movement/MovementAction.java
+++ b/src/main/java/btm/sword/system/action/movement/MovementAction.java
@@ -21,6 +21,7 @@ import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.aspect.AspectType;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.impl.Combatant;
+import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.utility.Debug;
 import btm.sword.utility.Prefab;
 import btm.sword.utility.SwordTimeUnit;
@@ -46,7 +47,6 @@ public class MovementAction extends SwordAction {
      * @param executor The combatant performing the dash.
      */
     public static void dash(Combatant executor, DashDirection direction) {
-        boolean onGround = executor.isGrounded();
         Runnable dashConsumer;
         switch (direction) {
             case FORWARD -> dashConsumer = () -> new Dash(executor, 1).execute();
@@ -57,6 +57,12 @@ public class MovementAction extends SwordAction {
         }
         // execution occurs immediately; input-driven casting is handled by the InputAction's castDuration
         dashConsumer.run();
+
+        // TODO: I'm resetting the tree here because not being at root is causing issues with the ability action
+        //  system. Should there be a builder call that describes terminals for ability inputs?
+        if (executor instanceof SwordPlayer sp && !sp.notHoldingAbilityItem()) {
+            sp.resetTree();
+        }
     }
 
     private static void strafe(Combatant executor, boolean onGround, int direction) {

--- a/src/main/java/btm/sword/system/action/skill/type/impl/active/KnifeThrowAbility.java
+++ b/src/main/java/btm/sword/system/action/skill/type/impl/active/KnifeThrowAbility.java
@@ -5,16 +5,20 @@ import java.util.Set;
 
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
+import org.joml.Vector3f;
 
 import btm.sword.system.action.skill.AbilityUseType;
 import btm.sword.system.action.skill.SkillId;
 import btm.sword.system.action.skill.SkillIds;
 import btm.sword.system.action.skill.SkillType;
 import btm.sword.system.action.skill.type.ActivatableAbility;
+import btm.sword.system.action.throwing.ImpactType;
 import btm.sword.system.action.throwing.ThrowAction;
+import btm.sword.system.action.throwing.types.ThrownItem;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.item.AbilityItemBuilder;
 import btm.sword.system.item.ItemStackBuilder;
+import btm.sword.utility.Prefab;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 
@@ -33,7 +37,7 @@ public class KnifeThrowAbility extends ActivatableAbility {
     private static final Component NAME = Component.text("Throwing Knife");
 
     /** Projectile scale relative to a normal thrown sword. */
-    private static final float PROJECTILE_SCALE = 0.5f;
+    private static final Vector3f PROJECTILE_SCALE = new Vector3f(0.5f, 0.75f, 0.5f);
 
     /** Initial velocity magnitude passed to the physics simulation. */
     private static final double PROJECTILE_VELOCITY = 2.0;
@@ -64,8 +68,7 @@ public class KnifeThrowAbility extends ActivatableAbility {
     @Override
     public List<Component> description() {
         return List.of(
-            Component.text("Hurl a knife at your target.", NamedTextColor.GRAY),
-            Component.text("Can also be used as a weak melee weapon.", NamedTextColor.DARK_GRAY)
+            Component.text("Hurl a knife at your target.", NamedTextColor.GRAY)
         );
     }
 
@@ -109,10 +112,18 @@ public class KnifeThrowAbility extends ActivatableAbility {
     public void execute(Combatant combatant) {
         ItemStack projectile = ItemStackBuilder.of(Material.DIAMOND_SWORD)
             .name(Component.text("Throwing Knife"))
+            .tagImpactType(ImpactType.IMPALE)
+            .unbreakable(true)
             .hideAll()
             .build();
         AbilityItemBuilder.tag(projectile, id());
         ThrowAction.throwDirect(combatant, projectile, PROJECTILE_SCALE, PROJECTILE_VELOCITY);
+        ThrownItem thrown = combatant.getThrownItem();
+        if (thrown != null) {
+            thrown.setHitPacket(Prefab.Attacks.KNIFE_THROW);
+            thrown.setKnockbackFunction(target ->
+                thrown.getVelocity().clone().multiply(0.2).add(target.self().getVelocity()));
+        }
     }
 
     @Override

--- a/src/main/java/btm/sword/system/action/throwing/ItemThrowStyle.java
+++ b/src/main/java/btm/sword/system/action/throwing/ItemThrowStyle.java
@@ -4,6 +4,7 @@ public enum ItemThrowStyle {
     SPEAR, // Strong, direct throw with no rotation, impaling enemies hit
     LOB, // for heavy objects like blocks, slight upward arc forward
     PITCH, // for smaller objects, a direct throw with more speed and
+    ROTATE, // a balanced spinning throw used by smithing refits and similar item mods
     HATCHET, // for axes and knives and short swords that would twirl forward when thrown
     // BOOMERANG ???
     // THROW_FOR_SHOW Twirl upwards for a cool catch or setup for other moves ???

--- a/src/main/java/btm/sword/system/action/throwing/ThrowAction.java
+++ b/src/main/java/btm/sword/system/action/throwing/ThrowAction.java
@@ -14,6 +14,7 @@ import btm.sword.system.action.throwing.types.ThrownItem;
 import btm.sword.system.action.throwing.types.VisualProjectile;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.entity.impl.ThrowPhase;
 import btm.sword.system.input.ActivationContext;
 
 /**
@@ -66,9 +67,7 @@ public class ThrowAction extends SwordAction {
      * @param itemOverride the explicit item to throw, or {@code null} to derive from the executor's hand
      */
     public static void throwReady(Combatant executor, @Nullable ItemStack itemOverride) {
-        executor.setAttemptingThrow(true);
-        executor.setThrowCancelled(false);
-        executor.setThrowSuccessful(false);
+        executor.setThrowPhase(ThrowPhase.THROWING);
         if (executor instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.THROWING);
 
         Consumer<ItemDisplay> setupInstructions;
@@ -126,9 +125,7 @@ public class ThrowAction extends SwordAction {
      * @param velocity     the initial velocity magnitude passed to {@link ThrownItem#onRelease(double)}
      */
     public static void throwDirect(Combatant executor, ItemStack item, Vector3f displayScale, double velocity) {
-        executor.setAttemptingThrow(true);
-        executor.setThrowCancelled(false);
-        executor.setThrowSuccessful(false);
+        executor.setThrowPhase(ThrowPhase.THROWING);
         if (executor instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.THROWING);
 
         ThrownItem thrownItem = new ThrownItem(executor, display -> display.setItemStack(item), 1);
@@ -147,8 +144,7 @@ public class ThrowAction extends SwordAction {
                 if (thrownItem.getDisplay() == null) {
                     misses++;
                 } else {
-                    executor.setAttemptingThrow(false);
-                    executor.setThrowSuccessful(true);
+                    executor.setThrowPhase(ThrowPhase.SUCCESS);
                     if (executor instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.NORMAL);
                     thrownItem.onRelease(velocity);
                     cancel();
@@ -193,9 +189,7 @@ public class ThrowAction extends SwordAction {
      */
     public static void throwCancel(Combatant executor) {
         Sword.getInstance().getLogger().info("\nThrow was <CANCELED>\n");
-        executor.setAttemptingThrow(false);
-        executor.setThrowCancelled(true);
-        executor.setThrowSuccessful(false);
+        executor.setThrowPhase(ThrowPhase.CANCELLED);
         if (executor instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.NORMAL);
 
         if (executor instanceof SwordPlayer sp) {
@@ -222,10 +216,9 @@ public class ThrowAction extends SwordAction {
      * @param executor The combatant performing the throw.
      */
     public static void throwItem(Combatant executor) {
-        if (executor.isThrowCancelled()) return;
+        if (executor.getThrowPhase() == ThrowPhase.CANCELLED) return;
 
-        executor.setAttemptingThrow(false);
-        executor.setThrowSuccessful(true);
+        executor.setThrowPhase(ThrowPhase.SUCCESS);
         if (executor instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.NORMAL);
 
         if (executor.getThrownItem() != null) executor.getThrownItem().onRelease(2);

--- a/src/main/java/btm/sword/system/action/throwing/ThrowAction.java
+++ b/src/main/java/btm/sword/system/action/throwing/ThrowAction.java
@@ -16,6 +16,7 @@ import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.entity.impl.ThrowPhase;
 import btm.sword.system.input.ActivationContext;
+import btm.sword.utility.Debug;
 
 /**
  * Handles the sequence of actions involved in a {@code Combatant} performing a throw action.
@@ -188,7 +189,7 @@ public class ThrowAction extends SwordAction {
      * @param executor The combatant whose throw action is being canceled.
      */
     public static void throwCancel(Combatant executor) {
-        Sword.getInstance().getLogger().info("\nThrow was <CANCELED>\n");
+        Debug.system("Throw was <CANCELED>");
         executor.setThrowPhase(ThrowPhase.CANCELLED);
         if (executor instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.NORMAL);
 

--- a/src/main/java/btm/sword/system/action/throwing/ThrowAction.java
+++ b/src/main/java/btm/sword/system/action/throwing/ThrowAction.java
@@ -6,10 +6,12 @@ import org.bukkit.entity.ItemDisplay;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.Nullable;
+import org.joml.Vector3f;
 
 import btm.sword.Sword;
 import btm.sword.system.action.SwordAction;
 import btm.sword.system.action.throwing.types.ThrownItem;
+import btm.sword.system.action.throwing.types.VisualProjectile;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.input.ActivationContext;
@@ -115,15 +117,15 @@ public class ThrowAction extends SwordAction {
      * <p>
      * {@code displayScale} is applied to the item's transform in
      * {@link ThrownItem#determineOrientation()} via
-     * {@link btm.sword.system.action.throwing.types.VisualProjectile#displayScale}.
+     * {@link VisualProjectile#setDisplayScale(Vector3f)}.
      * Pass {@code 1.0f} for normal size.
      *
      * @param executor     the combatant performing the throw
      * @param item         the item to throw
-     * @param displayScale uniform scale applied to the display transform (e.g. {@code 0.5f} for half size)
+     * @param displayScale scale vector applied to the display transform (e.g. {@code new Vector3f(x_scale, y_scale, z_scale)})
      * @param velocity     the initial velocity magnitude passed to {@link ThrownItem#onRelease(double)}
      */
-    public static void throwDirect(Combatant executor, ItemStack item, float displayScale, double velocity) {
+    public static void throwDirect(Combatant executor, ItemStack item, Vector3f displayScale, double velocity) {
         executor.setAttemptingThrow(true);
         executor.setThrowCancelled(false);
         executor.setThrowSuccessful(false);
@@ -153,6 +155,28 @@ public class ThrowAction extends SwordAction {
                 }
             }
         }.runTaskTimer(Sword.getInstance(), 0L, 1L);
+    }
+
+    /**
+     * Throws an item directly without the {@link #throwReady} aim-and-hold windup.
+     * <p>
+     * The display entity is spawned on the next server tick; once it exists the
+     * {@link ThrownItem} is immediately released at the given velocity — {@code onReady()}
+     * is never called. This is suitable for instant-release throws (e.g. knife throws)
+     * where no aim window or slowness effect is desired.
+     * <p>
+     * {@code displayScale} is applied to the item's transform in
+     * {@link ThrownItem#determineOrientation()} via
+     * {@link VisualProjectile#setDisplayScale(Vector3f)}.
+     * Pass {@code 1.0f} for normal size.
+     *
+     * @param executor     the combatant performing the throw
+     * @param item         the item to throw
+     * @param displayScale uniform scale applied to the display transform (e.g. {@code 0.5f} for half size)
+     * @param velocity     the initial velocity magnitude passed to {@link ThrownItem#onRelease(double)}
+     */
+    public static void throwDirect(Combatant executor, ItemStack item, float displayScale, double velocity) {
+        throwDirect(executor, item, new Vector3f(displayScale), velocity);
     }
 
     /**

--- a/src/main/java/btm/sword/system/action/throwing/types/SimulatedDisplay.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/SimulatedDisplay.java
@@ -33,8 +33,7 @@ public abstract class SimulatedDisplay implements InteractiveItem {
     protected void determineOrientation() {
         String name = display.getItemStack().getType().toString();
 
-        // *** These numbers are fine for now, config later but this system may change.
-
+        // TODO: use CONFIG
         if (name.endsWith("_SWORD")) {
             display.setTransformation(new Transformation(
                 new Vector3f(),
@@ -71,5 +70,4 @@ public abstract class SimulatedDisplay implements InteractiveItem {
             ));
         }
     }
-
 }

--- a/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
@@ -300,9 +300,7 @@ public class ThrownItem extends VisualProjectile {
             boolean isMainHand = thrower.getItemStackInHand(true).isSimilar(itemStack);
             thrower.setItemStackInHand(ItemStack.of(Material.AIR), isMainHand);
         }
-        if (!isAbilityItem()) {
-            super.handleOnReleaseActions(); // InteractiveItemArbiter.put(this)
-        }
+        super.handleOnReleaseActions(); // InteractiveItemArbiter.put(this)
     }
 
     /**

--- a/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
@@ -2,6 +2,7 @@ package btm.sword.system.action.throwing.types;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.bukkit.Color;
@@ -28,6 +29,7 @@ import btm.sword.config.Config;
 import btm.sword.system.action.throwing.ImpactType;
 import btm.sword.system.action.throwing.ThrowAction;
 import btm.sword.system.action.throwing.impale.Impalement;
+import btm.sword.system.attack.HitValuePacket;
 import btm.sword.system.control.PredicateRunnablePair;
 import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.control.TimeArbiter;
@@ -66,6 +68,15 @@ public class ThrownItem extends VisualProjectile {
 
     /** Predicate tested by the impalement follow-task to decide when embedding ends. */
     protected Predicate<VisualProjectile> exitImpalementStatePredicate;
+
+    /** If non-null, overrides {@link btm.sword.utility.Prefab.Attacks#THROWN_WEAPON} for hit resolution. */
+    private HitValuePacket hitPacket;
+
+    /**
+     * If non-null, overrides the default grounded/airborne knockback calculation.
+     * Receives the hit target and returns the knockback vector to apply.
+     */
+    private Function<SwordEntity, org.bukkit.util.Vector> knockbackFunction;
 
     // Landing marker (issue #15)
     private TextDisplay landingMarker;
@@ -166,9 +177,11 @@ public class ThrownItem extends VisualProjectile {
                 if (thrower instanceof SwordPlayer sp) {
                     if (!sp.isChangingHandIndex() && sp.getCurrentInvIndex() == sp.getThrownItemIndex()) {
                         if (iteration[0] < 10)
-                            sp.itemNameDisplay("- HURL IT AT 'EM SOLDIER! -", TextColor.color(100, 100, 100), null);
+                            sp.itemNameDisplay("- HURL IT AT 'EM SOLDIER! -",
+                                TextColor.color(100, 100, 100), null, Material.GUNPOWDER);
                         else
-                            sp.itemNameDisplay("| HURL IT AT 'EM SOLDIER! |", TextColor.color(150, 150, 150), null);
+                            sp.itemNameDisplay("| HURL IT AT 'EM SOLDIER! |",
+                                TextColor.color(150, 150, 150), null, Material.GUNPOWDER);
 
                         if (iteration[0] > 20) iteration[0] = 0;
                         iteration[0]++;
@@ -245,7 +258,7 @@ public class ThrownItem extends VisualProjectile {
 
         handleItemDamageAndCheckIfBroken();
 
-        if (ImpactType.fromItem(display.getItemStack()) == ImpactType.IMPALE) {
+        if (ImpactType.fromItem(itemStack) == ImpactType.IMPALE) {
             startImpalementTask(hitEntity);
         } else {
             nonImpalingImpact(hitEntity);
@@ -287,7 +300,9 @@ public class ThrownItem extends VisualProjectile {
             boolean isMainHand = thrower.getItemStackInHand(true).isSimilar(itemStack);
             thrower.setItemStackInHand(ItemStack.of(Material.AIR), isMainHand);
         }
-        super.handleOnReleaseActions(); // InteractiveItemArbiter.put(this)
+        if (!isAbilityItem()) {
+            super.handleOnReleaseActions(); // InteractiveItemArbiter.put(this)
+        }
     }
 
     /**
@@ -322,9 +337,15 @@ public class ThrownItem extends VisualProjectile {
             entity.getUniqueId() != display.getUniqueId()
                 && (entity instanceof LivingEntity l)
                 && !l.isDead();
-        return timeStep.get() < Config.Timing.THROWN_ITEMS_CATCH_GRACE_PERIOD
+        boolean excludeThrower = isAbilityItem()
+            || timeStep.get() < Config.Timing.THROWN_ITEMS_CATCH_GRACE_PERIOD;
+        return excludeThrower
             ? entity -> filter.test(entity) && entity.getUniqueId() != thrower.getUniqueId()
             : filter;
+    }
+
+    private boolean isAbilityItem() {
+        return itemStack != null && KeyRegistry.hasKey(itemStack, KeyRegistry.ABILITY_ID_KEY);
     }
 
     /**
@@ -394,8 +415,10 @@ public class ThrownItem extends VisualProjectile {
      * @param target the struck entity
      */
     protected void nonImpalingImpact(SwordEntity target) {
-        target.hit(thrower, Prefab.Attacks.THROWN_WEAPON,
-            velocity.clone().multiply(Config.Combat.THROWN_DAMAGE_OTHER_KNOCKBACK_MULTIPLIER));
+        Vector kb = knockbackFunction != null
+            ? knockbackFunction.apply(target)
+            : velocity.clone().multiply(Config.Combat.THROWN_DAMAGE_OTHER_KNOCKBACK_MULTIPLIER);
+        target.hit(thrower, hitPacket != null ? hitPacket : Prefab.Attacks.THROWN_WEAPON, kb);
 
         target.world().createExplosion(target.getChestLocation(),
             Config.Combat.THROWN_DAMAGE_OTHER_EXPLOSION_POWER,
@@ -413,15 +436,17 @@ public class ThrownItem extends VisualProjectile {
      * @param target the struck entity
      */
     public void startImpalementTask(SwordEntity target) {
-        Vector kb = EntityUtil.isOnGround(target.self())
-            ? velocity.clone().multiply(Config.Combat.THROWN_DAMAGE_SWORD_AXE_KNOCKBACK_GROUNDED)
-            : VectorUtil.getProjOntoPlane(velocity, Config.Direction.up())
-                .multiply(Config.Combat.THROWN_DAMAGE_SWORD_AXE_KNOCKBACK_AIRBORNE);
+        Vector kb = knockbackFunction != null
+            ? knockbackFunction.apply(target)
+            : EntityUtil.isOnGround(target.self())
+                ? velocity.clone().multiply(Config.Combat.THROWN_DAMAGE_SWORD_AXE_KNOCKBACK_GROUNDED)
+                : VectorUtil.getProjOntoPlane(velocity, Config.Direction.up())
+                    .multiply(Config.Combat.THROWN_DAMAGE_SWORD_AXE_KNOCKBACK_AIRBORNE);
 
         if (display.isValid()) {
             impale(target.self());
         }
-        target.hit(thrower, Prefab.Attacks.THROWN_WEAPON, kb);
+        target.hit(thrower, hitPacket != null ? hitPacket : Prefab.Attacks.THROWN_WEAPON, kb);
     }
 
     /**
@@ -589,6 +614,19 @@ public class ThrownItem extends VisualProjectile {
     // -----------------------------------------------------------------------
     // Dispose override — also removes the landing marker
     // -----------------------------------------------------------------------
+
+    /**
+     * For ability projectiles, silently disposes instead of dropping an interactive world item.
+     * Prevents knives and other ability throws from littering the ground on entity death or expiry.
+     */
+    @Override
+    public void disposeWithNewInteractiveItem() {
+        if (isAbilityItem()) {
+            dispose();
+            return;
+        }
+        super.disposeWithNewInteractiveItem();
+    }
 
     /**
      * Disposes of the item display, cancels tasks, and removes any landing marker.

--- a/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
@@ -36,6 +36,7 @@ import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.entity.impl.ThrowPhase;
 import btm.sword.system.input.ActivationContext;
 import btm.sword.system.item.ItemUsageManager;
 import btm.sword.system.item.KeyRegistry;
@@ -157,9 +158,8 @@ public class ThrownItem extends VisualProjectile {
             sp.setThrownItemIndex();
 
             if (sp.isInteractingWithEntity()) {
-                sp.setAttemptingThrow(false);
+                sp.setThrowPhase(ThrowPhase.SUCCESS);
                 sp.setActivationContext(ActivationContext.NORMAL);
-                sp.setThrowSuccessful(true);
                 sp.getThrownItem().onRelease(2);
                 thrower.setItemTypeInHand(Material.AIR, true);
                 sp.endHoldingRight();
@@ -196,7 +196,7 @@ public class ThrownItem extends VisualProjectile {
             0, 50,
             ThrownItem.class, "onReady",
             new PredicateRunnablePair(
-                thrower::isThrowCancelled,
+                () -> thrower.getThrowPhase() == ThrowPhase.CANCELLED,
                 () -> {
                     display.remove();
                     ThrowAction.throwCancel(thrower);
@@ -204,7 +204,7 @@ public class ThrownItem extends VisualProjectile {
                 }
             ),
             new PredicateRunnablePair(
-                thrower::isThrowSuccessful,
+                () -> thrower.getThrowPhase() == ThrowPhase.SUCCESS,
                 () -> thrower.setItemTypeInHand(Material.AIR, true)
             )
         );

--- a/src/main/java/btm/sword/system/action/throwing/types/VisualProjectile.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/VisualProjectile.java
@@ -284,7 +284,7 @@ public class VisualProjectile extends SimulatedDisplay {
     protected void rotate() {
         switch (getThrowStyle()) {
             case SPEAR -> {}
-            case HATCHET -> applyRotation(false, (float) Config.Physics.THROWN_ITEMS_ROTATION_SPEED_AXE);
+            case HATCHET, ROTATE -> applyRotation(false, (float) Config.Physics.THROWN_ITEMS_ROTATION_SPEED_AXE);
             case LOB -> applyRotation(true, (float) (Config.Physics.THROWN_ITEMS_ROTATION_SPEED_DEFAULT_SPEED * 0.4));
             default -> applyRotation(true, (float) Config.Physics.THROWN_ITEMS_ROTATION_SPEED_DEFAULT_SPEED);
         }

--- a/src/main/java/btm/sword/system/action/throwing/types/VisualProjectile.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/VisualProjectile.java
@@ -89,6 +89,8 @@ public class VisualProjectile extends SimulatedDisplay {
      */
     protected float displayScale = 1.0f;
 
+    protected Vector3f displayScaleVector = new Vector3f(1.0f);
+
     /**
      * Scales the time parameter fed to {@link #positionFunction}.
      * Negative value means no scaling (raw tick count is used).
@@ -478,29 +480,30 @@ public class VisualProjectile extends SimulatedDisplay {
             display.setTransformation(new Transformation(
                 base.add(new Vector3f()),
                 new Quaternionf().rotateY((float) Math.PI / 2).rotateZ((float) Math.PI / 2),
-                new Vector3f(displayScale, displayScale, displayScale),
+                displayScaleVector,
                 new Quaternionf()
             ));
         } else if (name.endsWith("AXE") || name.endsWith("_HOE") || name.endsWith("_SHOVEL")) {
-            float axeScale = 1.5f * displayScale;
+            Vector3f axeScaleVector = new Vector3f(displayScaleVector).mul(1.5f); // TODO: Config?
             display.setTransformation(new Transformation(
                 base.add(new Vector3f()),
                 new Quaternionf().rotateY((float) -Math.PI / 2).rotateZ((float) Math.PI / 4),
-                new Vector3f(axeScale, axeScale, axeScale),
+                // TODO: Config all of these magic numbers?
+                axeScaleVector,
                 new Quaternionf()
             ));
         } else if (display.getItemStack().getType() == Material.SHIELD) {
             display.setTransformation(new Transformation(
-                base.add(new Vector3f(0, 0, 0)),
+                base.add(new Vector3f(0)),
                 new Quaternionf().rotateY((float) (Math.PI / 1.01f) * 0),
-                new Vector3f(displayScale, displayScale, displayScale),
+                displayScaleVector,
                 new Quaternionf()
             ));
         } else {
             display.setTransformation(new Transformation(
                 base.add(new Vector3f()),
                 new Quaternionf().rotateZ((float) Math.PI / 8),
-                new Vector3f(displayScale, displayScale, displayScale),
+                displayScaleVector,
                 new Quaternionf()
             ));
         }
@@ -703,6 +706,16 @@ public class VisualProjectile extends SimulatedDisplay {
      */
     public void setTimeStep(int timeStep) {
         this.timeStep.set(timeStep);
+    }
+
+    public void setDisplayScale(float displayScale) {
+        this.displayScale = displayScale;
+        this.displayScaleVector = new Vector3f(displayScale);
+    }
+
+    public void setDisplayScale(Vector3f displayScaleVector) {
+        this.displayScale = 1;
+        this.displayScaleVector = displayScaleVector;
     }
 
     /**

--- a/src/main/java/btm/sword/system/action/utility/GrabAction.java
+++ b/src/main/java/btm/sword/system/action/utility/GrabAction.java
@@ -23,6 +23,7 @@ import btm.sword.system.entity.aspect.AspectType;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.entity.impl.ThrowPhase;
 import btm.sword.utility.Prefab;
 import btm.sword.utility.SwordTimeUnit;
 import btm.sword.utility.entity.HitboxUtil;
@@ -123,7 +124,9 @@ public class GrabAction extends SwordAction {
         SwordEntity swordTarget = SwordEntityArbiter.getOrAdd(target);
         if (swordTarget == null || swordTarget.isHit()) return;
 
-        if (swordTarget instanceof Combatant c && c.isAttemptingThrow()) c.setThrowCancelled(true);
+        if (swordTarget instanceof Combatant c && c.getThrowPhase() == ThrowPhase.THROWING) {
+            c.setThrowPhase(ThrowPhase.CANCELLED);
+        }
 
         if (executor instanceof SwordPlayer swordPlayer) {
             swordPlayer.setTargetedEntity(swordTarget);

--- a/src/main/java/btm/sword/system/entity/SwordTeam.java
+++ b/src/main/java/btm/sword/system/entity/SwordTeam.java
@@ -32,6 +32,8 @@ public enum SwordTeam {
     /** Reserved for future faction use. */
     YELLOW("sword_team_yellow");
 
+    private static final SwordTeam[] VALUES = values();
+
     private final String tag;
 
     SwordTeam(String tag) {
@@ -51,7 +53,7 @@ public enum SwordTeam {
      * @return the matching team, or {@code null}
      */
     public static SwordTeam fromEntity(LivingEntity entity) {
-        for (SwordTeam team : values()) {
+        for (SwordTeam team : VALUES) {
             if (entity.getScoreboardTags().contains(team.tag)) {
                 return team;
             }

--- a/src/main/java/btm/sword/system/entity/ai/HostileStateMachine.java
+++ b/src/main/java/btm/sword/system/entity/ai/HostileStateMachine.java
@@ -45,12 +45,22 @@ public class HostileStateMachine extends StateMachine<Hostile> {
 
     @Override
     public void onAnyTransition() {
-        context.broadcastMessage(20, "cur: " + currentState.name());
+        if (Config.Debug.LOGGING_VERBOSE_HOSTILE) {
+            context.broadcastMessage(20, "cur: " + currentState.name());
+        }
     }
 
     @Override
     public void afterAnyTransition() {
-        context.broadcastMessage(20, ">>> New State: " + currentState.name());
+        if (Config.Debug.LOGGING_VERBOSE_HOSTILE) {
+            context.broadcastMessage(20, ">>> New State: " + currentState.name());
+        }
+    }
+
+    @Override
+    public void tick() {
+        context.refreshTargetDistanceCache();
+        super.tick();
     }
 
     /**
@@ -132,8 +142,7 @@ public class HostileStateMachine extends StateMachine<Hostile> {
             PreAttackState.class,
             h -> {
                 if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return false;
-                return h.self().getLocation()
-                    .distanceSquared(h.getCurrentTarget().self().getLocation()) < Config.Hostile.APPROACH_DISTANCE_SQUARED;
+                return h.getCachedDistSqToTarget() < Config.Hostile.APPROACH_DISTANCE_SQUARED;
             },
             h -> {}
         ));
@@ -169,8 +178,7 @@ public class HostileStateMachine extends StateMachine<Hostile> {
             h -> {
                 if (!h.isAttackDone() || h.getAttackPostRoll() != 0) return false;
                 if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return false;
-                return h.self().getLocation()
-                    .distanceSquared(h.getCurrentTarget().self().getLocation()) <= Config.Hostile.AGGRO_RANGE_SQUARED;
+                return h.getCachedDistSqToTarget() <= Config.Hostile.AGGRO_RANGE_SQUARED;
             },
             h -> {}
         ));
@@ -182,8 +190,7 @@ public class HostileStateMachine extends StateMachine<Hostile> {
             h -> {
                 if (!h.isAttackDone() || h.getAttackPostRoll() != 1) return false;
                 if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return false;
-                return h.self().getLocation()
-                    .distanceSquared(h.getCurrentTarget().self().getLocation()) <= Config.Hostile.AGGRO_RANGE_SQUARED;
+                return h.getCachedDistSqToTarget() <= Config.Hostile.AGGRO_RANGE_SQUARED;
             },
             h -> {}
         ));
@@ -195,8 +202,7 @@ public class HostileStateMachine extends StateMachine<Hostile> {
             h -> {
                 if (!h.isAttackDone() || h.getAttackPostRoll() != 2) return false;
                 if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return false;
-                return h.self().getLocation()
-                    .distanceSquared(h.getCurrentTarget().self().getLocation()) <= Config.Hostile.AGGRO_RANGE_SQUARED;
+                return h.getCachedDistSqToTarget() <= Config.Hostile.AGGRO_RANGE_SQUARED;
             },
             h -> h.setCombo(true)
         ));
@@ -208,8 +214,7 @@ public class HostileStateMachine extends StateMachine<Hostile> {
             h -> {
                 if (!h.isAttackDone()) return false;
                 if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return true;
-                return h.self().getLocation()
-                    .distanceSquared(h.getCurrentTarget().self().getLocation()) > Config.Hostile.AGGRO_RANGE_SQUARED;
+                return h.getCachedDistSqToTarget() > Config.Hostile.AGGRO_RANGE_SQUARED;
             },
             h -> {
                 h.setCurrentTarget(null);
@@ -229,8 +234,7 @@ public class HostileStateMachine extends StateMachine<Hostile> {
             h -> {
                 if (h.getOnGuardTimer() > 0) return false;
                 if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return false;
-                return h.self().getLocation()
-                    .distanceSquared(h.getCurrentTarget().self().getLocation()) <= Config.Hostile.AGGRO_RANGE_SQUARED;
+                return h.getCachedDistSqToTarget() <= Config.Hostile.AGGRO_RANGE_SQUARED;
             },
             h -> {}
         ));
@@ -242,8 +246,7 @@ public class HostileStateMachine extends StateMachine<Hostile> {
             h -> {
                 if (h.getOnGuardTimer() > 0) return false;
                 if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return true;
-                return h.self().getLocation()
-                    .distanceSquared(h.getCurrentTarget().self().getLocation()) > Config.Hostile.AGGRO_RANGE_SQUARED;
+                return h.getCachedDistSqToTarget() > Config.Hostile.AGGRO_RANGE_SQUARED;
             },
             h -> {
                 h.setCurrentTarget(null);
@@ -260,8 +263,7 @@ public class HostileStateMachine extends StateMachine<Hostile> {
             h -> {
                 if (h.getAttackReadyTimer() > 0) return false;
                 if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return false;
-                return h.self().getLocation()
-                    .distanceSquared(h.getCurrentTarget().self().getLocation()) <= Config.Hostile.AGGRO_RANGE_SQUARED;
+                return h.getCachedDistSqToTarget() <= Config.Hostile.AGGRO_RANGE_SQUARED;
             },
             h -> {}
         ));
@@ -273,8 +275,7 @@ public class HostileStateMachine extends StateMachine<Hostile> {
             h -> {
                 if (h.getAttackReadyTimer() > 0) return false;
                 if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return true;
-                return h.self().getLocation()
-                    .distanceSquared(h.getCurrentTarget().self().getLocation()) > Config.Hostile.AGGRO_RANGE_SQUARED;
+                return h.getCachedDistSqToTarget() > Config.Hostile.AGGRO_RANGE_SQUARED;
             },
             h -> {
                 h.setCurrentTarget(null);
@@ -291,8 +292,7 @@ public class HostileStateMachine extends StateMachine<Hostile> {
             h -> {
                 if (h.getRetreatTimer() > 0) return false;
                 if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return false;
-                return h.self().getLocation()
-                    .distanceSquared(h.getCurrentTarget().self().getLocation()) < Config.Hostile.AGGRO_RANGE_SQUARED;
+                return h.getCachedDistSqToTarget() < Config.Hostile.AGGRO_RANGE_SQUARED;
             },
             h -> {}
         ));
@@ -304,8 +304,7 @@ public class HostileStateMachine extends StateMachine<Hostile> {
             h -> {
                 if (h.getRetreatTimer() > 0) return false;
                 if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return true;
-                return h.self().getLocation()
-                    .distanceSquared(h.getCurrentTarget().self().getLocation()) >= Config.Hostile.AGGRO_RANGE_SQUARED;
+                return h.getCachedDistSqToTarget() >= Config.Hostile.AGGRO_RANGE_SQUARED;
             },
             h -> {
                 h.setCurrentTarget(null);
@@ -339,8 +338,7 @@ public class HostileStateMachine extends StateMachine<Hostile> {
             h -> {
                 if (h.getLodgedThrowItem() != null) return false;
                 if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return false;
-                return h.self().getLocation()
-                    .distanceSquared(h.getCurrentTarget().self().getLocation()) <= Config.Hostile.AGGRO_RANGE_SQUARED;
+                return h.getCachedDistSqToTarget() <= Config.Hostile.AGGRO_RANGE_SQUARED;
             },
             h -> {}
         ));
@@ -352,8 +350,7 @@ public class HostileStateMachine extends StateMachine<Hostile> {
             h -> {
                 if (h.getLodgedThrowItem() != null) return false;
                 if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return true;
-                return h.self().getLocation()
-                    .distanceSquared(h.getCurrentTarget().self().getLocation()) > Config.Hostile.AGGRO_RANGE_SQUARED;
+                return h.getCachedDistSqToTarget() > Config.Hostile.AGGRO_RANGE_SQUARED;
             },
             h -> {
                 h.setCurrentTarget(null);

--- a/src/main/java/btm/sword/system/entity/ai/HostileStateMachine.java
+++ b/src/main/java/btm/sword/system/entity/ai/HostileStateMachine.java
@@ -18,6 +18,7 @@ import btm.sword.system.entity.ai.state.RetreatState;
 import btm.sword.system.entity.ai.state.RetrieveWeaponState;
 import btm.sword.system.entity.ai.state.SurroundState;
 import btm.sword.system.entity.impl.Hostile;
+import btm.sword.system.entity.impl.ThrowPhase;
 import btm.sword.utility.statemachine.State;
 import btm.sword.utility.statemachine.StateMachine;
 import btm.sword.utility.statemachine.Transition;
@@ -94,7 +95,7 @@ public class HostileStateMachine extends StateMachine<Hostile> {
             h -> {
                 if (h.getAiStateMachine().getState() instanceof RetrieveWeaponState) return false;
                 if (h.getAiStateMachine().getState() instanceof FleeState) return false;
-                if (h.isAttemptingThrow()) return false;
+                if (h.getThrowPhase() == ThrowPhase.THROWING) return false;
                 return h.getLodgedThrowItem() != null
                     && h.getLodgedThrowItem().getDisplay() != null
                     && h.getLodgedThrowItem().getDisplay().isValid();

--- a/src/main/java/btm/sword/system/entity/ai/ability/MobSlashAbility.java
+++ b/src/main/java/btm/sword/system/entity/ai/ability/MobSlashAbility.java
@@ -34,8 +34,7 @@ public class MobSlashAbility implements MobAbility {
 
     @Override
     public boolean canUse(Hostile h) {
-        Integer cooldown = h.getAbilityCooldowns().get(name());
-        return cooldown == null || cooldown <= 0;
+        return h.getAbilityCooldown(name()) <= 0;
     }
 
     @Override

--- a/src/main/java/btm/sword/system/entity/ai/ability/MobSlashAbility.java
+++ b/src/main/java/btm/sword/system/entity/ai/ability/MobSlashAbility.java
@@ -42,7 +42,7 @@ public class MobSlashAbility implements MobAbility {
     public void execute(Hostile h) {
         if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return;
         AttackType type = SLASH_TYPES[ThreadLocalRandom.current().nextInt(SLASH_TYPES.length)];
-        MobSweepAttack attack = new MobSweepAttack(new ItemStack(Material.STONE_SWORD), type, false);
+        MobSweepAttack attack = new MobSweepAttack(ItemStack.of(Material.STONE_SWORD), type, false);
         attack.execute(h);
     }
 

--- a/src/main/java/btm/sword/system/entity/ai/ability/MobThrowAbility.java
+++ b/src/main/java/btm/sword/system/entity/ai/ability/MobThrowAbility.java
@@ -128,7 +128,7 @@ public class MobThrowAbility implements MobAbility {
             }
 
             h.mob().setRotation(yaw, 0f);
-            ItemStack dirt = new ItemStack(Material.DIRT);
+            ItemStack dirt = ItemStack.of(Material.DIRT);
             h.setItemStackInHand(dirt, true);
 
             ThrowAction.throwReady(h, dirt);

--- a/src/main/java/btm/sword/system/entity/ai/ability/MobThrowAbility.java
+++ b/src/main/java/btm/sword/system/entity/ai/ability/MobThrowAbility.java
@@ -51,8 +51,7 @@ public class MobThrowAbility implements MobAbility {
      */
     @Override
     public boolean canUse(Hostile h) {
-        Integer cooldown = h.getAbilityCooldowns().get(name());
-        if (cooldown != null && cooldown > 0) return false;
+        if (h.getAbilityCooldown(name()) > 0) return false;
         return ThreadLocalRandom.current().nextDouble() < Config.Hostile.MOB_THROW_WEIGHT;
     }
 

--- a/src/main/java/btm/sword/system/entity/ai/ability/MobThrowAbility.java
+++ b/src/main/java/btm/sword/system/entity/ai/ability/MobThrowAbility.java
@@ -14,6 +14,7 @@ import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.entity.ai.MobGoalArbiter;
 import btm.sword.system.entity.ai.goal.LookAtTargetGoal;
 import btm.sword.system.entity.impl.Hostile;
+import btm.sword.system.entity.impl.ThrowPhase;
 
 /**
  * A ranged throwing ability for hostile mobs.
@@ -62,7 +63,7 @@ public class MobThrowAbility implements MobAbility {
         // Guard: combo re-entry (roll=2) re-calls execute() before the first throw's delayed
         // throwItem() fires. Without this check, a second ThrownItem is created and the first
         // one's display + landing marker are orphaned and never cleaned up.
-        if (h.isAttemptingThrow()) return;
+        if (h.getThrowPhase() == ThrowPhase.THROWING) return;
 
         MobGoalArbiter.GOALS.addGoal(h.mob(), 1, new LookAtTargetGoal(h.mob(), h));
 
@@ -107,7 +108,7 @@ public class MobThrowAbility implements MobAbility {
      */
     private void executeDirtThrow(Hostile h, Vector toTarget) {
         // Prevent re-entry during the animation window
-        h.setAttemptingThrow(true);
+        h.setThrowPhase(ThrowPhase.THROWING);
 
         float yaw = h.mob().getLocation().getYaw();
         h.mob().setRotation(yaw, 70f);
@@ -122,7 +123,7 @@ public class MobThrowAbility implements MobAbility {
         SwordScheduler.runBukkitTaskLater(() -> {
             if (!h.self().isValid() || h.getCurrentTarget() == null
                     || !h.getCurrentTarget().self().isValid()) {
-                h.setAttemptingThrow(false);
+                h.setThrowPhase(ThrowPhase.IDLE);
                 return;
             }
 

--- a/src/main/java/btm/sword/system/entity/ai/goal/FleeGoal.java
+++ b/src/main/java/btm/sword/system/entity/ai/goal/FleeGoal.java
@@ -91,9 +91,7 @@ public class FleeGoal implements Goal<@NotNull Mob> {
     /** Recalculates the flee direction every {@value #RECALC_CADENCE} ticks. */
     @Override
     public void tick() {
-        recalcTick++;
-        if (recalcTick >= RECALC_CADENCE) {
-            recalcTick = 0;
+        if (hostile.shouldRunAllyScan()) {
             recalculateFleeDirection();
         }
     }

--- a/src/main/java/btm/sword/system/entity/ai/state/ApproachState.java
+++ b/src/main/java/btm/sword/system/entity/ai/state/ApproachState.java
@@ -54,9 +54,7 @@ public class ApproachState extends HostileAIFacade {
     }
 
     private void handleAllyScan(Hostile h) {
-        h.setAllyScanTimer(h.getAllyScanTimer() + 1);
-        if (h.getAllyScanTimer() < 20) return;
-        h.setAllyScanTimer(0);
+        if (!h.shouldRunAllyScan()) return;
 
         double aggroRadius = Math.sqrt(Config.Hostile.AGGRO_RANGE_SQUARED);
         List<Hostile> allies = h.self().getWorld().getNearbyLivingEntities(

--- a/src/main/java/btm/sword/system/entity/ai/state/IdleState.java
+++ b/src/main/java/btm/sword/system/entity/ai/state/IdleState.java
@@ -53,9 +53,7 @@ public class IdleState extends HostileAIFacade {
     }
 
     private void handleAggroScan(Hostile h) {
-        h.setAggroScanTimer(h.getAggroScanTimer() + 1);
-        if (h.getAggroScanTimer() < 10) return;
-        h.setAggroScanTimer(0);
+        if (!h.shouldRunAggroScan()) return;
 
         // If the mob remembers a previous target, re-engage them immediately when in range.
         SwordEntity remembered = h.getAggroTarget();

--- a/src/main/java/btm/sword/system/entity/ai/state/SurroundState.java
+++ b/src/main/java/btm/sword/system/entity/ai/state/SurroundState.java
@@ -42,9 +42,7 @@ public class SurroundState extends HostileAIFacade {
     public void onTick(Hostile h) {
         if (h.getCurrentTarget() == null || !h.getCurrentTarget().self().isValid()) return;
 
-        h.setAllyScanTimer(h.getAllyScanTimer() + 1);
-        if (h.getAllyScanTimer() >= 20) {
-            h.setAllyScanTimer(0);
+        if (h.shouldRunAllyScan()) {
             evaluateArcPosition(h);
         }
     }

--- a/src/main/java/btm/sword/system/entity/base/CombatProfile.java
+++ b/src/main/java/btm/sword/system/entity/base/CombatProfile.java
@@ -1,6 +1,6 @@
 package btm.sword.system.entity.base;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 
 import btm.sword.system.action.skill.container.PlayerSkillContainer;
 import btm.sword.system.entity.aspect.AspectType;
@@ -15,7 +15,7 @@ import lombok.Getter;
  * <p>
  * Each {@code CombatProfile} defines a unique set of {@link AspectType aspect values}
  * that govern core combat resources such as shards, toughness, and soulfire.
- * These stats are stored in a {@link HashMap} mapping {@link AspectType} keys to
+ * These stats are stored in an {@link EnumMap} mapping {@link AspectType} keys to
  * {@link AspectValue} or {@link ResourceValue} instances.
  * </p>
  *
@@ -79,7 +79,7 @@ public class CombatProfile {
      * adjusted in-game through {@link btm.sword.system.entity.base.EntityAspects}.
      * </p>
      */
-    private final HashMap<AspectType, AspectValue> stats = new HashMap<>(); // max Stats
+    private final EnumMap<AspectType, AspectValue> stats = new EnumMap<>(AspectType.class); // max Stats
 
     /**
      * The maximum number of consecutive air-dodges the entity can perform

--- a/src/main/java/btm/sword/system/entity/base/SwordEntity.java
+++ b/src/main/java/btm/sword/system/entity/base/SwordEntity.java
@@ -76,6 +76,8 @@ import net.kyori.adventure.text.format.TextDecoration;
 @Getter
 @Setter
 public abstract class SwordEntity {
+    private static final PotionEffect IMPALE_SLOW = new PotionEffect(PotionEffectType.SLOWNESS, 1, 1);
+
     protected final UUID uuid;
     protected final CombatProfile combatProfile;
     protected final LivingEntity self;
@@ -222,7 +224,7 @@ public abstract class SwordEntity {
 
 
         if (isImpaled()) {
-            self.addPotionEffect(new PotionEffect(PotionEffectType.SLOWNESS, 1, 1));
+            self.addPotionEffect(IMPALE_SLOW);
         }
 
         if (statusDisplay != null && isStatusActive()) {

--- a/src/main/java/btm/sword/system/entity/base/SwordEntity.java
+++ b/src/main/java/btm/sword/system/entity/base/SwordEntity.java
@@ -936,7 +936,7 @@ public abstract class SwordEntity {
      * @param main true for main hand, false for off hand
      */
     public void setItemTypeInHand(Material itemType, boolean main) {
-        setItemStackInHand(new ItemStack(itemType), main);
+        setItemStackInHand(ItemStack.of(itemType), main);
     }
 
     /**

--- a/src/main/java/btm/sword/system/entity/base/SwordEntity.java
+++ b/src/main/java/btm/sword/system/entity/base/SwordEntity.java
@@ -110,6 +110,8 @@ public abstract class SwordEntity {
     private boolean grabbed;
     private boolean aiEnabled;
 
+    private SwordTeam cachedTeam;
+
     protected boolean shielding;
 
     protected final HashMap<Class<? extends Affliction>, Affliction> afflictions = new HashMap<>();
@@ -547,8 +549,7 @@ public abstract class SwordEntity {
                     float baseSoulfireReduction,
                     Vector knockbackVelocity,
                     Affliction... afflictions) {
-        SwordTeam attackerTeam = SwordTeam.fromEntity(source.self());
-        if (attackerTeam != null && attackerTeam == SwordTeam.fromEntity(self)) {
+        if (source.getCachedTeam() != null && source.getCachedTeam() == cachedTeam) {
             return;
         }
 
@@ -695,20 +696,21 @@ public abstract class SwordEntity {
      * @param team the team to join
      */
     public void joinTeam(SwordTeam team) {
-        for (SwordTeam existing : SwordTeam.values()) {
-            self.removeScoreboardTag(existing.tag());
+        if (cachedTeam != null) {
+            self.removeScoreboardTag(cachedTeam.tag());
         }
         self.addScoreboardTag(team.tag());
+        cachedTeam = team;
     }
 
     /**
-     * Returns this entity's current {@link SwordTeam} by reading its Bukkit scoreboard tags,
-     * or {@code null} if no sword team tag is present.
+     * Returns this entity's current {@link SwordTeam} from the cached field set in
+     * {@link #joinTeam(SwordTeam)}, or {@code null} if no team has been assigned.
      *
      * @return the team, or {@code null}
      */
     public SwordTeam getTeam() {
-        return SwordTeam.fromEntity(self);
+        return cachedTeam;
     }
 
     /**

--- a/src/main/java/btm/sword/system/entity/display/DisplayRig.java
+++ b/src/main/java/btm/sword/system/entity/display/DisplayRig.java
@@ -200,9 +200,9 @@ public final class DisplayRig {
             // Hidden state: keep the hook active so DEU's item-reset packets are suppressed.
             currentWeaponItem = null;
             WeaponAnchorPacketHook.override(
-                weaponAnchor, new ItemStack(Material.AIR), 0.001f, new Quaternionf(), new Vector3f());
+                weaponAnchor, ItemStack.of(Material.AIR), 0.001f, new Quaternionf(), new Vector3f());
             weaponAnchor.setGlowing(false);
-            weaponAnchor.setItemStack(new ItemStack(Material.AIR));
+            weaponAnchor.setItemStack(ItemStack.of(Material.AIR));
             return;
         }
 

--- a/src/main/java/btm/sword/system/entity/impl/Combatant.java
+++ b/src/main/java/btm/sword/system/entity/impl/Combatant.java
@@ -64,9 +64,7 @@ public abstract class Combatant extends SwordEntity {
     private ThrownItem thrownItem;
     private ItemStack offHandItemStackDuringThrow;
     private ItemStack mainHandItemStackDuringThrow;
-    private boolean attemptingThrow;
-    private boolean throwCancelled;
-    private boolean throwSuccessful;
+    private ThrowPhase throwPhase = ThrowPhase.IDLE;
 
     private final AttributeInstance attrHealth;
     private final AttributeInstance attrAbsorption;

--- a/src/main/java/btm/sword/system/entity/impl/Hostile.java
+++ b/src/main/java/btm/sword/system/entity/impl/Hostile.java
@@ -144,7 +144,7 @@ public class Hostile extends Combatant {
     private int onGuardTimer;
     private int attackReadyTimer;
 
-    ItemStack itemInLeftHand = new ItemStack(Material.SHIELD);
+    ItemStack itemInLeftHand = ItemStack.of(Material.SHIELD);
     ItemStack itemInRightHand = WeaponType.FALCHION.buildItemStack();
 
     /**
@@ -190,7 +190,7 @@ public class Hostile extends Combatant {
             } else {
                 equipment.setItemInMainHand(itemInRightHand);
                 equipment.setItemInOffHand(itemInLeftHand);
-                equipment.setChestplate(new ItemStack(Material.NETHERITE_CHESTPLATE));
+                equipment.setChestplate(ItemStack.of(Material.NETHERITE_CHESTPLATE));
             }
         }
     }

--- a/src/main/java/btm/sword/system/entity/impl/Hostile.java
+++ b/src/main/java/btm/sword/system/entity/impl/Hostile.java
@@ -1,12 +1,9 @@
 package btm.sword.system.entity.impl;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import org.bukkit.GameMode;
@@ -61,12 +58,39 @@ import lombok.Setter;
 @Getter
 @Setter
 public class Hostile extends Combatant {
+    private enum AbilitySlot {
+        SLASH("mob_slash"),
+        THROW("mob_throw");
+
+        private static final AbilitySlot[] VALUES = values();
+
+        private final String abilityName;
+
+        AbilitySlot(String abilityName) {
+            this.abilityName = abilityName;
+        }
+
+        public static AbilitySlot fromName(String name) {
+            for (AbilitySlot slot : VALUES) {
+                if (slot.abilityName.equals(name)) {
+                    return slot;
+                }
+            }
+            return null;
+        }
+    }
+
+    private record RegisteredAbility(AbilitySlot slot, MobAbility ability) {}
+
+    private static final int AGGRO_SCAN_CADENCE = 10;
+    private static final int ALLY_SCAN_CADENCE = 20;
+
     private final Mob mob;
     private final Pathfinder pathfinder;
     private Location origin;
 
     /** Ordered list of abilities this mob can select from during pre-attack. */
-    private final List<MobAbility> possibleAbilities;
+    private final List<RegisteredAbility> possibleAbilities;
 
     /** The ability selected at the start of PreAttackState; executed on AttackState entry. */
     private MobAbility pendingAbility;
@@ -79,7 +103,7 @@ public class Hostile extends Combatant {
     private ThrownItem lodgedThrowItem;
 
     /** Per-ability cooldown counters (ticks remaining). Decremented each tick; removed at 0. */
-    private final Map<String, Integer> abilityCooldowns;
+    private final int[] abilityCooldowns;
 
     /**
      * Log of every hit this mob received from a player, accumulated over its lifetime.
@@ -161,11 +185,11 @@ public class Hostile extends Combatant {
         pathfinder.setCanOpenDoors(true);
 
         origin = mob.getLocation();
-        possibleAbilities = new ArrayList<>();
-        abilityCooldowns = new HashMap<>();
-
-        possibleAbilities.add(new MobSlashAbility());
-        possibleAbilities.add(new MobThrowAbility());
+        possibleAbilities = List.of(
+            new RegisteredAbility(AbilitySlot.SLASH, new MobSlashAbility()),
+            new RegisteredAbility(AbilitySlot.THROW, new MobThrowAbility())
+        );
+        abilityCooldowns = new int[AbilitySlot.values().length];
 
         MobTypeDefinition mobTypeDef = MobTypeRegistry.getByEntityType(associatedEntity.getType());
         usesDisplayRig = mobTypeDef != null && mobTypeDef.displayGroup() != null;
@@ -342,17 +366,18 @@ public class Hostile extends Combatant {
      * {@code pendingAbility} is set to {@code null}.
      */
     public void selectAbility() {
-        List<MobAbility> available = new ArrayList<>();
-        for (MobAbility ability : possibleAbilities) {
+        MobAbility selected = null;
+        int seenUsable = 0;
+        for (RegisteredAbility registered : possibleAbilities) {
+            MobAbility ability = registered.ability();
             if (ability.canUse(this)) {
-                available.add(ability);
+                seenUsable++;
+                if (ThreadLocalRandom.current().nextInt(seenUsable) == 0) {
+                    selected = ability;
+                }
             }
         }
-        if (available.isEmpty()) {
-            pendingAbility = null;
-            return;
-        }
-        pendingAbility = available.get(new Random().nextInt(available.size()));
+        pendingAbility = selected;
     }
 
     /**
@@ -362,19 +387,37 @@ public class Hostile extends Combatant {
      * @param ticks the cooldown duration in ticks
      */
     public void setAbilityCooldown(String name, int ticks) {
-        abilityCooldowns.put(name, ticks);
+        AbilitySlot slot = AbilitySlot.fromName(name);
+        if (slot != null) {
+            abilityCooldowns[slot.ordinal()] = Math.max(ticks, 0);
+        }
+    }
+
+    public int getAbilityCooldown(String name) {
+        AbilitySlot slot = AbilitySlot.fromName(name);
+        return slot == null ? 0 : abilityCooldowns[slot.ordinal()];
+    }
+
+    public boolean shouldRunAggroScan() {
+        return shouldRunStaggeredScan(AGGRO_SCAN_CADENCE);
+    }
+
+    public boolean shouldRunAllyScan() {
+        return shouldRunStaggeredScan(ALLY_SCAN_CADENCE);
+    }
+
+    private boolean shouldRunStaggeredScan(int cadence) {
+        if (cadence <= 0) {
+            return true;
+        }
+        return Math.floorMod((int) (ticks + uuid.hashCode()), cadence) == 0;
     }
 
     /** Decrements all per-ability cooldown counters and removes entries that reach zero. */
     private void tickAbilityCooldowns() {
-        Iterator<Map.Entry<String, Integer>> it = abilityCooldowns.entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry<String, Integer> entry = it.next();
-            int remaining = entry.getValue() - 1;
-            if (remaining <= 0) {
-                it.remove();
-            } else {
-                entry.setValue(remaining);
+        for (int i = 0; i < abilityCooldowns.length; i++) {
+            if (abilityCooldowns[i] > 0) {
+                abilityCooldowns[i]--;
             }
         }
     }

--- a/src/main/java/btm/sword/system/entity/impl/Hostile.java
+++ b/src/main/java/btm/sword/system/entity/impl/Hostile.java
@@ -168,6 +168,9 @@ public class Hostile extends Combatant {
     private int onGuardTimer;
     private int attackReadyTimer;
 
+    /** Cached squared distance to {@link #currentTarget}, refreshed once per tick by {@link HostileStateMachine}. */
+    @Getter private double cachedDistSqToTarget = Double.MAX_VALUE;
+
     ItemStack itemInLeftHand = ItemStack.of(Material.SHIELD);
     ItemStack itemInRightHand = WeaponType.FALCHION.buildItemStack();
 
@@ -327,6 +330,19 @@ public class Hostile extends Combatant {
     public void onReleased() {
         incapacitated = false;
         mob.setAware(true);
+    }
+
+    /**
+     * Refreshes {@link #cachedDistSqToTarget} once per tick so transition conditions
+     * can read it without re-allocating {@link org.bukkit.Location} objects.
+     * Call this at the start of {@link btm.sword.system.entity.ai.HostileStateMachine#tick()}.
+     */
+    public void refreshTargetDistanceCache() {
+        if (currentTarget == null || !currentTarget.self().isValid()) {
+            cachedDistSqToTarget = Double.MAX_VALUE;
+        } else {
+            cachedDistSqToTarget = self().getLocation().distanceSquared(currentTarget.self().getLocation());
+        }
     }
 
     public void broadcastMessage(double radius, String message) {

--- a/src/main/java/btm/sword/system/entity/impl/InventoryMode.java
+++ b/src/main/java/btm/sword/system/entity/impl/InventoryMode.java
@@ -1,0 +1,18 @@
+package btm.sword.system.entity.impl;
+
+/**
+ * Encodes the mutually exclusive inventory interaction modes of a {@link SwordPlayer}.
+ *
+ * <p>Replaces the three boolean fields ({@code swappingInInv}, {@code droppingInInv},
+ * {@code inInventorySession}) that previously allowed illegal combinations.</p>
+ */
+public enum InventoryMode {
+    /** No inventory interaction is active. */
+    NONE,
+    /** The player is momentarily swapping items (clears after ~1 tick). */
+    SWAPPING,
+    /** The player is momentarily dropping items (clears after ~2 ticks). */
+    DROPPING,
+    /** The player has an inventory screen open. */
+    SESSION
+}

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -495,11 +495,11 @@ public class SwordPlayer extends Combatant {
             activationContext = ActivationContext.NORMAL;
         }
 
-        Debug.input("Pre-Ability Check Message, cur path="+inputExecutionTree.getPlainTextInputSequence() +
-            "\n           input="+input+
-            "\n           holdingAbilityItem?="+!notHoldingAbilityItem()+
-            "\n           isAtRoot="+isAtRoot() +
-            "\n           notHoldingChargeable="+!ChargeAction.isHoldingChargeable(this));
+        Debug.input("Pre-Ability Check Message, cur path=" + inputExecutionTree.getPlainTextInputSequence()
+            + "\n           input=" + input
+            + "\n           holdingAbilityItem?=" + !notHoldingAbilityItem()
+            + "\n           isAtRoot=" + isAtRoot()
+            + "\n           notHoldingChargeable=" + !ChargeAction.isHoldingChargeable(this));
 
         if (isAtRoot() && !ChargeAction.isHoldingChargeable(this) && handleAbilityInput(input)) {
             resetTree();

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -201,10 +201,7 @@ public class SwordPlayer extends Combatant {
 
     private int thrownItemIndex;
 
-    private boolean swappingInInv;
-    private boolean droppingInInv;
-    @Setter
-    private boolean inInventorySession;
+    private InventoryMode inventoryMode = InventoryMode.NONE;
 
     /** True while the scene overlay (glass-pane fill + invisibility) is active. Suppresses inventory upkeep. */
     private boolean inSceneOverlay = false;
@@ -344,9 +341,7 @@ public class SwordPlayer extends Combatant {
 
         thrownItemIndex = -1;
 
-        swappingInInv = false;
-        droppingInInv = false;
-        inInventorySession = false;
+        inventoryMode = InventoryMode.NONE;
     }
 
     /**
@@ -1624,32 +1619,50 @@ public class SwordPlayer extends Combatant {
 
     /**
      * Marks that the player is currently swapping items in inventory.
-     * Resets the flag shortly after (1 tick).
+     * Resets to {@link InventoryMode#NONE} after ~1 tick.
      */
     public void setSwappingInInv() {
-        swappingInInv = true;
-
+        inventoryMode = InventoryMode.SWAPPING;
         SwordScheduler.runBukkitTaskLater(
-            () -> swappingInInv = false,
+            () -> { if (inventoryMode == InventoryMode.SWAPPING) inventoryMode = InventoryMode.NONE; },
             50, TimeUnit.MILLISECONDS
         );
     }
 
     /**
      * Marks that the player is currently dropping items in inventory.
-     * Resets the flag shortly after (1 tick).
+     * Resets to {@link InventoryMode#NONE} after ~2 ticks.
      */
     public void setDroppingInInv() {
         Debug.inventory(">> set dropping in inv");
-
-        droppingInInv = true;
+        inventoryMode = InventoryMode.DROPPING;
         SwordScheduler.runBukkitTaskLater(
             () -> {
                 Debug.inventory(">> no longer dropping in inv");
-                droppingInInv = false;
+                if (inventoryMode == InventoryMode.DROPPING) inventoryMode = InventoryMode.NONE;
             },
             100, TimeUnit.MILLISECONDS
         );
+    }
+
+    /** Sets the inventory mode to {@link InventoryMode#SESSION} when the player opens a screen. */
+    public void setInInventorySession(boolean active) {
+        inventoryMode = active ? InventoryMode.SESSION : InventoryMode.NONE;
+    }
+
+    /** Returns {@code true} if the player currently has an inventory screen open. */
+    public boolean isInInventorySession() {
+        return inventoryMode == InventoryMode.SESSION;
+    }
+
+    /** Returns {@code true} if the player is in a momentary item-drop action. */
+    public boolean isDroppingInInv() {
+        return inventoryMode == InventoryMode.DROPPING;
+    }
+
+    /** Returns {@code true} if the player is in a momentary item-swap action. */
+    public boolean isSwappingInInv() {
+        return inventoryMode == InventoryMode.SWAPPING;
     }
 
     public void setPerformedDropAction() {
@@ -1658,11 +1671,6 @@ public class SwordPlayer extends Combatant {
             () -> performedDropAction = false,
             100, TimeUnit.MILLISECONDS
         );
-    }
-
-    @SuppressWarnings("all")
-    public boolean isInInventorySession() {
-        return inInventorySession;
     }
 
     public void incrementNumDummies() {

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -29,7 +29,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.persistence.PersistentDataType;
-import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.Transformation;
 import org.bukkit.util.Vector;
 import org.joml.Quaternionf;
@@ -82,6 +81,7 @@ import btm.sword.system.item.special.NonMovableItem;
 import btm.sword.system.item.special.SlotAnchoredItem;
 import btm.sword.system.playerdata.PlayerData;
 import btm.sword.system.playerdata.PlayerStorage;
+import btm.sword.system.scene.CameraController;
 import btm.sword.system.scene.animation.CutsceneInputHandler;
 import btm.sword.utility.Debug;
 import btm.sword.utility.Prefab;
@@ -162,7 +162,7 @@ public class SwordPlayer extends Combatant {
     private boolean performedDropAction;
     @Getter
     @Setter
-    private ItemStack lastHeldItemBeforeDrop = new ItemStack(Material.AIR);
+    private ItemStack lastHeldItemBeforeDrop = ItemStack.of(Material.AIR);
     @Setter
     private boolean changingHandIndex;
     @Setter
@@ -171,9 +171,6 @@ public class SwordPlayer extends Combatant {
     private boolean threwItem;
     @Setter
     private boolean blocking;
-
-    private boolean punchingWithLink = false;
-    private boolean commandingWithLink = false;
 
     /** System.currentTimeMillis() deadline for the active parry hit-detection window. */
     @Setter
@@ -244,9 +241,8 @@ public class SwordPlayer extends Combatant {
 
     @Getter
     @Setter
-    private btm.sword.system.scene.CameraController activeCameraController;
+    private CameraController activeCameraController;
 
-    private BukkitTask targetIndicatorTask;
     private SwordEntity targetedEntity;
     private TextDisplay targetIndicator;
 
@@ -270,7 +266,7 @@ public class SwordPlayer extends Combatant {
         profile = player.getPlayerProfile();
         username = profile.getName();
 
-        ItemStack temp = new ItemStack(Material.PLAYER_HEAD);
+        ItemStack temp = ItemStack.of(Material.PLAYER_HEAD);
         SkullMeta skullMeta = (SkullMeta) temp.getItemMeta();
         skullMeta.setPlayerProfile(profile);
 
@@ -495,6 +491,12 @@ public class SwordPlayer extends Combatant {
             activationContext = ActivationContext.NORMAL;
         }
 
+        Debug.input("Pre-Ability Check Message, cur path="+inputExecutionTree.getPlainTextInputSequence() +
+            "\n           input="+input+
+            "\n           holdingAbilityItem?="+!notHoldingAbilityItem()+
+            "\n           isAtRoot="+isAtRoot() +
+            "\n           notHoldingChargeable="+!ChargeAction.isHoldingChargeable(this));
+
         if (isAtRoot() && !ChargeAction.isHoldingChargeable(this) && handleAbilityInput(input)) {
             resetTree();
             return;
@@ -551,6 +553,8 @@ public class SwordPlayer extends Combatant {
             }
         }
 
+        Debug.input("Line before step is resolved.");
+
         // The execution trie is only traversed if the code makes it here!
         InputExecutionTree.InputNode node = inputExecutionTree.step(input);
 
@@ -574,16 +578,6 @@ public class SwordPlayer extends Combatant {
         if (internalAction != null) {
             internalAction.accept(this);
         }
-    }
-
-    public boolean isAbilityItem(ItemStack item) {
-        SwordItemType itemType = SwordItemType.fromString(item);
-        Debug.combat("ItemType=" + itemType);
-        return itemType == SwordItemType.ACTIVE_1 || itemType == SwordItemType.ACTIVE_2;
-    }
-
-    public boolean isAbilityItem(SwordItemType itemType) {
-        return itemType == SwordItemType.ACTIVE_1 || itemType == SwordItemType.ACTIVE_2;
     }
 
     public boolean isHeldItemOnCooldown() {
@@ -689,7 +683,7 @@ public class SwordPlayer extends Combatant {
 
     /**
      * Enters the scene overlay: saves the player's inventory (slots 0–35), fills all slots with
-     * blue stained glass panes (keeping the menu button in slot 8), hides the player from others,
+     * blue stained-glass panes (keeping the menu button in slot 8), hides the player from others,
      * and deactivates the umbral blade. Also suppresses {@link #inventoryUpkeep()} until exited.
      * <p>
      * Call from a {@link btm.sword.system.scene.CameraController}'s {@code onStart()} hook.
@@ -814,9 +808,9 @@ public class SwordPlayer extends Combatant {
 
         // Place menu button one row above the hotbar (slot 17) to free up the hotbar
         player.getInventory().setItem(17, menuButton.getItemStack());
-        player.getInventory().setItem(0, new ItemStack(Material.WOODEN_AXE));
-        player.getInventory().setItem(1, new ItemStack(Material.FIREWORK_ROCKET));
-        player.getInventory().setItem(38, new ItemStack(Material.ELYTRA));
+        player.getInventory().setItem(0, ItemStack.of(Material.WOODEN_AXE));
+        player.getInventory().setItem(1, ItemStack.of(Material.FIREWORK_ROCKET));
+        player.getInventory().setItem(38, ItemStack.of(Material.ELYTRA));
 
         setAllAnchoredItemUpkeep(false);
         Debug.SPECIAL_ITEM_CHECKS_ENABLED = false;
@@ -1002,7 +996,7 @@ public class SwordPlayer extends Combatant {
         }
 
         // Scene overlay is active — cancel all inventory interactions except the menu button above.
-        // Left-clicking an interactible (non-NON_MOVABLE) slot fires the scene-exit stub.
+        // Left-clicking an interactable (non-NON_MOVABLE) slot fires the scene-exit stub.
         // When special item checks are disabled, all overlay restrictions are bypassed.
         if (inSceneOverlay && Debug.SPECIAL_ITEM_CHECKS_ENABLED) {
             if (clickType == ClickType.LEFT && !clicked.getType().isAir() &&
@@ -1084,7 +1078,7 @@ public class SwordPlayer extends Combatant {
     }
 
     public ItemStack getPlayerHeadItemWithCustomText(Component title, List<Component> lore) {
-        ItemStack temp = new ItemStack(Material.PLAYER_HEAD);
+        ItemStack temp = ItemStack.of(Material.PLAYER_HEAD);
         SkullMeta skullMeta = (SkullMeta) temp.getItemMeta();
         skullMeta.setPlayerProfile(profile);
 
@@ -1229,7 +1223,7 @@ public class SwordPlayer extends Combatant {
         float cur = aspects.soulfireCur();
         itemNameDisplay(Component.text("»  " + (int) cur, TextColor.color(80, 80, 80), TextDecoration.BOLD)
             .append(Component.text("  ᅳ" + consumed, TextColor.color(30, 108, 167), TextDecoration.BOLD))
-            .append(Component.text("  «", TextColor.color(80, 80, 80), TextDecoration.BOLD)));
+            .append(Component.text("  «", TextColor.color(80, 80, 80), TextDecoration.BOLD)), null);
     }
 
     public void displayLackOfSoulfire(float required) {
@@ -1293,14 +1287,18 @@ public class SwordPlayer extends Combatant {
                     Duration.ofMillis(fadeOut))));
     }
 
-    public void itemNameDisplay(Component displayName) {
+    // TODO: Some way to cache this new itemStack and just send the equipment change each time
+    public void itemNameDisplay(Component displayName, Material newMaterial) {
         ItemStack stack = getItemStackInHand(true).clone();
-        if (stack.isEmpty() || stack.getType().isAir()) stack = new ItemStack(Material.GUNPOWDER);
+        if (newMaterial != null && (stack.isEmpty() || stack.getType().isAir())) {
+            stack = ItemStack.of(newMaterial);
+        }
         ItemMeta metaData = stack.getItemMeta();
         if (metaData == null) {
             return;
         }
-        metaData.displayName(displayName);
+
+        metaData.customName(displayName);
 
         stack.setItemMeta(metaData);
         player.sendEquipmentChange(self, EquipmentSlot.HAND, stack);
@@ -1313,12 +1311,12 @@ public class SwordPlayer extends Combatant {
      * @param color the {@link TextColor} to apply
      * @param style the {@link TextDecoration} to apply, or null for none
      */
-    public void itemNameDisplay(String toDisplay, TextColor color, TextDecoration style) {
+    public void itemNameDisplay(String toDisplay, TextColor color, @Nullable TextDecoration style, Material newMaterial) {
         if (style == null) {
-            itemNameDisplay(Component.text(toDisplay, color));
+            itemNameDisplay(Component.text(toDisplay, color), newMaterial);
         }
         else {
-            itemNameDisplay(Component.text(toDisplay, color, style));
+            itemNameDisplay(Component.text(toDisplay, color, style), newMaterial);
         }
     }
 
@@ -1370,6 +1368,7 @@ public class SwordPlayer extends Combatant {
         targetedEntity = newTarget;
     }
 
+    // TODO: Apply more often and give more meaning (Issue #279)
     protected void targetEntityIndicatorTick() {
         if (targetedEntity == null) return;
 
@@ -1432,18 +1431,19 @@ public class SwordPlayer extends Combatant {
         holdingRight = true;
         rightHoldTimeStart = System.currentTimeMillis();
 
-        mainItemStackAtTimeOfHold = getItemStackInHand(true);
-        offItemStackAtTimeOfHold = getItemStackInHand(false);
+        ItemStack mainHand = getItemStackInHand(true);
+        ItemStack offHand = getItemStackInHand(false);
+        mainItemStackAtTimeOfHold = mainHand == null ? ItemStack.of(Material.AIR) : mainHand.clone();
+        offItemStackAtTimeOfHold = offHand == null ? ItemStack.of(Material.AIR) : offHand.clone();
 
         indexOfRightHold = getCurrentInvIndex();
 
-        if (!holdingUmbralItemInMainHand()) {
-
-            if (!mainItemStackAtTimeOfHold.isEmpty() &&
-                !holdingUmbralItemInMainHand()) {
-                setItemStackInHand(new ItemStack(Material.GUNPOWDER), true); // can change the logic here later
-            }
+        if (!mainItemStackAtTimeOfHold.isEmpty() &&
+            !holdingUmbralItemInMainHand() &&
+            notHoldingAbilityItem()) {
+            setItemStackInHand(ItemStack.of(Material.GUNPOWDER), true); // can change the logic here later
         }
+
 
         rightClickHoldTask = TimeArbiter.runTimeIndependentBukkitTaskOnTimer(
             () -> {
@@ -1492,8 +1492,14 @@ public class SwordPlayer extends Combatant {
         setBlocking(false);
         cancelBlockDrainTask();
         setItemStackInHand(offItemStackAtTimeOfHold, false);
-        if (!mainItemStackAtTimeOfHold.isEmpty() && !threwItem && !holdingUmbralItemInMainHand())
-            setItemAtIndex(mainItemStackAtTimeOfHold, indexOfRightHold);
+        if (!threwItem && !holdingUmbralItemInMainHand()) {
+            if (abilitySlotManager.isAbilityHeldSlot(indexOfRightHold)) {
+                abilitySlotManager.restoreSlot(indexOfRightHold);
+            }
+            else if (!mainItemStackAtTimeOfHold.isEmpty()) {
+                setItemAtIndex(mainItemStackAtTimeOfHold, indexOfRightHold);
+            }
+        }
     }
 
     /**

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -29,6 +29,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Transformation;
 import org.bukkit.util.Vector;
 import org.joml.Quaternionf;
@@ -57,6 +59,8 @@ import btm.sword.system.control.SwordScheduler;
 import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.aspect.AspectType;
 import btm.sword.system.entity.base.SwordEntity;
+import btm.sword.system.hud.HudOverrideManager;
+import btm.sword.system.hud.HudRenderState;
 import btm.sword.system.input.ActivationContext;
 import btm.sword.system.input.InputAction;
 import btm.sword.system.input.InputActionExecutor;
@@ -1064,8 +1068,48 @@ public class SwordPlayer extends Combatant {
 
     public void updateVisualStats() {
         player.setAbsorptionAmount(aspects.toughnessCur());
-        player.setHealth(Math.max(2, 2 * aspects.shardsCur()));
-        player.setFoodLevel((int) (20 * (aspects.soulfireCur() / aspects.soulfireMaxVal())));
+        HudRenderState state = new HudRenderState(
+            Math.max(2, 2 * aspects.shardsCur()),
+            (int) (20 * (aspects.soulfireCur() / aspects.soulfireMaxVal())),
+            5.0f,
+            player.getRemainingAir()
+        );
+        HudOverrideManager.apply(player, HudOverrideManager.resolve(player, state));
+    }
+
+    /**
+     * Cycles through four HUD effect visuals for testing purposes, each lasting 5 seconds:
+     * wither hearts, poisoned hearts, empty food bar, then bubbles animating full to empty to full.
+     */
+    public void testHudSequence() {
+        player.addPotionEffect(new PotionEffect(PotionEffectType.WITHER, 100, 0, false, false));
+
+        SwordScheduler.after(5, TimeUnit.SECONDS, () -> {
+            player.removePotionEffect(PotionEffectType.WITHER);
+            player.addPotionEffect(new PotionEffect(PotionEffectType.POISON, 100, 0, false, false));
+        })
+        .andThen(5, TimeUnit.SECONDS, () -> {
+            player.removePotionEffect(PotionEffectType.POISON);
+            HudOverrideManager.register(player, "hud_test", 200,
+                (p, state) -> new HudRenderState(state.health(), 0, 0.0f, state.air()));
+        })
+        .andThen(5, TimeUnit.SECONDS, () -> {
+            HudOverrideManager.clear(player, "hud_test");
+            int maxAir = player.getMaximumAir();
+            int[] it = {0};
+            TimeArbiter.runFixedIterationTaskTimer(
+                () -> {
+                    int step = it[0]++;
+                    int air = step <= 50
+                        ? (int) ((maxAir - 1) * (1.0 - step / 50.0))
+                        : (int) ((maxAir - 1) * (step - 50) / 50.0);
+                    player.setRemainingAir(air);
+                },
+                null, 0, 50, 100,
+                SwordPlayer.class, "testHudSequence",
+                () -> player.setRemainingAir(maxAir)
+            );
+        });
     }
 
     /**

--- a/src/main/java/btm/sword/system/entity/impl/ThrowPhase.java
+++ b/src/main/java/btm/sword/system/entity/impl/ThrowPhase.java
@@ -1,0 +1,18 @@
+package btm.sword.system.entity.impl;
+
+/**
+ * Encodes the mutually exclusive phases of a {@link Combatant}'s throw lifecycle.
+ *
+ * <p>Replaces the three boolean fields ({@code attemptingThrow}, {@code throwCancelled},
+ * {@code throwSuccessful}) that previously allowed illegal combinations.</p>
+ */
+public enum ThrowPhase {
+    /** No throw is in progress. */
+    IDLE,
+    /** A throw has been initiated but not yet released or cancelled. */
+    THROWING,
+    /** The throw was interrupted before the item left the hand. */
+    CANCELLED,
+    /** The item was successfully released. */
+    SUCCESS
+}

--- a/src/main/java/btm/sword/system/entity/umbral/statemachine/UmbralStateMachine.java
+++ b/src/main/java/btm/sword/system/entity/umbral/statemachine/UmbralStateMachine.java
@@ -468,7 +468,7 @@ public class UmbralStateMachine extends StateMachine<UmbralBlade> {
         if (deactivated) return;
 
         currentState.onTick(context);
-        for (var t : transitions.keySet()) {
+        for (var t : transitions) {
             if (t.from().isAssignableFrom(currentState.getClass())
                 && t.condition().test(context)) {
 

--- a/src/main/java/btm/sword/system/hud/HudOverride.java
+++ b/src/main/java/btm/sword/system/hud/HudOverride.java
@@ -1,0 +1,19 @@
+package btm.sword.system.hud;
+
+import org.bukkit.entity.Player;
+
+/**
+ * Functional hook for mutating the vanilla HUD values shown to a player.
+ */
+@FunctionalInterface
+public interface HudOverride {
+
+    /**
+     * Applies an override to the current render state.
+     *
+     * @param player the player receiving the HUD
+     * @param state  the current HUD state
+     * @return the adjusted HUD state
+     */
+    HudRenderState apply(Player player, HudRenderState state);
+}

--- a/src/main/java/btm/sword/system/hud/HudOverrideManager.java
+++ b/src/main/java/btm/sword/system/hud/HudOverrideManager.java
@@ -1,0 +1,78 @@
+package btm.sword.system.hud;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.bukkit.attribute.Attribute;
+import org.bukkit.entity.Player;
+
+/**
+ * Central registry for systems that want to suppress or replace vanilla HUD elements.
+ */
+public final class HudOverrideManager {
+
+    private record RegisteredOverride(String key, int priority, HudOverride override) {}
+
+    public static final String CUSTOM_INTERACTION_KEY = "custom_interaction";
+
+    private static final Map<UUID, Map<String, RegisteredOverride>> OVERRIDES = new ConcurrentHashMap<>();
+
+    private static final HudOverride CUSTOM_INTERACTION_OVERRIDE = (player, state) -> {
+        double maxHealth = player.getAttribute(Attribute.MAX_HEALTH) != null
+            ? player.getAttribute(Attribute.MAX_HEALTH).getValue() // TODO: Make sure you're null-checking instances like this!
+            : state.health();
+        return new HudRenderState(maxHealth, 20, 5.0f, player.getMaximumAir());
+    };
+
+    private HudOverrideManager() {}
+
+    public static void register(Player player, String key, int priority, HudOverride override) {
+        OVERRIDES.computeIfAbsent(player.getUniqueId(), ignored -> new ConcurrentHashMap<>())
+            .put(key, new RegisteredOverride(key, priority, override));
+    }
+
+    public static void clear(Player player, String key) {
+        Map<String, RegisteredOverride> playerOverrides = OVERRIDES.get(player.getUniqueId());
+        if (playerOverrides == null) {
+            return;
+        }
+        playerOverrides.remove(key);
+        if (playerOverrides.isEmpty()) {
+            OVERRIDES.remove(player.getUniqueId());
+        }
+    }
+
+    public static void clearAll(Player player) {
+        OVERRIDES.remove(player.getUniqueId());
+    }
+
+    public static void enableCustomInteractionOverride(Player player) {
+        register(player, CUSTOM_INTERACTION_KEY, 100, CUSTOM_INTERACTION_OVERRIDE);
+    }
+
+    public static void disableCustomInteractionOverride(Player player) {
+        clear(player, CUSTOM_INTERACTION_KEY);
+    }
+
+    public static HudRenderState resolve(Player player, HudRenderState baseState) {
+        Map<String, RegisteredOverride> playerOverrides = OVERRIDES.get(player.getUniqueId());
+        if (playerOverrides == null || playerOverrides.isEmpty()) {
+            return baseState;
+        }
+
+        HudRenderState resolved = baseState;
+        for (RegisteredOverride override : playerOverrides.values().stream()
+            .sorted(Comparator.comparingInt(RegisteredOverride::priority))
+            .toList()) {
+            resolved = override.override().apply(player, resolved);
+        }
+        return resolved;
+    }
+
+    public static void apply(Player player, HudRenderState state) {
+        player.sendHealthUpdate(state.health(), state.food(), state.saturation());
+        player.setRemainingAir(state.air());
+    }
+}

--- a/src/main/java/btm/sword/system/hud/HudRenderState.java
+++ b/src/main/java/btm/sword/system/hud/HudRenderState.java
@@ -1,0 +1,16 @@
+package btm.sword.system.hud;
+
+/**
+ * Immutable snapshot of the vanilla HUD values currently presented to a player.
+ *
+ * @param health     displayed health value
+ * @param food       displayed food value
+ * @param saturation displayed saturation value
+ * @param air        displayed remaining air value
+ */
+public record HudRenderState(
+    double health,
+    int food,
+    float saturation,
+    int air
+) {}

--- a/src/main/java/btm/sword/system/input/InputExecutionTree.java
+++ b/src/main/java/btm/sword/system/input/InputExecutionTree.java
@@ -24,6 +24,7 @@ import lombok.Setter;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 
 /**
  * Represents a finite state tree that tracks sequences of player {@link InputType} inputs,
@@ -68,7 +69,7 @@ public class InputExecutionTree {
         stopTimeoutTimer();
         potentialInputSelectionText = Component.text(""); // reset potential input before new step
         // before taking input, if it is known that the current node is a leaf, reset and take input from the root
-        if (!hasChildren()) reset();
+        if (isTerminal()) reset();
 
         if (currentNode == null) {
             reset();
@@ -108,7 +109,7 @@ public class InputExecutionTree {
 
         currentNode = next;
 
-        if (!hasChildren()) return next;
+        if (isTerminal()) return next;
 
         boolean alreadyAppendedArrow = false;
 
@@ -239,12 +240,17 @@ public class InputExecutionTree {
      *
      * @return true if children exist, false otherwise
      */
-    public boolean hasChildren() {
-        return !currentNode.children.isEmpty();
+    public boolean isTerminal() {
+        return currentNode.children.isEmpty();
     }
 
     public Component getInputSequenceAsComponent() {
         return Component.textOfChildren(baseSequenceToDisplay, potentialInputSelectionText);
+    }
+
+    public String getPlainTextInputSequence() {
+        return PlainTextComponentSerializer.plainText().serialize(baseSequenceToDisplay) +
+            PlainTextComponentSerializer.plainText().serialize(potentialInputSelectionText);
     }
 
     /**
@@ -549,24 +555,19 @@ public class InputExecutionTree {
         }
 
         /**
-         * Returns true if this node is inaccessible for the given player.
+         * Sets the node-level visibility predicate. When the predicate returns {@code false}
+         * the node is hidden and not navigable, regardless of its action context predicates.
+         * <p>
+         * The Predicate should return true if this node is inaccessible for the given player.
          * <p>
          * For leaf nodes (with actions): hidden if no action's context predicate passes.
          * For intermediate nodes (null or empty actions): hidden only if every child is also
          * hidden — this prevents stepping into a path whose entire subtree is context-gated
          * (e.g. the F {@literal >} L umbral-skill prefix when not holding soul link).
          * </p>
-         *
-         * @param player the player to evaluate
-         * @return true if no accessible path exists through this node, false otherwise
-         */
-        /**
-         * Sets the node-level visibility predicate. When the predicate returns {@code false}
-         * the node is hidden and not navigable, regardless of its action context predicates.
-         *
          * @param visibleIf predicate returning {@code true} when this node should be visible
          */
-        public void setVisibleIf(Predicate<SwordPlayer> visibleIf) {
+        public void setVisibleIfPredicate(Predicate<SwordPlayer> visibleIf) {
             this.visibleIf = visibleIf;
         }
 
@@ -717,7 +718,7 @@ public class InputExecutionTree {
                     dummy.setDynamic(dynamic);
                 }
                 if (visibleIf != null) {
-                    dummy.setVisibleIf(visibleIf);
+                    dummy.setVisibleIfPredicate(visibleIf);
                 }
             }
         }

--- a/src/main/java/btm/sword/system/input/InputRegistrar.java
+++ b/src/main/java/btm/sword/system/input/InputRegistrar.java
@@ -255,7 +255,10 @@ public final class InputRegistrar {
             new InputExecutionTree.ActionContextPair(
                 () -> InputAction.builder()
                     .name("Release Charge")
-                    .action(c -> Debug.combat("Release now happens implicitly within Charge Action..."))
+                    .action(c -> {
+                        if (c instanceof SwordPlayer sp) sp.resetTree();
+                        Debug.combat("Release now happens implicitly within Charge Action...");
+                    })
                     .cooldown(executor -> 0)
                     .canCast(c -> true)
                     .displayDisabled(false)

--- a/src/main/java/btm/sword/system/interaction/CustomInteractionContext.java
+++ b/src/main/java/btm/sword/system/interaction/CustomInteractionContext.java
@@ -1,0 +1,38 @@
+package btm.sword.system.interaction;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Snapshot wrapper passed to custom inventory interactions.
+ */
+public record CustomInteractionContext(
+    Player player,
+    InventoryView view
+) {
+
+    public static final int SMITHING_TEMPLATE_SLOT = 0;
+    public static final int SMITHING_BASE_SLOT = 1;
+    public static final int SMITHING_ADDITION_SLOT = 2;
+    public static final int SMITHING_RESULT_SLOT = 3;
+
+    public Inventory topInventory() {
+        return view.getTopInventory();
+    }
+
+    public InventoryType inventoryType() {
+        return topInventory().getType();
+    }
+
+    public ItemStack topItem(int slot) {
+        ItemStack item = topInventory().getItem(slot);
+        return item == null ? ItemStack.empty() : item;
+    }
+
+    public void setTopItem(int slot, ItemStack item) {
+        topInventory().setItem(slot, item);
+    }
+}

--- a/src/main/java/btm/sword/system/interaction/CustomInteractionManager.java
+++ b/src/main/java/btm/sword/system/interaction/CustomInteractionManager.java
@@ -1,0 +1,36 @@
+package btm.sword.system.interaction;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.event.inventory.InventoryType;
+
+import btm.sword.system.interaction.smithing.RotateThrowStyleSmithingInteraction;
+
+/**
+ * Registry and lookup facade for custom inventory interactions.
+ */
+public final class CustomInteractionManager {
+    private static final List<CustomInventoryInteraction> INTERACTIONS = new ArrayList<>();
+
+    private CustomInteractionManager() {}
+
+    public static void initialize() {
+        INTERACTIONS.clear();
+        register(new RotateThrowStyleSmithingInteraction());
+    }
+
+    public static void register(CustomInventoryInteraction interaction) {
+        INTERACTIONS.add(interaction);
+    }
+
+    public static CustomInventoryInteraction find(CustomInteractionContext context) {
+        InventoryType type = context.inventoryType();
+        for (CustomInventoryInteraction interaction : INTERACTIONS) {
+            if (interaction.inventoryType() == type && interaction.matches(context)) {
+                return interaction;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/btm/sword/system/interaction/CustomInventoryInteraction.java
+++ b/src/main/java/btm/sword/system/interaction/CustomInventoryInteraction.java
@@ -1,0 +1,40 @@
+package btm.sword.system.interaction;
+
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Extensible contract for custom inventory-driven item transformations.
+ */
+public interface CustomInventoryInteraction {
+
+    /**
+     * Returns the top-inventory type this interaction applies to.
+     *
+     * @return the inventory type
+     */
+    InventoryType inventoryType();
+
+    /**
+     * Returns {@code true} when the interaction should provide a custom result.
+     *
+     * @param context the current interaction context
+     * @return whether this interaction matches
+     */
+    boolean matches(CustomInteractionContext context);
+
+    /**
+     * Builds the preview/result item shown to the player.
+     *
+     * @param context the current interaction context
+     * @return the crafted result
+     */
+    ItemStack createResult(CustomInteractionContext context);
+
+    /**
+     * Consumes or mutates the input slots after the player takes the result.
+     *
+     * @param context the current interaction context
+     */
+    void consumeInputs(CustomInteractionContext context);
+}

--- a/src/main/java/btm/sword/system/interaction/smithing/RotateThrowStyleSmithingInteraction.java
+++ b/src/main/java/btm/sword/system/interaction/smithing/RotateThrowStyleSmithingInteraction.java
@@ -1,0 +1,68 @@
+package btm.sword.system.interaction.smithing;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.Material;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+
+import btm.sword.system.action.throwing.ItemThrowStyle;
+import btm.sword.system.interaction.CustomInteractionContext;
+import btm.sword.system.interaction.CustomInventoryInteraction;
+import btm.sword.system.item.KeyRegistry;
+import btm.sword.system.item.weapon.WeaponType;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+
+/**
+ * Smithing-table interaction that rewrites a Falchion's throw style to a rotating toss.
+ */
+public final class RotateThrowStyleSmithingInteraction implements CustomInventoryInteraction {
+
+    @Override
+    public InventoryType inventoryType() {
+        return InventoryType.SMITHING;
+    }
+
+    @Override
+    public boolean matches(CustomInteractionContext context) {
+        ItemStack template = context.topItem(CustomInteractionContext.SMITHING_TEMPLATE_SLOT);
+        ItemStack base = context.topItem(CustomInteractionContext.SMITHING_BASE_SLOT);
+        ItemStack addition = context.topItem(CustomInteractionContext.SMITHING_ADDITION_SLOT);
+
+        if (!template.isEmpty() || !addition.isEmpty()) {
+            return false;
+        }
+        if (base.isEmpty() || WeaponType.fromItem(base) != WeaponType.FALCHION) {
+            return false;
+        }
+
+        String existing = KeyRegistry.getKeyField(base, KeyRegistry.THROW_STYLE_KEY, PersistentDataType.STRING);
+        return !ItemThrowStyle.ROTATE.name().equals(existing);
+    }
+
+    @Override
+    public ItemStack createResult(CustomInteractionContext context) {
+        ItemStack result = context.topItem(CustomInteractionContext.SMITHING_BASE_SLOT).clone();
+        KeyRegistry.setKeyField(result, KeyRegistry.THROW_STYLE_KEY, PersistentDataType.STRING, ItemThrowStyle.ROTATE.name());
+
+        ItemMeta meta = result.getItemMeta();
+        List<Component> lore = meta.lore();
+        List<Component> updatedLore = lore == null ? new ArrayList<>() : new ArrayList<>(lore);
+        updatedLore.add(Component.text("Smithing Refit: Rotating Throw", NamedTextColor.GOLD)
+            .decoration(TextDecoration.ITALIC, false));
+        meta.lore(updatedLore);
+        result.setItemMeta(meta);
+        return result;
+    }
+
+    @Override
+    public void consumeInputs(CustomInteractionContext context) {
+        context.setTopItem(CustomInteractionContext.SMITHING_BASE_SLOT, ItemStack.of(Material.AIR));
+        context.setTopItem(CustomInteractionContext.SMITHING_RESULT_SLOT, ItemStack.of(Material.AIR));
+    }
+}

--- a/src/main/java/btm/sword/system/inventory/PlayerMenuManager.java
+++ b/src/main/java/btm/sword/system/inventory/PlayerMenuManager.java
@@ -32,7 +32,7 @@ public class PlayerMenuManager {
         if (!cursor.isEmpty()) {
             Map<Integer, ItemStack> leftover = player.getInventory().addItem(cursor.clone());
             leftover.values().forEach(swordPlayer::spawnInventoryDrop);
-            player.setItemOnCursor(new ItemStack(Material.AIR));
+            player.setItemOnCursor(ItemStack.of(Material.AIR));
         }
 
         menu.open();
@@ -44,7 +44,7 @@ public class PlayerMenuManager {
         SwordScheduler.runBukkitTaskLater(() -> {
             ItemStack afterCursor = player.getItemOnCursor();
             if (!afterCursor.isEmpty() && KeyRegistry.hasKey(afterCursor, KeyRegistry.NON_MOVABLE_KEY)) {
-                player.setItemOnCursor(new ItemStack(Material.AIR));
+                player.setItemOnCursor(ItemStack.of(Material.AIR));
             }
         }, 50, TimeUnit.MILLISECONDS);
     }

--- a/src/main/java/btm/sword/system/inventory/menu/MainMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/MainMenu.java
@@ -172,7 +172,7 @@ public class MainMenu extends Menu {
                 }
                 ItemStack cursor = click.getPlayer().getItemOnCursor();
                 if (cursor.isEmpty() || NonMovableItem.isNonMovable(cursor)) return;
-                click.getPlayer().setItemOnCursor(new ItemStack(Material.AIR));
+                click.getPlayer().setItemOnCursor(ItemStack.of(Material.AIR));
             }
         );
 

--- a/src/main/java/btm/sword/system/inventory/menu/MovesetMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/MovesetMenu.java
@@ -184,7 +184,7 @@ public class MovesetMenu extends Menu {
      * @return the colored leather boots ItemStack
      */
     private ItemStack buildMovementToggleItem(boolean enabled) {
-        ItemStack boots = new ItemStack(Material.LEATHER_BOOTS);
+        ItemStack boots = ItemStack.of(Material.LEATHER_BOOTS);
         LeatherArmorMeta meta = (LeatherArmorMeta) boots.getItemMeta();
         meta.setColor(enabled ? Color.LIME : Color.RED);
 

--- a/src/main/java/btm/sword/system/inventory/menu/dev/CreativeInventoryMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/CreativeInventoryMenu.java
@@ -55,7 +55,7 @@ public class CreativeInventoryMenu extends Menu {
                 new ItemStackBuilder(m)
                     .name(Component.text(formatName(m), NamedTextColor.WHITE))
                     .build(),
-                click -> click.getPlayer().getInventory().addItem(new ItemStack(m, m.getMaxStackSize()))
+                click -> click.getPlayer().getInventory().addItem(ItemStack.of(m, m.getMaxStackSize()))
             ))
             .collect(Collectors.toList());
 

--- a/src/main/java/btm/sword/system/inventory/menu/dev/DevMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/DevMenu.java
@@ -199,7 +199,7 @@ public class DevMenu extends Menu {
             new ItemStackBuilder(material)
                 .name(Component.text(label, NamedTextColor.WHITE))
                 .build(),
-            click -> click.getPlayer().getInventory().addItem(new ItemStack(material))
+            click -> click.getPlayer().getInventory().addItem(ItemStack.of(material))
         );
     }
 }

--- a/src/main/java/btm/sword/system/inventory/menu/dev/TestingMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/TestingMenu.java
@@ -7,6 +7,7 @@ import java.util.concurrent.TimeUnit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 import btm.sword.config.Config;
 import btm.sword.gamemode.QueueManager;
@@ -20,6 +21,7 @@ import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.inventory.menu.PacketTestMenu;
 import btm.sword.system.item.ItemStackBuilder;
+import btm.sword.system.item.weapon.WeaponType;
 import btm.sword.system.scene.DEUAnimationController;
 import btm.sword.system.scene.SceneManager;
 import btm.sword.system.scene.animation.AnimationDef;
@@ -194,11 +196,40 @@ public class TestingMenu extends Menu {
             }
         );
 
+        SimpleItem hudOverrideTest = new SimpleItem(
+            new ItemStackBuilder(Material.GOLDEN_CARROT)
+                .name(Component.text("HUD Effect Test", NamedTextColor.GOLD, TextDecoration.BOLD))
+                .lore(List.of(
+                    Component.text("Cycles: wither (5s) → poison (5s) → hunger (5s) → bubbles (5s)", NamedTextColor.DARK_GRAY)
+                ))
+                .build(),
+            click -> {
+                swordPlayer.testHudSequence();
+                swordPlayer.message(Component.text("HUD effect cycle started (20s total).", NamedTextColor.GREEN));
+            }
+        );
+
+        SimpleItem smithingInteractionTest = new SimpleItem(
+            new ItemStackBuilder(Material.SMITHING_TABLE)
+                .name(Component.text("Smithing Refit Test", NamedTextColor.AQUA, TextDecoration.BOLD))
+                .lore(List.of(
+                    Component.text("Gives you a Falchion and opens smithing", NamedTextColor.DARK_GRAY),
+                    Component.text("Place only the Falchion in the base slot", NamedTextColor.DARK_GRAY)
+                ))
+                .build(),
+            click -> {
+                ItemStack falchion = WeaponType.FALCHION.buildItemStack();
+                player.getInventory().addItem(falchion);
+                player.openSmithingTable(null, true);
+                swordPlayer.message(Component.text("Smithing test ready: place the Falchion into the base slot.", NamedTextColor.GREEN));
+            }
+        );
+
         Gui gui = Gui.normal()
             .setStructure(
                 "# # # . . . # # #",
                 "# P X . F . B K #",
-                ". D . . . . . . .",
+                ". D . H . M . . .",
                 "# O . . . . . . #",
                 "< > # . . . # # #")
             .addIngredient('#', BORDER)
@@ -209,6 +240,8 @@ public class TestingMenu extends Menu {
             .addIngredient('B', bossBarTest)
             .addIngredient('K', scoreboardTest)
             .addIngredient('D', ctfDebug)
+            .addIngredient('H', hudOverrideTest)
+            .addIngredient('M', smithingInteractionTest)
             .addIngredient('O', ctfStop)
             .addIngredient('<', generatePreviousButtonOrDefault())
             .addIngredient('>', generateForwardPreviousButtonOrDefault())

--- a/src/main/java/btm/sword/system/item/Item.java
+++ b/src/main/java/btm/sword/system/item/Item.java
@@ -22,7 +22,7 @@ import lombok.Getter;
  * <p>
  * Example usage:
  * <pre>
- * ItemStack stack = new ItemStack(Material.DIAMOND_SWORD);
+ * ItemStack stack = ItemStack.of(Material.DIAMOND_SWORD);
  * Item custom = new Item(stack);
  *
  * if (custom.hasTag("uuid")) {

--- a/src/main/java/btm/sword/system/item/ItemStackBuilder.java
+++ b/src/main/java/btm/sword/system/item/ItemStackBuilder.java
@@ -56,10 +56,10 @@ public class ItemStackBuilder {
      */
     public ItemStackBuilder(Material material) {
         ItemMeta preMeta;
-        this.item = new ItemStack(material);
+        this.item = ItemStack.of(material);
         preMeta = item.getItemMeta();
         if (preMeta == null)
-            preMeta = new ItemStack(Material.SHIELD).getItemMeta();
+            preMeta = ItemStack.of(Material.SHIELD).getItemMeta();
         this.meta = preMeta;
     }
 
@@ -81,7 +81,7 @@ public class ItemStackBuilder {
      */
     public ItemStackBuilder name(Component component) {
         meta.itemName(component);
-        meta.displayName(component);
+        meta.customName(component);
         return this;
     }
 

--- a/src/main/java/btm/sword/system/item/armor/ArmorType.java
+++ b/src/main/java/btm/sword/system/item/armor/ArmorType.java
@@ -33,7 +33,7 @@ public enum ArmorType {
      * @return the configured armor ItemStack, or {@link Material#AIR} if not yet implemented
      */
     public ItemStack buildItemStack() {
-        return new ItemStack(Material.AIR);
+        return ItemStack.of(Material.AIR);
     }
 
     /**

--- a/src/main/java/btm/sword/system/item/quest/QuestItemType.java
+++ b/src/main/java/btm/sword/system/item/quest/QuestItemType.java
@@ -37,7 +37,7 @@ public enum QuestItemType {
      * @return an ItemStack for this quest item type
      */
     public ItemStack buildItemStack() {
-        return new ItemStack(Material.AIR);
+        return ItemStack.of(Material.AIR);
     }
 
     /**

--- a/src/main/java/btm/sword/system/item/special/AbilitySlotItem.java
+++ b/src/main/java/btm/sword/system/item/special/AbilitySlotItem.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
 
+import btm.sword.system.action.throwing.InteractiveItemArbiter;
 import btm.sword.system.item.ItemStackBuilder;
 import btm.sword.system.item.KeyRegistry;
 import btm.sword.system.item.SwordItemType;
@@ -21,17 +22,17 @@ import net.kyori.adventure.text.format.TextDecoration;
  *
  * <p>The slot has four visual states:
  * <ul>
- *   <li>{@link SlotState#LOCKED} — gray glass, slot has not been unlocked.</li>
- *   <li>{@link SlotState#EMPTY} — gray glass, unlocked but no ability equipped.</li>
- *   <li>{@link SlotState#EQUIPPED} — the ability's world item, tagged and non-movable.</li>
- *   <li>{@link SlotState#DEPLETED} — black glass, ability uses exhausted.</li>
+ *   <li>{@link SlotState#LOCKED} - gray glass, slot has not been unlocked.</li>
+ *   <li>{@link SlotState#EMPTY} - gray glass, unlocked but no ability equipped.</li>
+ *   <li>{@link SlotState#EQUIPPED} - the ability's world item, tagged and non-movable.</li>
+ *   <li>{@link SlotState#DEPLETED} - black glass, ability uses exhausted.</li>
  * </ul>
  *
  * <p>{@link #isSatisfied(Player)} returns {@code true} when any of these four states
  * occupies the target slot. If none match, {@link #restore(Player)} replaces the slot
  * with the current state's item.</p>
  *
- * <p>These items follow the same protection pattern as the umbral blade and soul link —
+ * <p>These items follow the same protection pattern as the umbral blade and soul link -
  * they are only protected/restored when {@link btm.sword.utility.Debug#SPECIAL_ITEM_CHECKS_ENABLED}
  * is {@code true}. The {@code inventoryUpkeep()} loop already checks this for managed items.</p>
  */
@@ -52,8 +53,6 @@ public class AbilitySlotItem extends SlotAnchoredItem {
     /**
      * -- GETTER --
      *  Returns the current visual state of this slot.
-     *
-     * @return the current {@link SlotState}
      */
     @Getter
     private SlotState state;
@@ -81,7 +80,7 @@ public class AbilitySlotItem extends SlotAnchoredItem {
 
     /**
      * Updates the slot's visual state and internal item. Does not place the item
-     * into the player's inventory — call {@link #restore(Player)} afterward.
+     * into the player's inventory - call {@link #restore(Player)} afterward.
      *
      * @param newState the new state
      */
@@ -133,33 +132,74 @@ public class AbilitySlotItem extends SlotAnchoredItem {
     /**
      * Places the current state's item into the target slot.
      *
-     * <p>For {@link SlotState#LOCKED} and {@link SlotState#EMPTY}, clears any stale ability item
-     * from the slot but otherwise leaves the hotbar slot free for the player.
-     * For {@link SlotState#EQUIPPED} and {@link SlotState#DEPLETED}, writes the current item.</p>
+     * <p>When a real ability item is displaced, it is first offered back to the player's
+     * inventory and only falls back to a dropped-item world spawn if inventory is full.
+     * Placeholder panes are never preserved.</p>
      *
      * @param player the player whose inventory to restore the item into
      */
     @Override
     public void restore(Player player) {
+        ItemStack existing = player.getInventory().getItem(getTargetSlot());
         if (state == SlotState.LOCKED || state == SlotState.EMPTY) {
-            ItemStack current = player.getInventory().getItem(getTargetSlot());
-            if (current != null && KeyRegistry.hasKey(current, KeyRegistry.ABILITY_SLOT_KEY)) {
+            if (existing != null && KeyRegistry.hasKey(existing, KeyRegistry.ABILITY_SLOT_KEY)) {
                 player.getInventory().setItem(getTargetSlot(), null);
             }
             return;
         }
-        // Preserve any non-ability item currently in the slot — move it elsewhere
-        ItemStack existing = player.getInventory().getItem(getTargetSlot());
-        if (existing != null && !existing.isEmpty()
-                && !KeyRegistry.hasKey(existing, KeyRegistry.ABILITY_SLOT_KEY)) {
-            Map<Integer, ItemStack> overflow = player.getInventory().addItem(existing);
-            overflow.values().forEach(leftover ->
-                player.getWorld().dropItemNaturally(player.getLocation(), leftover));
-        }
+
+        ItemStack displaced = shouldPreserveOnReplace(existing) ? toInventoryItem(existing) : null;
         player.getInventory().setItem(getTargetSlot(), currentItem);
+        if (displaced != null) {
+            moveToInventoryOrDrop(player, displaced);
+        }
     }
 
-    // ── Static item builders ─────────────────────────────────────────────────
+    private boolean shouldPreserveOnReplace(ItemStack existing) {
+        if (existing == null || existing.isEmpty() || isCurrentSlotItem(existing)) {
+            return false;
+        }
+
+        if (!KeyRegistry.hasKey(existing, KeyRegistry.ABILITY_SLOT_KEY)) {
+            return toInventoryItem(existing) != null;
+        }
+
+        String existingAbilityId = KeyRegistry.getKeyField(existing, KeyRegistry.ABILITY_ID_KEY, PersistentDataType.STRING);
+        String currentAbilityId = currentItem == null
+            ? null
+            : KeyRegistry.getKeyField(currentItem, KeyRegistry.ABILITY_ID_KEY, PersistentDataType.STRING);
+
+        return existingAbilityId != null
+            && currentAbilityId != null
+            && !existingAbilityId.equals(currentAbilityId)
+            && toInventoryItem(existing) != null;
+    }
+
+    private boolean isCurrentSlotItem(ItemStack existing) {
+        return currentItem != null
+            && existing.isSimilar(currentItem)
+            && existing.getAmount() == currentItem.getAmount();
+    }
+
+    private ItemStack toInventoryItem(ItemStack existing) {
+        if (existing == null || existing.isEmpty()) return null;
+
+        if (KeyRegistry.hasKey(existing, KeyRegistry.ABILITY_SLOT_KEY)
+            && !KeyRegistry.hasKey(existing, KeyRegistry.ABILITY_ID_KEY)) {
+            return null;
+        }
+
+        ItemStack copy = existing.clone();
+        KeyRegistry.removeKey(copy, KeyRegistry.ABILITY_SLOT_KEY);
+        KeyRegistry.removeKey(copy, KeyRegistry.NON_MOVABLE_KEY);
+        KeyRegistry.removeKey(copy, KeyRegistry.ITEM_TYPE_KEY);
+        return copy;
+    }
+
+    private void moveToInventoryOrDrop(Player player, ItemStack item) {
+        Map<Integer, ItemStack> overflow = player.getInventory().addItem(item);
+        overflow.values().forEach(leftover -> InteractiveItemArbiter.dropNaturally(player.getLocation(), leftover));
+    }
 
     private static ItemStack buildStateItem(SlotState state, SwordItemType swordItemType) {
         return switch (state) {
@@ -175,7 +215,7 @@ public class AbilitySlotItem extends SlotAnchoredItem {
                 Component.text("Depleted", NamedTextColor.DARK_GRAY, TextDecoration.ITALIC),
                 List.of(Component.text("This ability has been used up.", NamedTextColor.DARK_GRAY)),
                 swordItemType);
-            case EQUIPPED -> // Equipped items are set via setEquipped(); this fallback should not normally be reached.
+            case EQUIPPED ->
                 buildPlaceholder(Material.GRAY_STAINED_GLASS_PANE,
                     Component.text("Empty Ability Slot", NamedTextColor.GRAY),
                     List.of(Component.text("Equip an ability from the Character Menu.", NamedTextColor.GRAY)),

--- a/src/main/java/btm/sword/system/item/special/AbilitySlotItem.java
+++ b/src/main/java/btm/sword/system/item/special/AbilitySlotItem.java
@@ -202,24 +202,19 @@ public class AbilitySlotItem extends SlotAnchoredItem {
     }
 
     private static ItemStack buildStateItem(SlotState state, SwordItemType swordItemType) {
-        return switch (state) {
+        return switch (state) { // TODO: Config the materials
             case LOCKED -> buildPlaceholder(Material.GRAY_STAINED_GLASS_PANE,
                 Component.text("Locked Ability Slot", NamedTextColor.DARK_GRAY, TextDecoration.BOLD),
                 List.of(Component.text("Unlock this slot from the Character Menu.", NamedTextColor.GRAY)),
                 swordItemType);
-            case EMPTY -> buildPlaceholder(Material.GRAY_STAINED_GLASS_PANE,
+            case EMPTY, EQUIPPED -> buildPlaceholder(Material.GRAY_STAINED_GLASS_PANE,
                 Component.text("Empty Ability Slot", NamedTextColor.GRAY),
                 List.of(Component.text("Equip an ability from the Character Menu.", NamedTextColor.GRAY)),
                 swordItemType);
-            case DEPLETED -> buildPlaceholder(Material.BLACK_STAINED_GLASS_PANE,
+            case DEPLETED -> buildPlaceholder(Material.GRAY_DYE,
                 Component.text("Depleted", NamedTextColor.DARK_GRAY, TextDecoration.ITALIC),
                 List.of(Component.text("This ability has been used up.", NamedTextColor.DARK_GRAY)),
                 swordItemType);
-            case EQUIPPED ->
-                buildPlaceholder(Material.GRAY_STAINED_GLASS_PANE,
-                    Component.text("Empty Ability Slot", NamedTextColor.GRAY),
-                    List.of(Component.text("Equip an ability from the Character Menu.", NamedTextColor.GRAY)),
-                    swordItemType);
         };
     }
 

--- a/src/main/java/btm/sword/system/item/special/AbilitySlotManager.java
+++ b/src/main/java/btm/sword/system/item/special/AbilitySlotManager.java
@@ -157,6 +157,8 @@ public class AbilitySlotManager {
             int ticks = ability.cooldownTicks();
             player.setCooldown(current.getType(), ticks);
         }
+
+        syncSlotItemFromState(slotIndex);
     }
 
     /**
@@ -301,6 +303,20 @@ public class AbilitySlotManager {
     }
 
     /**
+     * Restores a single managed ability slot from persistent slot state.
+     * Useful when the live inventory stack was temporarily replaced (for example,
+     * by the right-click hold gunpowder placeholder).
+     *
+     * @param slotIndex 1 or 2
+     */
+    public void restoreSlot(int slotIndex) {
+        syncSlotItemFromState(slotIndex);
+        AbilitySlotItem slotItem = slotIndex == SLOT_1 ? slot1 : slot2;
+        slotItem.restore(owner.player());
+        syncEnabled();
+    }
+
+    /**
      * Returns the {@link SwordItemType} for the ability at the given hotbar slot index,
      * or {@code null} if that slot does not have an active (equipped) ability.
      * Used by {@code handleAbilityInput} as a reliable alternative to PDC tag lookups.
@@ -342,6 +358,13 @@ public class AbilitySlotManager {
     private void syncEnabled() {
         slotEnabled[0] = slot1.getState() == AbilitySlotItem.SlotState.EQUIPPED;
         slotEnabled[1] = slot2.getState() == AbilitySlotItem.SlotState.EQUIPPED;
+    }
+
+    private void syncSlotItemFromState(int slotIndex) {
+        SkillSlot skillSlot = toSkillSlot(slotIndex);
+        SkillSlotState state = owner.getCombatProfile().getPlayerSkillContainer().getSlotState(skillSlot);
+        AbilitySlotItem slotItem = slotIndex == SLOT_1 ? slot1 : slot2;
+        refreshSlot(slotItem, skillSlot, state.remainingUses(), state.remainingDurability());
     }
 
     private SkillSlot toSkillSlot(int slotIndex) {

--- a/src/main/java/btm/sword/system/scene/FakePlayerManager.java
+++ b/src/main/java/btm/sword/system/scene/FakePlayerManager.java
@@ -824,6 +824,6 @@ public final class FakePlayerManager {
     }
 
     private static ItemStack orAir(ItemStack item) {
-        return item != null ? item : new ItemStack(org.bukkit.Material.AIR);
+        return item != null ? item : ItemStack.of(org.bukkit.Material.AIR);
     }
 }

--- a/src/main/java/btm/sword/system/scene/FakePlayerPacketTester.java
+++ b/src/main/java/btm/sword/system/scene/FakePlayerPacketTester.java
@@ -123,7 +123,7 @@ public final class FakePlayerPacketTester {
     public static void loopEntityFlags(SwordPlayer viewer) {
         startLoop(viewer, "ENTITY_DATA (living entity flags — blocking)", () -> {
             FakePlayerManager.setEquipmentSlot(
-                viewer, EnumWrappers.ItemSlot.MAINHAND, new ItemStack(Material.SHIELD));
+                viewer, EnumWrappers.ItemSlot.MAINHAND, ItemStack.of(Material.SHIELD));
             return FakePlayerManager.setEntityFlags(viewer, true, false, false);
         });
     }
@@ -181,7 +181,7 @@ public final class FakePlayerPacketTester {
             () -> assertSent(FakePlayerManager.velocityFake(viewer, 0.0, 0.42, 0.0)))) passed++;
         if (run(log, "ENTITY_DATA (living entity flags — blocking)", () -> {
             assertSent(FakePlayerManager.setEquipmentSlot(
-                viewer, EnumWrappers.ItemSlot.MAINHAND, new ItemStack(Material.SHIELD)));
+                viewer, EnumWrappers.ItemSlot.MAINHAND, ItemStack.of(Material.SHIELD)));
             assertSent(FakePlayerManager.setEntityFlags(viewer, true, false, false));
         })) passed++;
 

--- a/src/main/java/btm/sword/utility/Prefab.java
+++ b/src/main/java/btm/sword/utility/Prefab.java
@@ -182,6 +182,15 @@ public final class Prefab {
             () -> Config.Combat.HIT_PUNCH_SOULFIRE_LOSS
         );
 
+        /** Hit packet for thrown knife ability projectiles. Low shard damage, high toughness damage. */
+        public static final HitValuePacket KNIFE_THROW = new HitValuePacket(
+            () -> 0f,
+            () -> Config.Combat.THROWN_DAMAGE_SWORD_AXE_INVULNERABILITY_TICKS,
+            () -> 1,
+            () -> 15f,
+            () -> 0f
+        );
+
         /**
          * Hit packet for UmbralBlade lunge and grab-impale hits.
          * SHIELD_PASSING: reduces damage by {@link Config.Combat#SHIELD_PASSING_BYPASS_POWER}

--- a/src/main/java/btm/sword/utility/statemachine/StateMachine.java
+++ b/src/main/java/btm/sword/utility/statemachine/StateMachine.java
@@ -2,7 +2,10 @@ package btm.sword.utility.statemachine;
 
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Generic finite state machine (FSM).
@@ -30,6 +33,13 @@ public class StateMachine<T> {
     protected final List<Transition<T>> transitions = new ArrayList<>();
 
     /**
+     * Per-state-class cache of the filtered, ordered subset of {@link #transitions} that apply
+     * to that state. Computed lazily on first encounter; avoids the O(N) full scan and
+     * {@link Class#isAssignableFrom} calls every tick.
+     */
+    private final Map<Class<?>, List<Transition<T>>> effectiveTransitionCache = new HashMap<>();
+
+    /**
      * Creates the state machine with the given context and enters the initial state immediately.
      *
      * @param context      the shared context object
@@ -54,14 +64,16 @@ public class StateMachine<T> {
     public void afterAnyTransition() {}
 
     /**
-     * Ticks the current state and evaluates all registered transitions.
-     * Called once per server tick by the owning system.
+     * Ticks the current state and evaluates only the transitions applicable to the current state.
+     * <p>
+     * The applicable subset is computed lazily on first encounter via
+     * {@link #effectiveTransitionsFor(Class)} and cached for subsequent ticks,
+     * eliminating the O(N) full scan and {@link Class#isAssignableFrom} calls every tick.
      */
     public void tick() {
         currentState.onTick(context);
-        for (var t : transitions) {
-            if (t.from().isAssignableFrom(currentState.getClass())
-                && t.condition().test(context)) {
+        for (var t : effectiveTransitionsFor(currentState.getClass())) {
+            if (t.condition().test(context)) {
                 onAnyTransition();
                 t.onTransition().accept(context);
                 setState(createState(t.to()));
@@ -69,6 +81,20 @@ public class StateMachine<T> {
                 return;
             }
         }
+    }
+
+    /**
+     * Returns the cached subset of {@link #transitions} whose {@code from} class is assignable
+     * from {@code stateClass}. Built once per unique state class and reused on every subsequent tick.
+     *
+     * @param stateClass the concrete state class currently active
+     * @return ordered list of transitions applicable to that state
+     */
+    private List<Transition<T>> effectiveTransitionsFor(Class<?> stateClass) {
+        return effectiveTransitionCache.computeIfAbsent(stateClass,
+            cls -> transitions.stream()
+                .filter(t -> t.from().isAssignableFrom(cls))
+                .collect(Collectors.toList()));
     }
 
     /**
@@ -94,6 +120,7 @@ public class StateMachine<T> {
      */
     public void addTransition(Transition<T> transition) {
         transitions.add(transition);
+        effectiveTransitionCache.clear();
     }
 
     /**

--- a/src/main/java/btm/sword/utility/statemachine/StateMachine.java
+++ b/src/main/java/btm/sword/utility/statemachine/StateMachine.java
@@ -1,9 +1,8 @@
 package btm.sword.utility.statemachine;
 
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.function.Predicate;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Generic finite state machine (FSM).
@@ -27,8 +26,8 @@ public class StateMachine<T> {
     /** The currently active state. */
     protected State<T> currentState;
 
-    /** Ordered map of transitions; evaluated top-to-bottom each tick. */
-    protected final Map<Transition<T>, Predicate<T>> transitions = new LinkedHashMap<>();
+    /** Ordered list of transitions; evaluated top-to-bottom each tick. */
+    protected final List<Transition<T>> transitions = new ArrayList<>();
 
     /**
      * Creates the state machine with the given context and enters the initial state immediately.
@@ -60,7 +59,7 @@ public class StateMachine<T> {
      */
     public void tick() {
         currentState.onTick(context);
-        for (var t : transitions.keySet()) {
+        for (var t : transitions) {
             if (t.from().isAssignableFrom(currentState.getClass())
                 && t.condition().test(context)) {
                 onAnyTransition();
@@ -94,7 +93,7 @@ public class StateMachine<T> {
      * @param transition the transition to register
      */
     public void addTransition(Transition<T> transition) {
-        transitions.put(transition, transition.condition());
+        transitions.add(transition);
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR encompasses a comprehensive performance optimization pass and cleanup of the throw system, addressing six linked issues and adding critical infrastructure improvements.

### Issues Addressed

- **#292**: Fix ability-slot item swapping and refresh behavior
- **#301**: Cache SwordTeam on SwordEntity; eliminate 4 allocations per hit via cached field comparison
- **#302**: Partition StateMachine transitions by from-state; O(k) tick evaluation instead of O(N)
- **#303**: Cache hostile-to-target distanceSquared once per tick; eliminate 3-5 Location allocations per mob
- **#304**: Gate HostileStateMachine broadcastMessage() calls behind LOGGING_VERBOSE_HOSTILE; remove O(n) world scan on every AI transition
- **#305**: Gate MovementListener Debug.listener() string concat behind LOGGING_VERBOSE_LISTENER flag
- **#306**: ThrowPhase/InventoryMode enums replace boolean throw/inventory state flags on Combatant/SwordPlayer

### Changes

- **Fix**: Re-register ability projectiles in InteractiveItemArbiter so they can be picked up and dashed to
- **Fix**: Knife throw impact type, ImpactType check moved to itemStack to avoid PDC loss through ItemDisplay round-trip
- **Fix**: Throw-cancel log gated behind Debug.system()
- **Update**: ItemStack API modernization (ItemStack.of(), customName()) across the codebase
- **New**: HUD override infrastructure and custom smithing interaction system (ROTATE throw style)

## Test Plan

Please verify the following before merging:

- [x] **Throw/Catch/Dash**: Knife throw mechanic works correctly; catch/recall interacts properly with thrown items; dash-to-thrown-item works and picks up projectiles
- [x] **Hostile AI Transitions**: Mobs transition states smoothly; no unexpected state loops; aggro/de-aggro works correctly
- [x] **Team-Based Friendly Fire**: Team assignments respected; no hits on teammates; team switching doesn't cause issues
- [x] **Ability Slot Behavior**: Ability slots switch correctly; proper item swapping on slot change; ability costs applied correctly
- [x] **Performance**: Monitor for any frame rate improvements; check debug logs for expected reduced allocations