### PR TITLE
Perf: skip status display rebuild when values unchanged

### DIFF
--- a/src/main/java/btm/sword/system/entity/base/SwordEntity.java
+++ b/src/main/java/btm/sword/system/entity/base/SwordEntity.java
@@ -95,6 +95,9 @@ public abstract class SwordEntity {
     protected TextDisplay statusDisplay;
     protected boolean statusActive;
 
+    private int prevDisplayShards = -1;
+    private float prevDisplayToughness = -1f;
+
     private long timeOfLastAttack;
     /**
      * in milliseconds
@@ -244,8 +247,16 @@ public abstract class SwordEntity {
 
     protected void updateStatusDisplayText() {
         int shards = (int) aspects.shardsCur();
-        int maxEffShards = (int) aspects.shardsMaxVal();
         float toughness = aspects.toughnessCur();
+
+        if (shards == prevDisplayShards && toughness == prevDisplayToughness) {
+            return;
+        }
+
+        prevDisplayShards = shards;
+        prevDisplayToughness = toughness;
+
+        int maxEffShards = (int) aspects.shardsMaxVal();
         float maxEffToughness = aspects.toughnessMaxVal();
 
         String bar = "█".repeat(shards);


### PR DESCRIPTION
## Summary
Cache previous display shards and toughness values in `SwordEntity` to skip Component/String allocations when values haven't changed.

## Details
- Added `prevDisplayShards` (int, init -1) and `prevDisplayToughness` (float, init -1f) cache fields
- `updateStatusDisplayText()` now reads current values, compares against cache, and returns early if unchanged
- Cache updated before building display text on actual changes

Closes #300