### PR TITLE
Feat: keyframe effects UX + UmbralBlade lifecycle unification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # User-specific stuff
 .idea/
 notes.txt
+enforcement.txt
 
 *.iml
 *.ipr

--- a/docs/plans/umbral_blade_lifecycle_unification_plan.md
+++ b/docs/plans/umbral_blade_lifecycle_unification_plan.md
@@ -1,0 +1,496 @@
+# Umbral Blade Lifecycle Unification Plan
+
+## Purpose
+
+This plan unifies Umbral Blade lifecycle ownership so the system becomes easier to reason about, safer under join/respawn/gamemode changes, and much easier to test.
+
+The immediate goal is to answer one question in exactly one place:
+
+> Should this combatant currently have a live Umbral Blade instance in the world?
+
+Right now that answer is scattered across listeners, `Combatant`, `AnimationMode`, `InactiveState`, `RecoverState`, and ad hoc display cleanup. That is the main source of the fragility.
+
+---
+
+## Design Decisions
+
+### 1. `Combatant` becomes the single lifecycle owner
+
+`Combatant` should own the entire blade lifecycle:
+
+- whether the blade is allowed to exist
+- whether the blade should currently be active
+- whether the blade system is ready to be started yet
+- creating a fresh blade instance
+- fully shutting down and disposing the current blade instance
+
+No listener, menu, dev mode, or state class should directly decide to remove or respawn the blade display.
+
+Those callers should only express intent through clean `Combatant` methods.
+
+### 2. The blade should start deactivated
+
+On player construction and early join staging, the blade should begin in a fully inactive lifecycle state.
+
+It should only be activated once the player is actually ready for normal gameplay:
+
+- load-in / join routing is complete
+- the player is not in a special suppressed mode
+- the combatant is allowed to own a blade
+
+This removes the current "constantly poll until maybe it should exist" behavior and replaces it with explicit lifecycle transitions.
+
+### 3. `InactiveState` should stay, but with a much narrower job
+
+`InactiveState` can remain as an FSM state, but it should no longer be a substitute for full lifecycle destruction.
+
+Recommended contract:
+
+- lifecycle layer decides whether the blade instance exists at all
+- if the blade instance exists but is intentionally dormant, FSM may sit in `InactiveState`
+- `InactiveState` may suppress almost all normal transition work
+- `InactiveState.onTick()` may lazily check whether the combatant's active flag says it should wake back up
+
+Important constraint:
+
+- `InactiveState` must not call `blade.dispose()`
+- entering `InactiveState` must not permanently strand the FSM
+
+If we want "off but recoverable," that is an FSM concern.
+If we want "gone and fully destroyed," that is a lifecycle concern owned by `Combatant`.
+
+### 4. Full destruction and recoverable dormancy must be separate concepts
+
+We should explicitly model these as different operations:
+
+- **Deactivate/Destroy**: fully dispose the blade instance, cancel tasks, remove display, null the combatant reference
+- **Activate/Start**: create a fresh blade instance and prepare it for a known ready state
+- **Suspend**: optional, keep an existing instance but move FSM into `InactiveState`
+- **Resume**: optional, wake a suspended instance back into its ready state
+
+Today these ideas are mixed together and that is what makes the system hard to follow.
+
+### 5. `UmbralBlade` should eventually stop extending `ThrownItem`
+
+Architecturally, the blade does not naturally fit `ThrownItem`.
+
+Reasons:
+
+- the blade is a persistent weapon system, not a disposable projectile
+- it owns a long-lived FSM and inventory identity
+- it has its own standby/wield/sheathed lifecycle that is unrelated to normal thrown-item semantics
+- several `ThrownItem` behaviors are overridden, bypassed, or treated as special cases already
+
+Recommendation:
+
+- **Phase 1**: keep the inheritance temporarily while lifecycle ownership is stabilized
+- **Phase 2**: extract the useful projectile/trajectory pieces into a reusable helper or component and remove `ThrownItem` inheritance from `UmbralBlade`
+
+This avoids trying to do both a lifecycle rewrite and a deep movement/physics refactor at the same time.
+
+---
+
+## Target Architecture
+
+### `Combatant` lifecycle API
+
+`Combatant` should expose a small, explicit API for the blade:
+
+- `setUmbralBladeAllowed(boolean allowed)`
+- `setUmbralBladeActive(boolean active)`
+- `markUmbralBladeSystemReady()`
+- `markUmbralBladeSystemNotReady()`
+- `startUmbralBlade(ReadyState initialState)`
+- `deactivateUmbralBladeCompletely()`
+- `restartUmbralBlade(ReadyState initialState)`
+- `hasActiveUmbralBlade()`
+
+`ReadyState` should be an explicit enum owned by the blade lifecycle, not inferred from whatever state happened to run last:
+
+- `SHEATHED`
+- `STANDBY`
+
+This is cleaner than "activate to previous state," because it makes activation deterministic.
+
+### Lifecycle flags on `Combatant`
+
+Recommended flags:
+
+- `umbralBladeAllowed`
+- `umbralBladeActiveRequested`
+- `umbralBladeSystemReady`
+- `umbralBladeStarting`
+
+Interpretation:
+
+- `allowed`: permanent capability gate
+- `activeRequested`: whether gameplay/dev state currently wants the blade on
+- `systemReady`: whether it is safe to spawn after join/load/menu setup
+- `starting`: guards against duplicate startups
+
+### Lifecycle rule
+
+Each combatant tick should follow one clear rule:
+
+1. If the system is not ready, do not spawn the blade.
+2. If the blade is not allowed, ensure it is fully destroyed.
+3. If active is not requested, ensure it is fully destroyed or suspended, depending on the caller's intent.
+4. If active is requested and no blade exists, start one in a known ready state.
+5. If a blade exists, tick it.
+
+This replaces the current loose "if null maybe schedule setup" behavior.
+
+---
+
+## Concrete Behavior Changes
+
+### A. Remove implicit delayed setup as the primary startup model
+
+Current behavior:
+
+- `handleUmbralBladeTick()` notices null
+- schedules delayed creation
+- external systems independently mutate blade requests and display state
+
+Target behavior:
+
+- creation only happens through `startUmbralBlade(...)`
+- if a small delayed spawn is still needed for visuals, that delay lives inside `startUmbralBlade(...)`
+- the lifecycle layer owns that delay and its guard conditions
+
+The system should no longer "constantly check whether the blade is alive or not, based on some boolean value changed somewhere."
+
+### B. Remove `ACTIVATE_TO_PREVIOUS`
+
+This request is a symptom of unclear lifecycle ownership.
+
+A reactivation path should always say exactly what it wants:
+
+- re-create to `SHEATHED`
+- re-create to `STANDBY`
+
+This is more readable, more deterministic, and safer after disposal.
+
+### C. Stop listener-driven display mutation
+
+`PlayerListener.gameChangeEvent()` should not:
+
+- remove the blade display directly
+- push ad hoc activation requests
+
+Instead it should call explicit lifecycle intent methods on the player:
+
+- spectator enter -> `setUmbralBladeActive(false)`
+- spectator exit -> `setUmbralBladeActive(true)`
+
+If the architecture team wants hard destruction instead of suspension for spectator, that should still flow through the `Combatant` lifecycle API rather than direct display manipulation.
+
+### D. Join/load should explicitly arm the blade
+
+The player should spawn with the blade system not ready.
+
+Once join staging and routing are complete:
+
+- mark the blade system ready
+- request activation
+- start in `SHEATHED` or `STANDBY` depending on desired UX
+
+That gives a clean, testable boot sequence.
+
+### E. Animation/dev systems should talk to lifecycle, not raw FSM requests
+
+For example:
+
+- entering animation mode: `setUmbralBladeActive(false)` or suspend explicitly
+- leaving animation mode: `startUmbralBlade(STANDBY)` or `setUmbralBladeActive(true)`
+
+No dev tool should need to know about `DEACTIVATE` or `ACTIVATE_TO_PREVIOUS`.
+
+---
+
+## Proposed `InactiveState` Contract
+
+Keep `InactiveState`, but redefine it carefully.
+
+### Responsibilities
+
+- represent a dormant but recoverable FSM mode
+- avoid normal combat transitions
+- avoid motion/follow/attack tasks
+- optionally hide or null out nonessential visual behavior
+- lazily check whether the owning combatant now wants the blade active again
+
+### Non-responsibilities
+
+- should not destroy the blade instance
+- should not null the combatant reference
+- should not be the primary join/spectator cleanup path if we want true destruction
+
+### Wake-up rule
+
+`InactiveState.onTick()` may read a simple combatant-owned flag:
+
+- if `thrower.isUmbralBladeActiveRequested()` and the instance is valid, transition to a known ready state
+
+That would support a suspend/resume flow cleanly.
+
+### Open question for review
+
+There are two valid variants:
+
+1. **Hard-destroy model**
+   Spectator/dev suppression fully destroys the blade instance. `InactiveState` is reserved for narrow internal uses only.
+
+2. **Suspend/resume model**
+   Spectator/dev suppression moves the blade into `InactiveState`, keeping the instance alive for fast wake-up.
+
+Recommendation:
+
+- use **hard-destroy** for join, leave, death, and any reliability-critical cleanup
+- allow **suspend/resume** only if there is a concrete UX or dev-tool benefit and its semantics remain simple
+
+This gives us the safest core while still leaving room for a recoverable inactive mode.
+
+---
+
+## Should `UmbralBlade` Still Extend `ThrownItem`?
+
+### Short answer
+
+Not long-term.
+
+### Why it currently feels wrong
+
+`ThrownItem` assumes a mostly projectile-shaped lifecycle:
+
+- setup
+- ready
+- release
+- impact/catch/end
+- dispose
+
+`UmbralBlade` is instead:
+
+- a persistent equipment system
+- a combat-state machine
+- a display identity tied to inventory state
+- sometimes projectile-like during only a few states
+
+That mismatch causes a lot of override-heavy behavior and makes disposal/recovery semantics muddy.
+
+### Migration strategy
+
+Do not remove inheritance in the same pass as lifecycle cleanup.
+
+Instead:
+
+1. stabilize lifecycle ownership first
+2. identify the reusable projectile functions the blade actually needs
+3. extract those into a shared helper/component
+4. migrate `UmbralBlade` to composition
+
+Likely extraction candidates:
+
+- trajectory generation
+- `initFlight()` / `stepFlight()`
+- hit filtering helpers
+- grounded/hit/catch termination plumbing
+- display projectile teleport helpers
+
+---
+
+## Dev Testing Tool
+
+To support fast verification, add a dedicated dev item:
+
+- item: `BREEZE_ROD`
+- source: obtainable from `DevMenu`
+- purpose: direct Umbral Blade lifecycle testing
+
+### Desired behavior
+
+When held by a `DevSwordPlayer`:
+
+- `LEFT` -> completely deactivate and destroy the blade
+- `DROP` -> completely reactivate the blade into ready state
+
+Recommended ready state on reactivation:
+
+- `STANDBY`
+
+That makes the result visually obvious and removes ambiguity about whether the blade came back correctly.
+
+### Integration point
+
+Add a new item in `DevMenu` that gives the player the testing rod.
+
+Suggested name:
+
+- `Umbral Blade Tester`
+
+Suggested lore:
+
+- `Left-click: fully destroy blade`
+- `Drop: fully recreate blade in standby`
+
+### Input routing
+
+The tester should use the existing dev-only input path, not generic gameplay input:
+
+- detect the rod by a dedicated item key
+- route it through `DevSwordPlayer.act(...)` or a small dedicated dev action helper
+
+This keeps the tool isolated from normal combat inputs.
+
+### Why this tool matters
+
+It gives the team a deterministic way to test:
+
+- full shutdown
+- clean recreation
+- whether tasks leak after destruction
+- whether the ready-state startup path is stable
+
+---
+
+## Implementation Plan
+
+### Phase 1. Establish clean lifecycle API
+
+Files:
+
+- `Combatant`
+- `SwordPlayer`
+- `DevSwordPlayer`
+- join/load flow classes
+
+Changes:
+
+- add explicit lifecycle flags to `Combatant`
+- add clean start/stop/restart methods
+- move all blade creation into `startUmbralBlade(...)`
+- ensure full destruction always nulls the reference
+- make startup target state explicit (`SHEATHED` or `STANDBY`)
+
+### Phase 2. Rewire external callers to lifecycle API
+
+Files:
+
+- `PlayerListener`
+- `AnimationMode`
+- any dev/menu/special-mode classes touching blade requests directly
+
+Changes:
+
+- replace direct `BladeRequest.DEACTIVATE` / `ACTIVATE_TO_PREVIOUS` usage
+- remove manual display removal
+- express intent only through `Combatant` lifecycle methods
+
+### Phase 3. Redefine `InactiveState`
+
+Files:
+
+- `InactiveState`
+- `UmbralStateMachine`
+- `BladeRequest`
+
+Changes:
+
+- remove recursive self-disposal behavior from `InactiveState`
+- decide whether `InactiveState` is suspend/resume only or nearly unused
+- remove `ACTIVATE_TO_PREVIOUS`
+- if needed, add explicit wake-to-ready transition logic
+
+### Phase 4. Simplify startup and recovery
+
+Files:
+
+- `Combatant`
+- `UmbralBlade`
+- `RecoverState`
+
+Changes:
+
+- replace passive null polling with explicit start requests
+- make recovery one-shot and deterministic
+- ensure startup and repair both land in known ready states
+
+### Phase 5. Add the dev testing rod
+
+Files:
+
+- `DevMenu`
+- dev input routing classes
+- possibly `KeyRegistry`
+- a new small dev action helper
+
+Changes:
+
+- add `BREEZE_ROD` dev item
+- left click destroys blade
+- drop recreates blade in standby
+- keep behavior dev-only
+
+### Phase 6. Remove `ThrownItem` inheritance in a follow-up refactor
+
+Files:
+
+- `UmbralBlade`
+- `ThrownItem`
+- new shared projectile helper/component
+
+Changes:
+
+- extract reusable projectile logic
+- move blade to composition
+- preserve behavior while reducing inheritance mismatch
+
+---
+
+## Verification Matrix
+
+After implementation, verify all of the following manually:
+
+1. Join during load-in -> no blade before system-ready moment.
+2. Join complete -> blade starts exactly once in the chosen ready state.
+3. Breeze rod left click -> blade fully disappears, no jitter, no ghost.
+4. Breeze rod drop -> blade recreates exactly once in standby.
+5. Repeat destroy/reactivate rapidly -> no duplicate displays, no stale tasks.
+6. `/kill` or normal death -> blade fully destroyed and recreates cleanly after respawn readiness.
+7. Spectator enter -> blade follows the selected suppression policy cleanly.
+8. Spectator exit -> blade returns through the lifecycle API, not stale FSM state.
+9. Animation mode enter/exit -> no direct display manipulation, no orphaned blade.
+10. Leave and rejoin -> never see old blade jittering beside new blade.
+11. Kill display entities externally -> repair path produces one clean blade only.
+
+---
+
+## Recommended Review Decisions
+
+The architecture review should explicitly approve or reject these points:
+
+1. `Combatant` is the sole Umbral Blade lifecycle owner.
+2. Blade startup must be explicit and readiness-gated.
+3. `ACTIVATE_TO_PREVIOUS` should be removed.
+4. `InactiveState` remains only as a recoverable dormant state, not a destroy path.
+5. Spectator/dev suppression should default to full destruction unless there is a strong reason to keep suspend/resume.
+6. `UmbralBlade` should be migrated away from `ThrownItem` in a second refactor phase, not the first.
+7. A dev-only `BREEZE_ROD` tester should be added immediately to validate the new lifecycle.
+
+---
+
+## Summary
+
+The key simplification is this:
+
+- the FSM decides what the blade is doing
+- the lifecycle layer decides whether the blade exists at all
+
+Once that separation is enforced, the rest of the cleanup becomes much easier:
+
+- startup becomes explicit
+- deactivation becomes explicit
+- reactivation becomes deterministic
+- dev testing becomes trivial
+- `InactiveState` becomes understandable
+- and the long-term removal of `ThrownItem` inheritance becomes much safer

--- a/src/main/java/btm/sword/Sword.java
+++ b/src/main/java/btm/sword/Sword.java
@@ -2,7 +2,6 @@ package btm.sword;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -11,8 +10,6 @@ import org.bukkit.World;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
-import org.joml.Quaternionf;
-import org.joml.Vector3f;
 
 import com.comphenix.protocol.ProtocolLibrary;
 import com.comphenix.protocol.ProtocolManager;
@@ -31,14 +28,9 @@ import btm.sword.listeners.packet.MovementListener;
 import btm.sword.system.action.throwing.InteractiveItemArbiter;
 import btm.sword.system.action.throwing.ProjectileManager;
 import btm.sword.system.attack.HitPacketRegistry;
-import btm.sword.system.attack.HitValuePacket;
-import btm.sword.system.attack.def.AttackDef;
 import btm.sword.system.attack.def.AttackRegistry;
 import btm.sword.system.attack.def.ParticleDisplayLibrary;
 import btm.sword.system.attack.simulation.CollisionEventBridge;
-import btm.sword.system.attack.simulation.KeyframeType;
-import btm.sword.system.attack.simulation.VolumeKeyframe;
-import btm.sword.system.attack.simulation.VolumeShape;
 import btm.sword.system.attack.simulation.VolumeSimulation;
 import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.display.BossBarManager;
@@ -131,17 +123,6 @@ public final class Sword extends JavaPlugin {
 
         // Load particle display library presets from plugins/sword/particles.yml
         ParticleDisplayLibrary.load(new File(getDataFolder(), "particles.yml"));
-
-        // Register dev test AttackDef used by the TEST_VOLUME_ATTACK test item
-        AttackRegistry.register(new AttackDef.Builder("test_volume_attack")
-            .duration(600)
-            .onHit(new HitValuePacket(
-                () -> 0f, () -> 10, () -> 2, () -> 0f, () -> 0f))
-            .keyframes(List.of(
-                new VolumeKeyframe(0f, new Vector3f(0f, 1f, 1f), new Vector3f(0.5f, 0.5f, 0.5f), new Quaternionf(), VolumeShape.SPHERE, null, false, false, KeyframeType.STANDARD),
-                new VolumeKeyframe(1f, new Vector3f(0f, 1f, 2f), new Vector3f(0.5f, 0.5f, 0.5f), new Quaternionf(), VolumeShape.SPHERE, null, false, false, KeyframeType.STANDARD)
-            ))
-            .build());
 
         // Drain simulation collision events to the main thread every tick
         TimeArbiter.runTimeIndependentBukkitTaskOnTimer(

--- a/src/main/java/btm/sword/Sword.java
+++ b/src/main/java/btm/sword/Sword.java
@@ -34,6 +34,7 @@ import btm.sword.system.attack.HitPacketRegistry;
 import btm.sword.system.attack.HitValuePacket;
 import btm.sword.system.attack.def.AttackDef;
 import btm.sword.system.attack.def.AttackRegistry;
+import btm.sword.system.attack.def.ParticleDisplayLibrary;
 import btm.sword.system.attack.simulation.CollisionEventBridge;
 import btm.sword.system.attack.simulation.KeyframeType;
 import btm.sword.system.attack.simulation.VolumeKeyframe;
@@ -127,6 +128,9 @@ public final class Sword extends JavaPlugin {
 
         // Load hit-packet presets from plugins/sword/hit-packets.yaml
         HitPacketRegistry.bootstrap(this);
+
+        // Load particle display library presets from plugins/sword/particles.yml
+        ParticleDisplayLibrary.load(new File(getDataFolder(), "particles.yml"));
 
         // Register dev test AttackDef used by the TEST_VOLUME_ATTACK test item
         AttackRegistry.register(new AttackDef.Builder("test_volume_attack")

--- a/src/main/java/btm/sword/commands/SwordCommands.java
+++ b/src/main/java/btm/sword/commands/SwordCommands.java
@@ -1,5 +1,6 @@
 package btm.sword.commands;
 
+import java.io.File;
 import java.util.List;
 import java.util.Map;
 
@@ -13,8 +14,10 @@ import com.mojang.brigadier.arguments.DoubleArgumentType;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 
+import btm.sword.Sword;
 import btm.sword.config.Config;
 import btm.sword.config.ConfigManager;
+import btm.sword.system.attack.def.ParticleDisplayLibrary;
 import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.display.WeaponDisplayRegistry;
@@ -162,6 +165,7 @@ public final class SwordCommands {
         try {
             MobTypeRegistry.reload();
             WeaponDisplayRegistry.reload();
+            ParticleDisplayLibrary.load(new File(Sword.getInstance().getDataFolder(), "particles.yml"));
             boolean success = ConfigManager.getInstance().reload();
 
             if (success) {

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -2892,6 +2892,14 @@ public final class Config {
             v -> LOGGING_VERBOSE_ATTACK_VOLUME = v,
             ConfigurationSection::getBoolean); }
 
+        /** Log ParticleEffect → ParticleWrapper conversion: particle type, dustOptions type, and dispatch path. */
+        public static boolean LOGGING_VERBOSE_PARTICLE_DISPLAY = false;
+        static { register(
+            "debug.logging_verbose_particle_display",
+            LOGGING_VERBOSE_PARTICLE_DISPLAY, Boolean.class,
+            v -> LOGGING_VERBOSE_PARTICLE_DISPLAY = v,
+            ConfigurationSection::getBoolean); }
+
         // Visualization configuration
         public static boolean VISUALIZATION_SHOW_HITBOXES = false;
         static { register(

--- a/src/main/java/btm/sword/config/Config.java
+++ b/src/main/java/btm/sword/config/Config.java
@@ -2812,6 +2812,13 @@ public final class Config {
             v -> LOGGING_VERBOSE_UMBRAL = v,
             ConfigurationSection::getBoolean); }
 
+        public static boolean LOGGING_VERBOSE_UMBRAL_STATES = false;
+        static { register(
+            "debug.logging_verbose_umbral_states",
+            LOGGING_VERBOSE_UMBRAL_STATES, Boolean.class,
+            v -> LOGGING_VERBOSE_UMBRAL_STATES = v,
+            ConfigurationSection::getBoolean); }
+
         public static boolean LOGGING_VERBOSE_HOSTILE = false;
         static { register(
             "debug.logging_verbose_hostile",

--- a/src/main/java/btm/sword/listeners/PlayerListener.java
+++ b/src/main/java/btm/sword/listeners/PlayerListener.java
@@ -1,8 +1,6 @@
 package btm.sword.listeners;
 
-import java.util.Objects;
 
-import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.entity.HumanEntity;
@@ -38,8 +36,6 @@ import btm.sword.system.entity.SwordEntityArbiter;
 import btm.sword.system.entity.base.SwordEntity;
 import btm.sword.system.entity.impl.DevSwordPlayer;
 import btm.sword.system.entity.impl.SwordPlayer;
-import btm.sword.system.entity.umbral.UmbralBlade;
-import btm.sword.system.entity.umbral.input.BladeRequest;
 import btm.sword.system.item.KeyRegistry;
 import btm.sword.system.item.material.MaterialType;
 import btm.sword.system.item.special.NonMovableItem;
@@ -433,23 +429,10 @@ public class PlayerListener implements Listener {
         }
     }
 
-    /** Handles game mode changes; removes blade display entities and deactivates the blade in spectator mode. */
+    /** Blade lifecycle (including spectator destroy/recreate) is owned by {@code Combatant.handleUmbralBladeTick()}. */
     @EventHandler
     public void gameChangeEvent(PlayerGameModeChangeEvent event) {
-        SwordPlayer swordPlayer = (SwordPlayer) SwordEntityArbiter.getOrAdd(event.getPlayer());
-
-        // TODO: #233 - Find a better way to handle display entity orphaning on game mode change
-        UmbralBlade blade = swordPlayer.getUmbralBlade();
-        if (blade != null && blade.getDisplay() != null && blade.getDisplay().isValid()) {
-            blade.getDisplay().remove();
-        }
-
-        if (event.getNewGameMode().equals(GameMode.SPECTATOR)) {
-            swordPlayer.requestUmbralBladeState(BladeRequest.DEACTIVATE);
-        }
-        else if (Objects.equals(event.getPlayer().getGameMode(), GameMode.SPECTATOR)) {
-            swordPlayer.requestUmbralBladeState(BladeRequest.ACTIVATE_TO_PREVIOUS);
-        }
+        // intentionally empty
     }
 
 //    @EventHandler

--- a/src/main/java/btm/sword/system/action/attack/AttackAction.java
+++ b/src/main/java/btm/sword/system/action/attack/AttackAction.java
@@ -4,11 +4,10 @@ import static btm.sword.system.action.attack.PunchAction.throwPunch;
 
 import org.bukkit.inventory.ItemStack;
 
-import btm.sword.Sword;
 import btm.sword.config.Config;
 import btm.sword.system.action.SwordAction;
 import btm.sword.system.attack.SweepAttack;
-import btm.sword.system.attack.def.AttackDef;
+import btm.sword.system.attack.def.AttackInstance;
 import btm.sword.system.attack.dev.AttackDevSession;
 import btm.sword.system.attack.dev.DevMode;
 import btm.sword.system.attack.dev.VolumeEditorMode;
@@ -21,6 +20,7 @@ import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.inventory.menu.dev.SweepGeneratorMenu;
 import btm.sword.system.item.ItemUsageManager;
 import btm.sword.system.item.KeyRegistry;
+import btm.sword.utility.Debug;
 import btm.sword.utility.misc.ConsumerToConsumePair;
 
 
@@ -52,21 +52,21 @@ public class AttackAction extends SwordAction {
         if (KeyRegistry.hasKey(itemUsedInAttack, KeyRegistry.TEST_VOLUME_ATTACK_KEY)) {
             if (executor instanceof SwordPlayer sp) {
                 AttackDevSession devSession = AttackDevSession.get(sp.player().getUniqueId());
-                Sword.print("[AttackAction] wand fired by " + sp.player().getName()
+                Debug.attackVolume("[AttackAction] wand fired by " + sp.player().getName()
                     + " — devSession=" + (devSession == null ? "null" : devSession.getMode())
-                    + " loadedAttack=" + (devSession == null || devSession.getLoadedAttackDef() == null
-                        ? "null" : devSession.getLoadedAttackDef().getId())
+                    + " loadedAttack=" + (devSession == null || devSession.getLoadedAttackInstance() == null
+                    ? "null" : devSession.getLoadedAttackInstance().getId())
                     + " editingSessions=" + AttackDevSession.getEditingSessions().size());
                 if (devSession != null && devSession.getMode() == DevMode.EDITING) {
-                    Sword.print("[AttackAction]   keyframes=" + devSession.getEditKeyframes().size()
+                    Debug.attackVolume("[AttackAction]   keyframes=" + devSession.getEditKeyframes().size()
                         + " duration=" + devSession.getEditDurationMs() + "ms");
                 }
                 if (devSession != null && devSession.getMode() == DevMode.RECORDING) {
                     new SweepGeneratorMenu(sp).open();
                     return;
                 }
-                if (devSession != null && devSession.getLoadedAttackDef() != null) {
-                    fireWandDef(executor, devSession.getLoadedAttackDef());
+                if (devSession != null && devSession.getLoadedAttackInstance() != null) {
+                    fireWandDef(executor, devSession.getLoadedAttackInstance());
                     return;
                 }
             }
@@ -132,10 +132,10 @@ public class AttackAction extends SwordAction {
             .execute(executor);
     }
 
-    private static void fireWandDef(Combatant executor, AttackDef def) {
+    private static void fireWandDef(Combatant executor, AttackInstance def) {
         long startMs = System.currentTimeMillis();
-        executor.launchAttackDef(def);
-        if (executor instanceof SwordPlayer sp) {
+        executor.launchAttack(def);
+        if (executor instanceof SwordPlayer sp && Config.Debug.VISUALIZATION_SHOW_HITBOXES) {
             VolumeEditorMode.startPlaybackVisualization(
                 sp.player(), def.getTrajectory(), startMs, def.getDurationMs(),
                 def.isLockOriginOnFire(), def.isOrientWithPitch());

--- a/src/main/java/btm/sword/system/action/throwing/ThrowAction.java
+++ b/src/main/java/btm/sword/system/action/throwing/ThrowAction.java
@@ -85,7 +85,8 @@ public class ThrowAction extends SwordAction {
             logicalItem = executor.getItemStackInHand(true);
         }
 
-        ThrownItem thrownItem = new ThrownItem(executor, setupInstructions, 1);
+        ThrownItem thrownItem = new ThrownItem(executor, setupInstructions);
+        thrownItem.setup(1);
         thrownItem.setItemStack(logicalItem);
         executor.setThrownItem(thrownItem);
 
@@ -129,7 +130,8 @@ public class ThrowAction extends SwordAction {
         executor.setThrowPhase(ThrowPhase.THROWING);
         if (executor instanceof SwordPlayer sp) sp.setActivationContext(ActivationContext.THROWING);
 
-        ThrownItem thrownItem = new ThrownItem(executor, display -> display.setItemStack(item), 1);
+        ThrownItem thrownItem = new ThrownItem(executor, display -> display.setItemStack(item));
+        thrownItem.setup(1);
         thrownItem.setItemStack(item);
         thrownItem.setDisplayScale(displayScale);
         executor.setThrownItem(thrownItem);

--- a/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
+++ b/src/main/java/btm/sword/system/action/throwing/types/ThrownItem.java
@@ -91,7 +91,7 @@ public class ThrownItem extends VisualProjectile {
      * @param displaySetupInstructions  applied to the {@link ItemDisplay} immediately after it spawns
      * @param setupPeriod               polling interval in ticks for the spawn-check loop
      */
-    public ThrownItem(Combatant thrower, Consumer<ItemDisplay> displaySetupInstructions, int setupPeriod) {
+    public ThrownItem(Combatant thrower, Consumer<ItemDisplay> displaySetupInstructions) {
         this.thrower = thrower;
         this.displaySetupInstructions = displaySetupInstructions;
         setupSuccessful = false;
@@ -99,8 +99,6 @@ public class ThrownItem extends VisualProjectile {
         xDisplayOffset = -0.6f;
         yDisplayOffset = 0.25f;
         zDisplayOffset = -0.1f;
-
-        setup(setupPeriod);
     }
 
     /**
@@ -109,7 +107,7 @@ public class ThrownItem extends VisualProjectile {
      *
      * @param period polling interval in ticks
      */
-    protected void setup(int period) {
+    public void setup(int period) {
         TimeArbiter.runTimeIndependentBukkitTaskOnTimer(
             null,
             () -> {

--- a/src/main/java/btm/sword/system/attack/ActiveAttack.java
+++ b/src/main/java/btm/sword/system/attack/ActiveAttack.java
@@ -3,10 +3,10 @@ package btm.sword.system.attack;
 import java.util.Set;
 import java.util.UUID;
 
-import btm.sword.system.attack.def.AttackDef;
+import btm.sword.system.attack.def.AttackInstance;
 
 /**
- * Represents an {@link AttackDef}-driven attack that is currently active for a combatant.
+ * Represents an {@link AttackInstance}-driven attack that is currently active for a combatant.
  *
  * <p>Holds the game-layer view of an in-progress attack: which definition is running,
  * who owns it, when it started, and which entities have already been hit.
@@ -22,7 +22,7 @@ import btm.sword.system.attack.def.AttackDef;
  * @param hitThisAttack thread-safe set of entity UUIDs hit so far
  */
 public record ActiveAttack(
-        AttackDef def,
+        AttackInstance def,
         UUID ownerUuid,
         long startTimeMs,
         Set<UUID> hitThisAttack) {

--- a/src/main/java/btm/sword/system/attack/def/AttackDefSerializer.java
+++ b/src/main/java/btm/sword/system/attack/def/AttackDefSerializer.java
@@ -278,6 +278,7 @@ public final class AttackDefSerializer {
                 yield OriginAnchor.body(bp);
             }
             case "LOCKED" -> OriginAnchor.fireLocked();
+            case "RAYCAST_ORIGIN" -> OriginAnchor.raycastOrigin();
             default -> OriginAnchor.owning();
         };
     }
@@ -511,6 +512,7 @@ public final class AttackDefSerializer {
                 m.put("point", ebp.point().name());
             }
             case OriginAnchor.FireLockedOrigin ignored -> m.put("kind", "LOCKED");
+            case OriginAnchor.RaycastOrigin ignored -> m.put("kind", "RAYCAST_ORIGIN");
             default -> m.put("kind", "OWNING");
         }
         return m;

--- a/src/main/java/btm/sword/system/attack/def/AttackDefSerializer.java
+++ b/src/main/java/btm/sword/system/attack/def/AttackDefSerializer.java
@@ -21,14 +21,14 @@ import org.joml.Vector3f;
 import btm.sword.system.attack.HitValuePacket;
 import btm.sword.system.attack.simulation.ControlMode;
 import btm.sword.system.attack.simulation.ControlPoint;
-import btm.sword.system.attack.simulation.ControlPointTrajectory;
+import btm.sword.system.attack.simulation.ControlPointSequence;
 import btm.sword.system.attack.simulation.KeyframeEffect;
 import btm.sword.system.attack.simulation.KeyframeType;
-import btm.sword.system.attack.simulation.KeyframedTrajectory;
+import btm.sword.system.attack.simulation.KeyframedSequence;
 import btm.sword.system.attack.simulation.ParticleEffect;
 import btm.sword.system.attack.simulation.SoundCue;
 import btm.sword.system.attack.simulation.SweepCurve;
-import btm.sword.system.attack.simulation.SweepTrajectory;
+import btm.sword.system.attack.simulation.SweepSequence;
 import btm.sword.system.attack.simulation.VolumeKeyframe;
 import btm.sword.system.attack.simulation.VolumeShape;
 import btm.sword.system.attack.visuals.CircleDisplay;
@@ -40,7 +40,7 @@ import btm.sword.system.attack.visuals.SphereDisplay;
 import btm.sword.utility.Debug;
 
 /**
- * Serializes and deserializes {@link AttackDef} entries to/from Bukkit {@link YamlConfiguration}.
+ * Serializes and deserializes {@link AttackInstance} entries to/from Bukkit {@link YamlConfiguration}.
  *
  * <p>SWEEP format uses a {@code curve} section with {@code control-points} and
  * {@code radius-profile} lists. VOLUME format uses a {@code keyframes} list.
@@ -56,14 +56,14 @@ public final class AttackDefSerializer {
     // ── Load ──────────────────────────────────────────────────────────────────
 
     /**
-     * Deserializes a single {@link AttackDef} from a {@link ConfigurationSection}.
+     * Deserializes a single {@link AttackInstance} from a {@link ConfigurationSection}.
      *
      * @param section the YAML section for this attack (child of {@code attacks:})
      * @param id      the attack identifier (key in the parent section)
      * @return the deserialized attack definition
      * @throws IllegalArgumentException if required fields are missing or malformed
      */
-    public static AttackDef load(ConfigurationSection section, String id) {
+    public static AttackInstance load(ConfigurationSection section, String id) {
         String typeStr = section.getString("type");
         if (typeStr == null) throw new IllegalArgumentException("Attack '" + id + "' missing 'type'");
         VolumeType type = VolumeType.valueOf(typeStr.toUpperCase());
@@ -74,7 +74,7 @@ public final class AttackDefSerializer {
         boolean orientWithPitch = section.getBoolean("orient-with-pitch", false);
         boolean lockOriginOnFire = section.getBoolean("lock-origin-on-fire", true);
 
-        AttackDef.Builder builder = new AttackDef.Builder(id)
+        AttackInstance.Builder builder = new AttackInstance.Builder(id)
             .duration(duration)
             .onHit(hitValue)
             .orientWithPitch(orientWithPitch)
@@ -279,6 +279,8 @@ public final class AttackDefSerializer {
             }
             case "LOCKED" -> OriginAnchor.fireLocked();
             case "RAYCAST_ORIGIN" -> OriginAnchor.raycastOrigin();
+            case "NEXT_KEYFRAME" -> OriginAnchor.nextKeyframe(
+                map.get("offset") instanceof Number n ? n.intValue() : 1);
             default -> OriginAnchor.owning();
         };
     }
@@ -302,9 +304,23 @@ public final class AttackDefSerializer {
             int g = dustMap.get("g") instanceof Number gn ? gn.intValue() : 255;
             int b = dustMap.get("b") instanceof Number bn ? bn.intValue() : 255;
             float size = dustMap.get("size") instanceof Number sn2 ? sn2.floatValue() : 1.0f;
-            dust = new Particle.DustOptions(Color.fromRGB(r, g, b), size);
+            if (dustMap.containsKey("to-r")) {
+                int tr = dustMap.get("to-r") instanceof Number rn ? rn.intValue() : 255;
+                int tg = dustMap.get("to-g") instanceof Number gn ? gn.intValue() : 255;
+                int tb = dustMap.get("to-b") instanceof Number bn ? bn.intValue() : 255;
+                dust = new Particle.DustTransition(Color.fromRGB(r, g, b), Color.fromRGB(tr, tg, tb), size);
+            } else {
+                dust = new Particle.DustOptions(Color.fromRGB(r, g, b), size);
+            }
         }
-        return new ParticleEffect(type, count, spreadOffset, speed, dust);
+        Color entityColor = null;
+        if (map.get("entityColor") instanceof Map<?, ?> ecMap) {
+            int r = ecMap.get("r") instanceof Number rn ? rn.intValue() : 255;
+            int g = ecMap.get("g") instanceof Number gn ? gn.intValue() : 255;
+            int b = ecMap.get("b") instanceof Number bn ? bn.intValue() : 255;
+            entityColor = Color.fromRGB(r, g, b);
+        }
+        return new ParticleEffect(type, count, spreadOffset, speed, dust, entityColor);
     }
 
     private static SoundCue loadSoundCue(Map<?, ?> map) {
@@ -337,7 +353,7 @@ public final class AttackDefSerializer {
     // ── Save ──────────────────────────────────────────────────────────────────
 
     /**
-     * Serializes a single {@link AttackDef} into {@code file}, merging with any
+     * Serializes a single {@link AttackInstance} into {@code file}, merging with any
      * existing entries already present in the file.
      *
      * @param file   destination YAML file
@@ -345,7 +361,7 @@ public final class AttackDefSerializer {
      * @throws UnsupportedOperationException if the attack uses a custom lambda trajectory
      *                                        that cannot be serialized
      */
-    public static void save(File file, AttackDef attack) {
+    public static void save(File file, AttackInstance attack) {
         YamlConfiguration yaml = file.exists() ? YamlConfiguration.loadConfiguration(file) : new YamlConfiguration();
         String path = "attacks." + attack.getId();
 
@@ -377,8 +393,8 @@ public final class AttackDefSerializer {
         yaml.set(path + ".invulnerable-ticks", hv.invulnerableTicks());
     }
 
-    private static void saveSweepCurve(YamlConfiguration yaml, String path, AttackDef attack) {
-        if (!(attack.getTrajectory() instanceof SweepTrajectory sweep)) {
+    private static void saveSweepCurve(YamlConfiguration yaml, String path, AttackInstance attack) {
+        if (!(attack.getTrajectory() instanceof SweepSequence sweep)) {
             throw new UnsupportedOperationException("Cannot serialize non-SweepTrajectory as SWEEP for: " + attack.getId());
         }
         SweepCurve curve = sweep.getCurve();
@@ -395,12 +411,12 @@ public final class AttackDefSerializer {
         yaml.set(path + ".curve.radius-profile", radiusMaps);
     }
 
-    private static void saveKeyframes(YamlConfiguration yaml, String path, AttackDef attack) {
-        if (!(attack.getTrajectory() instanceof KeyframedTrajectory kt)) {
+    private static void saveKeyframes(YamlConfiguration yaml, String path, AttackInstance attack) {
+        if (!(attack.getTrajectory() instanceof KeyframedSequence kt)) {
             throw new UnsupportedOperationException("Cannot serialize non-KeyframedTrajectory as VOLUME for: " + attack.getId());
         }
         List<Map<String, Object>> kfMaps = new ArrayList<>();
-        for (VolumeKeyframe kf : kt.getKeyframes()) {
+        for (VolumeKeyframe kf : kt.keyframes()) {
             Map<String, Object> kfMap = new LinkedHashMap<>();
             kfMap.put("t", (double) kf.t());
             kfMap.put("position", vecMap(kf.localPosition()));
@@ -430,8 +446,8 @@ public final class AttackDefSerializer {
         yaml.set(path + ".keyframes", kfMaps);
     }
 
-    private static void saveControlPoints(YamlConfiguration yaml, String path, AttackDef attack) {
-        if (!(attack.getTrajectory() instanceof ControlPointTrajectory cpt)) {
+    private static void saveControlPoints(YamlConfiguration yaml, String path, AttackInstance attack) {
+        if (!(attack.getTrajectory() instanceof ControlPointSequence cpt)) {
             throw new UnsupportedOperationException(
                 "Cannot serialize non-ControlPointTrajectory as CTRL_POINT for: " + attack.getId());
         }
@@ -513,6 +529,10 @@ public final class AttackDefSerializer {
             }
             case OriginAnchor.FireLockedOrigin ignored -> m.put("kind", "LOCKED");
             case OriginAnchor.RaycastOrigin ignored -> m.put("kind", "RAYCAST_ORIGIN");
+            case OriginAnchor.NextKeyframe nk -> {
+                m.put("kind", "NEXT_KEYFRAME");
+                m.put("offset", nk.offset());
+            }
             default -> m.put("kind", "OWNING");
         }
         return m;
@@ -531,6 +551,13 @@ public final class AttackDefSerializer {
                 "g", d.getColor().getGreen(),
                 "b", d.getColor().getBlue(),
                 "size", (double) d.getSize()
+            ));
+        }
+        if (p.entityColor() != null) {
+            map.put("entityColor", Map.of(
+                "r", p.entityColor().getRed(),
+                "g", p.entityColor().getGreen(),
+                "b", p.entityColor().getBlue()
             ));
         }
         return map;

--- a/src/main/java/btm/sword/system/attack/def/AttackInstance.java
+++ b/src/main/java/btm/sword/system/attack/def/AttackInstance.java
@@ -6,16 +6,17 @@ import java.util.function.BiFunction;
 import org.joml.Vector3f;
 
 import btm.sword.config.Config;
+import btm.sword.system.attack.ActiveAttack;
 import btm.sword.system.attack.HitValuePacket;
 import btm.sword.system.attack.simulation.ControlMode;
 import btm.sword.system.attack.simulation.ControlPoint;
-import btm.sword.system.attack.simulation.ControlPointTrajectory;
-import btm.sword.system.attack.simulation.KeyframedTrajectory;
+import btm.sword.system.attack.simulation.ControlPointSequence;
+import btm.sword.system.attack.simulation.KeyframedSequence;
 import btm.sword.system.attack.simulation.SweepCurve;
-import btm.sword.system.attack.simulation.SweepTrajectory;
+import btm.sword.system.attack.simulation.SweepSequence;
 import btm.sword.system.attack.simulation.Volume;
 import btm.sword.system.attack.simulation.VolumeKeyframe;
-import btm.sword.system.attack.simulation.VolumeTrajectory;
+import btm.sword.system.attack.simulation.VolumeSequence;
 import btm.sword.system.entity.base.SwordEntity;
 import lombok.Getter;
 
@@ -34,21 +35,21 @@ import lombok.Getter;
  * }</pre>
  *
  * <p>When activating an attack, allocate a fresh {@link Volume} buffer via
- * {@link #createVolume()} and pass it to {@link btm.sword.system.attack.simulation.ActiveAttack}.</p>
+ * {@link #createVolume()} and pass it to {@link ActiveAttack}.</p>
  */
 @Getter
-public final class AttackDef {
+public final class AttackInstance {
 
     private final String id;
     private final VolumeType type;
     private final int durationMs;
-    private final VolumeTrajectory trajectory;
+    private final VolumeSequence trajectory;
     private final HitValuePacket hitValue;
     private final BiFunction<Vector3f, SwordEntity, Vector3f> knockbackFunction;
     private final boolean orientWithPitch;
     private final boolean lockOriginOnFire;
 
-    private AttackDef(Builder b) {
+    private AttackInstance(Builder b) {
         this.id = b.id;
         this.type = b.type;
         this.durationMs = b.durationMs;
@@ -62,7 +63,7 @@ public final class AttackDef {
     /**
      * Allocates a fresh {@link Volume} buffer appropriate for this attack's {@link VolumeType}.
      * Call once per activation and pass the result to
-     * {@link btm.sword.system.attack.simulation.ActiveAttack}.
+     * {@link ActiveAttack}.
      *
      * @return a new, empty volume buffer
      */
@@ -73,14 +74,14 @@ public final class AttackDef {
     // ── Builder ───────────────────────────────────────────────────────────────
 
     /**
-     * Fluent builder for {@link AttackDef}.
+     * Fluent builder for {@link AttackInstance}.
      */
     public static final class Builder {
 
         private final String id;
         private VolumeType type;
         private int durationMs;
-        private VolumeTrajectory trajectory;
+        private VolumeSequence trajectory;
         private HitValuePacket hitValue;
         private BiFunction<Vector3f, SwordEntity, Vector3f> knockbackFunction =
             (contact, src) -> new Vector3f();
@@ -107,7 +108,7 @@ public final class AttackDef {
         }
 
         /**
-         * Explicitly sets the primitive type. Required when using {@link #trajectory(VolumeTrajectory)};
+         * Explicitly sets the primitive type. Required when using {@link #trajectory(VolumeSequence)};
          * implied automatically by {@link #keyframes} and {@link #sweep}.
          *
          * @param type the collision primitive
@@ -119,7 +120,7 @@ public final class AttackDef {
         }
 
         /**
-         * Builds a {@link KeyframedTrajectory} from the given keyframes and sets {@code type = VOLUME}.
+         * Builds a {@link KeyframedSequence} from the given keyframes and sets {@code type = VOLUME}.
          * Overridden by a subsequent {@link #trajectory} call.
          *
          * @param keyframes ordered list of OBB keyframes
@@ -127,12 +128,12 @@ public final class AttackDef {
          */
         public Builder keyframes(List<VolumeKeyframe> keyframes) {
             this.type = VolumeType.VOLUME;
-            this.trajectory = new KeyframedTrajectory(keyframes);
+            this.trajectory = new KeyframedSequence(keyframes);
             return this;
         }
 
         /**
-         * Builds a {@link SweepTrajectory} from the given curve and sets {@code type = SWEEP}.
+         * Builds a {@link SweepSequence} from the given curve and sets {@code type = SWEEP}.
          * Overridden by a subsequent {@link #trajectory} call.
          *
          * @param curve the Catmull-Rom sweep curve
@@ -140,12 +141,12 @@ public final class AttackDef {
          */
         public Builder sweep(SweepCurve curve) {
             this.type = VolumeType.SWEEP;
-            this.trajectory = new SweepTrajectory(curve);
+            this.trajectory = new SweepSequence(curve);
             return this;
         }
 
         /**
-         * Builds a {@link ControlPointTrajectory} from the given control points and mode,
+         * Builds a {@link ControlPointSequence} from the given control points and mode,
          * and sets {@code type = CTRL_POINT}. Overridden by a subsequent {@link #trajectory} call.
          *
          * @param points ordered list of control points; must be 2 for {@link ControlMode#LINEAR}
@@ -155,7 +156,7 @@ public final class AttackDef {
          */
         public Builder controlPoints(List<ControlPoint> points, ControlMode mode) {
             this.type = VolumeType.CTRL_POINT;
-            this.trajectory = new ControlPointTrajectory(points, mode);
+            this.trajectory = new ControlPointSequence(points, mode);
             return this;
         }
 
@@ -166,7 +167,7 @@ public final class AttackDef {
          * @param trajectory custom trajectory implementation or lambda
          * @return this builder
          */
-        public Builder trajectory(VolumeTrajectory trajectory) {
+        public Builder trajectory(VolumeSequence trajectory) {
             this.trajectory = trajectory;
             return this;
         }
@@ -221,18 +222,18 @@ public final class AttackDef {
         }
 
         /**
-         * Builds and returns an immutable {@link AttackDef}.
+         * Builds and returns an immutable {@link AttackInstance}.
          *
          * @return the constructed attack definition
          * @throws IllegalStateException if {@code type}, {@code trajectory}, {@code hitValue},
          *                               or {@code durationMs} have not been set
          */
-        public AttackDef build() {
+        public AttackInstance build() {
             if (type == null) throw new IllegalStateException("AttackDef '" + id + "': type not set");
             if (trajectory == null) throw new IllegalStateException("AttackDef '" + id + "': trajectory not set");
             if (hitValue == null) throw new IllegalStateException("AttackDef '" + id + "': hitValue not set");
             if (durationMs <= 0) throw new IllegalStateException("AttackDef '" + id + "': durationMs must be > 0");
-            return new AttackDef(this);
+            return new AttackInstance(this);
         }
     }
 }

--- a/src/main/java/btm/sword/system/attack/def/AttackRegistry.java
+++ b/src/main/java/btm/sword/system/attack/def/AttackRegistry.java
@@ -13,14 +13,14 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import btm.sword.utility.Debug;
 
 /**
- * Global registry of all named {@link AttackDef}s.
+ * Global registry of all named {@link AttackInstance}s.
  *
  * <p>Attacks are registered at plugin startup and on {@code /sword reload}.
  * All lookups are O(1) via a {@link ConcurrentHashMap}.</p>
  */
 public final class AttackRegistry {
 
-    private static final ConcurrentHashMap<String, AttackDef> REGISTRY = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, AttackInstance> REGISTRY = new ConcurrentHashMap<>();
 
     private AttackRegistry() {}
 
@@ -29,19 +29,19 @@ public final class AttackRegistry {
      *
      * @param def the attack definition to register
      */
-    public static void register(AttackDef def) {
+    public static void register(AttackInstance def) {
         REGISTRY.put(def.getId(), def);
     }
 
     /**
-     * Returns the {@link AttackDef} for the given id.
+     * Returns the {@link AttackInstance} for the given id.
      *
      * @param id the unique attack identifier
      * @return the registered attack definition
      * @throws IllegalArgumentException if no attack is registered under {@code id}
      */
-    public static AttackDef get(String id) {
-        AttackDef def = REGISTRY.get(id);
+    public static AttackInstance get(String id) {
+        AttackInstance def = REGISTRY.get(id);
         if (def == null) throw new IllegalArgumentException("No AttackDef registered for id: " + id);
         return def;
     }
@@ -51,7 +51,7 @@ public final class AttackRegistry {
      *
      * @return all registered attacks
      */
-    public static Collection<AttackDef> getAll() {
+    public static Collection<AttackInstance> getAll() {
         return Collections.unmodifiableCollection(REGISTRY.values());
     }
 

--- a/src/main/java/btm/sword/system/attack/def/ParticleDisplayLibrary.java
+++ b/src/main/java/btm/sword/system/attack/def/ParticleDisplayLibrary.java
@@ -1,0 +1,130 @@
+package btm.sword.system.attack.def;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import btm.sword.Sword;
+import btm.sword.system.attack.visuals.ParticleDisplay;
+
+/**
+ * Static registry of named {@link ParticleDisplay} presets persisted in
+ * {@code plugins/sword/particles.yml}.
+ *
+ * <p>Presets are keyed by a user-supplied name (e.g. {@code "sweep_trail"}).
+ * The file is loaded at plugin startup via {@link #load(File)} and can be
+ * reloaded at any time via the same method. Saves are explicit via
+ * {@link #save(File)} — triggered by the in-game editor when the player
+ * adds or removes a preset.</p>
+ *
+ * <p>YAML format:</p>
+ * <pre>
+ * presets:
+ *   sweep_trail:
+ *     shape: LINE
+ *     anchor: {kind: OWNING}
+ *     ...
+ *   crit_flash:
+ *     shape: POINT
+ *     ...
+ * </pre>
+ */
+public final class ParticleDisplayLibrary {
+
+    private static final Map<String, ParticleDisplay> PRESETS = new LinkedHashMap<>();
+
+    private ParticleDisplayLibrary() {}
+
+    /**
+     * Loads (or reloads) all presets from {@code particles.yml}. Clears the existing
+     * registry first so stale entries are not retained across reloads.
+     *
+     * @param file the {@code particles.yml} file to read; created with defaults if absent
+     */
+    public static void load(File file) {
+        PRESETS.clear();
+        if (!file.exists()) return;
+        YamlConfiguration yaml = YamlConfiguration.loadConfiguration(file);
+        var section = yaml.getConfigurationSection("presets");
+        if (section == null) return;
+        for (String key : section.getKeys(false)) {
+            var raw = section.get(key);
+            if (raw instanceof Map<?, ?> map) {
+                try {
+                    PRESETS.put(key, ParticleDisplaySerializer.load(map));
+                } catch (Exception e) {
+                    Sword.getInstance().getLogger().warning(
+                        "[ParticleDisplayLibrary] Failed to load preset '" + key + "': " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * Writes the current registry to {@code particles.yml}.
+     *
+     * @param file the target file
+     * @throws IOException if the file cannot be written
+     */
+    public static void save(File file) throws IOException {
+        YamlConfiguration yaml = new YamlConfiguration();
+        Map<String, Object> presets = new LinkedHashMap<>();
+        for (Map.Entry<String, ParticleDisplay> entry : PRESETS.entrySet()) {
+            presets.put(entry.getKey(), ParticleDisplaySerializer.serialize(entry.getValue()));
+        }
+        yaml.set("presets", presets);
+        yaml.save(file);
+    }
+
+    /**
+     * Adds or replaces the preset with the given name and immediately saves to disk.
+     *
+     * @param name    the preset name (will be used as the YAML key)
+     * @param display the display to store; a deep copy is made via {@link ParticleDisplay#copy()}
+     * @param file    the {@code particles.yml} file to save to
+     */
+    public static void register(String name, ParticleDisplay display, File file) {
+        PRESETS.put(name, display.copy());
+        try {
+            save(file);
+        } catch (IOException e) {
+            Sword.getInstance().getLogger().warning(
+                "[ParticleDisplayLibrary] Save failed after register: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Removes the preset with the given name and immediately saves to disk.
+     *
+     * @param name the preset name to remove
+     * @param file the {@code particles.yml} file to save to
+     */
+    public static void remove(String name, File file) {
+        if (PRESETS.remove(name) != null) {
+            try {
+                save(file);
+            } catch (IOException e) {
+                Sword.getInstance().getLogger().warning(
+                    "[ParticleDisplayLibrary] Save failed after remove: " + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Returns an unmodifiable ordered view of all named presets.
+     *
+     * @return map of name → display (insertion order preserved)
+     */
+    public static Map<String, ParticleDisplay> getAll() {
+        return Collections.unmodifiableMap(PRESETS);
+    }
+
+    /** Returns {@code true} if a preset with the given name exists. */
+    public static boolean contains(String name) {
+        return PRESETS.containsKey(name);
+    }
+}

--- a/src/main/java/btm/sword/system/attack/def/ParticleDisplaySerializer.java
+++ b/src/main/java/btm/sword/system/attack/def/ParticleDisplaySerializer.java
@@ -100,44 +100,50 @@ public final class ParticleDisplaySerializer {
     /**
      * Serializes a {@link ParticleDisplay} to a raw YAML-compatible map.
      *
-     * @param d the display to serialize
+     * @param display the display to serialize
      * @return a map suitable for writing with {@link org.bukkit.configuration.file.YamlConfiguration}
      */
-    public static Map<String, Object> serialize(ParticleDisplay d) {
+    public static Map<String, Object> serialize(ParticleDisplay display) {
         Map<String, Object> map = new LinkedHashMap<>();
-        String shape = switch (d) {
+        String shape = switch (display) {
             case LineDisplay ignored -> "LINE";
             case SphereDisplay ignored -> "SPHERE";
             case CircleDisplay ignored -> "CIRCLE";
             default -> "POINT";
         };
         map.put("shape", shape);
-        map.put("anchor", serializeAnchor(d.getAnchor()));
-        map.put("origin-offset", vecMap(d.getOriginOffset()));
-        map.put("random-offset-range", vecMap(d.getRandomOffsetRange()));
-        map.put("repeat-count", d.getRepeatCount());
-        map.put("repeat-period-ticks", d.getRepeatPeriodTicks());
-        if (d.getBetweenKfRepeat() > 0) map.put("between-kf-repeat", d.getBetweenKfRepeat());
+        map.put("anchor", serializeAnchor(display.getAnchor()));
+        map.put("origin-offset", vecMap(display.getOriginOffset()));
+        map.put("random-offset-range", vecMap(display.getRandomOffsetRange()));
+        map.put("repeat-count", display.getRepeatCount());
+        map.put("repeat-period-ticks", display.getRepeatPeriodTicks());
+        if (display.getBetweenKfRepeat() > 0) map.put("between-kf-repeat", display.getBetweenKfRepeat());
         List<Map<String, Object>> pList = new ArrayList<>();
-        for (ParticleEffect p : d.getParticles()) {
+        for (ParticleEffect p : display.getParticles()) {
             pList.add(serializeParticle(p));
         }
         map.put("particles", pList);
-        if (d instanceof LineDisplay ld) {
-            map.put("end-anchor", serializeAnchor(ld.getEndAnchor()));
-            map.put("end-offset", vecMap(ld.getEndOffset()));
-            map.put("end-random-range", vecMap(ld.getEndRandomRange()));
-            map.put("spacing", ld.getSpacing());
-        } else if (d instanceof SphereDisplay sd) {
-            map.put("radius", sd.getRadius());
-            map.put("density", sd.getDensity());
-            map.put("filled", sd.isFilled());
-        } else if (d instanceof CircleDisplay cd) {
-            map.put("outer-radius", cd.getOuterRadius());
-            map.put("inner-radius", cd.getInnerRadius());
-            map.put("spacing-radial", cd.getSpacingRadial());
-            map.put("spacing-arc", cd.getSpacingArc());
-            map.put("normal", cd.getNormal().name());
+        switch (display) {
+            case LineDisplay ld -> {
+                map.put("end-anchor", serializeAnchor(ld.getEndAnchor()));
+                map.put("end-offset", vecMap(ld.getEndOffset()));
+                map.put("end-random-range", vecMap(ld.getEndRandomRange()));
+                map.put("spacing", ld.getSpacing());
+            }
+            case SphereDisplay sd -> {
+                map.put("radius", sd.getRadius());
+                map.put("density", sd.getDensity());
+                map.put("filled", sd.isFilled());
+            }
+            case CircleDisplay cd -> {
+                map.put("outer-radius", cd.getOuterRadius());
+                map.put("inner-radius", cd.getInnerRadius());
+                map.put("spacing-radial", cd.getSpacingRadial());
+                map.put("spacing-arc", cd.getSpacingArc());
+                map.put("normal", cd.getNormal().name());
+            }
+            default -> {
+            }
         }
         return map;
     }
@@ -181,7 +187,6 @@ public final class ParticleDisplaySerializer {
     public static Map<String, Object> serializeAnchor(OriginAnchor anchor) {
         Map<String, Object> m = new LinkedHashMap<>();
         switch (anchor) {
-            case OriginAnchor.OwningKeyframe ignored -> m.put("kind", "OWNING");
             case OriginAnchor.KeyframeIndex ki -> {
                 m.put("kind", "KEYFRAME");
                 m.put("index", ki.index());
@@ -219,9 +224,23 @@ public final class ParticleDisplaySerializer {
             int g = dustMap.get("g") instanceof Number n ? n.intValue() : 255;
             int b = dustMap.get("b") instanceof Number n ? n.intValue() : 255;
             float size = dustMap.get("size") instanceof Number n ? n.floatValue() : 1.0f;
-            dustOptions = new Particle.DustOptions(Color.fromRGB(r, g, b), size);
+            if (dustMap.containsKey("to-r")) {
+                int tr = dustMap.get("to-r") instanceof Number n ? n.intValue() : 255;
+                int tg = dustMap.get("to-g") instanceof Number n ? n.intValue() : 255;
+                int tb = dustMap.get("to-b") instanceof Number n ? n.intValue() : 255;
+                dustOptions = new Particle.DustTransition(Color.fromRGB(r, g, b), Color.fromRGB(tr, tg, tb), size);
+            } else {
+                dustOptions = new Particle.DustOptions(Color.fromRGB(r, g, b), size);
+            }
         }
-        return new ParticleEffect(type, count, spreadOffset, speed, dustOptions);
+        Color entityColor = null;
+        if (map.get("entityColor") instanceof Map<?, ?> ecMap) {
+            int r = ecMap.get("r") instanceof Number n ? n.intValue() : 255;
+            int g = ecMap.get("g") instanceof Number n ? n.intValue() : 255;
+            int b = ecMap.get("b") instanceof Number n ? n.intValue() : 255;
+            entityColor = Color.fromRGB(r, g, b);
+        }
+        return new ParticleEffect(type, count, spreadOffset, speed, dustOptions, entityColor);
     }
 
     /**
@@ -236,13 +255,30 @@ public final class ParticleDisplaySerializer {
         map.put("count", p.count());
         map.put("spreadOffset", vecMap(p.spreadOffset()));
         map.put("speed", p.speed());
-        if (p.dustOptions() != null) {
+        if (p.dustOptions() instanceof Particle.DustTransition dt) {
+            map.put("dust", Map.of(
+                "r", dt.getColor().getRed(),
+                "g", dt.getColor().getGreen(),
+                "b", dt.getColor().getBlue(),
+                "to-r", dt.getToColor().getRed(),
+                "to-g", dt.getToColor().getGreen(),
+                "to-b", dt.getToColor().getBlue(),
+                "size", (double) dt.getSize()
+            ));
+        } else if (p.dustOptions() != null) {
             Particle.DustOptions d = p.dustOptions();
             map.put("dust", Map.of(
                 "r", d.getColor().getRed(),
                 "g", d.getColor().getGreen(),
                 "b", d.getColor().getBlue(),
                 "size", (double) d.getSize()
+            ));
+        }
+        if (p.entityColor() != null) {
+            map.put("entityColor", Map.of(
+                "r", p.entityColor().getRed(),
+                "g", p.entityColor().getGreen(),
+                "b", p.entityColor().getBlue()
             ));
         }
         return map;

--- a/src/main/java/btm/sword/system/attack/def/ParticleDisplaySerializer.java
+++ b/src/main/java/btm/sword/system/attack/def/ParticleDisplaySerializer.java
@@ -45,6 +45,7 @@ public final class ParticleDisplaySerializer {
             ? readVec(rMap) : new Vector3f();
         int repeatCount = map.get("repeat-count") instanceof Number n ? n.intValue() : 1;
         int repeatPeriodTicks = map.get("repeat-period-ticks") instanceof Number n ? n.intValue() : 0;
+        int betweenKfRepeat = map.get("between-kf-repeat") instanceof Number n ? n.intValue() : 0;
         List<ParticleEffect> particles = new ArrayList<>();
         if (map.get("particles") instanceof List<?> pList) {
             for (Object item : pList) {
@@ -53,7 +54,7 @@ public final class ParticleDisplaySerializer {
                 }
             }
         }
-        return switch (shape) {
+        ParticleDisplay display = switch (shape) {
             case "LINE" -> {
                 OriginAnchor endAnchor = loadAnchor(map.get("end-anchor"));
                 Vector3f endOffset = map.get("end-offset") instanceof Map<?, ?> eo
@@ -92,6 +93,8 @@ public final class ParticleDisplaySerializer {
             default -> new PointDisplay(anchor, originOffset, randomRange,
                 repeatCount, repeatPeriodTicks, particles);
         };
+        display.setBetweenKfRepeat(betweenKfRepeat);
+        return display;
     }
 
     /**
@@ -114,6 +117,7 @@ public final class ParticleDisplaySerializer {
         map.put("random-offset-range", vecMap(d.getRandomOffsetRange()));
         map.put("repeat-count", d.getRepeatCount());
         map.put("repeat-period-ticks", d.getRepeatPeriodTicks());
+        if (d.getBetweenKfRepeat() > 0) map.put("between-kf-repeat", d.getBetweenKfRepeat());
         List<Map<String, Object>> pList = new ArrayList<>();
         for (ParticleEffect p : d.getParticles()) {
             pList.add(serializeParticle(p));

--- a/src/main/java/btm/sword/system/attack/def/ParticleDisplaySerializer.java
+++ b/src/main/java/btm/sword/system/attack/def/ParticleDisplaySerializer.java
@@ -1,0 +1,261 @@
+package btm.sword.system.attack.def;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.bukkit.Color;
+import org.bukkit.Particle;
+import org.joml.Vector3f;
+
+import btm.sword.system.attack.simulation.ParticleEffect;
+import btm.sword.system.attack.visuals.CircleDisplay;
+import btm.sword.system.attack.visuals.LineDisplay;
+import btm.sword.system.attack.visuals.OriginAnchor;
+import btm.sword.system.attack.visuals.ParticleDisplay;
+import btm.sword.system.attack.visuals.PointDisplay;
+import btm.sword.system.attack.visuals.SphereDisplay;
+
+/**
+ * Public serialization utilities for {@link ParticleDisplay} and its components.
+ *
+ * <p>Extracted from {@link AttackDefSerializer} so that other systems (e.g.
+ * {@link ParticleDisplayLibrary}) can read and write display data without going through
+ * the full attack serialization path.</p>
+ */
+public final class ParticleDisplaySerializer {
+
+    private ParticleDisplaySerializer() {}
+
+    /**
+     * Deserializes a {@link ParticleDisplay} from a raw YAML map.
+     *
+     * @param map the raw map from YAML
+     * @return the deserialized display, or a default {@link PointDisplay} if the map is malformed
+     */
+    public static ParticleDisplay load(Map<?, ?> map) {
+        if (map == null) return new PointDisplay(OriginAnchor.owning(), new Vector3f(), new Vector3f(), 1, 0, new ArrayList<>());
+        Object shapeRaw = map.get("shape");
+        String shape = (shapeRaw != null ? shapeRaw.toString() : "POINT").toUpperCase();
+        OriginAnchor anchor = loadAnchor(map.get("anchor"));
+        Vector3f originOffset = map.get("origin-offset") instanceof Map<?, ?> oMap
+            ? readVec(oMap) : new Vector3f();
+        Vector3f randomRange = map.get("random-offset-range") instanceof Map<?, ?> rMap
+            ? readVec(rMap) : new Vector3f();
+        int repeatCount = map.get("repeat-count") instanceof Number n ? n.intValue() : 1;
+        int repeatPeriodTicks = map.get("repeat-period-ticks") instanceof Number n ? n.intValue() : 0;
+        List<ParticleEffect> particles = new ArrayList<>();
+        if (map.get("particles") instanceof List<?> pList) {
+            for (Object item : pList) {
+                if (item instanceof Map<?, ?> pMap) {
+                    particles.add(loadParticleEffect(pMap));
+                }
+            }
+        }
+        return switch (shape) {
+            case "LINE" -> {
+                OriginAnchor endAnchor = loadAnchor(map.get("end-anchor"));
+                Vector3f endOffset = map.get("end-offset") instanceof Map<?, ?> eo
+                    ? readVec(eo) : new Vector3f();
+                Vector3f endRandom = map.get("end-random-range") instanceof Map<?, ?> er
+                    ? readVec(er) : new Vector3f();
+                double spacing = map.get("spacing") instanceof Number n ? n.doubleValue() : 0.25;
+                yield new LineDisplay(anchor, originOffset, randomRange,
+                    repeatCount, repeatPeriodTicks, particles,
+                    endAnchor, endOffset, endRandom, spacing);
+            }
+            case "SPHERE" -> {
+                double radius = map.get("radius") instanceof Number n ? n.doubleValue() : 1.0;
+                int density = map.get("density") instanceof Number n ? n.intValue() : 30;
+                boolean filled = Boolean.TRUE.equals(map.get("filled"));
+                yield new SphereDisplay(anchor, originOffset, randomRange,
+                    repeatCount, repeatPeriodTicks, particles, radius, density, filled);
+            }
+            case "CIRCLE" -> {
+                double outer = map.get("outer-radius") instanceof Number n ? n.doubleValue() : 1.0;
+                double inner = map.get("inner-radius") instanceof Number n ? n.doubleValue() : 0.8;
+                double sr = map.get("spacing-radial") instanceof Number n ? n.doubleValue() : 0.25;
+                double sa = map.get("spacing-arc") instanceof Number n ? n.doubleValue() : Math.PI / 16;
+                CircleDisplay.Normal normal;
+                Object normalRaw = map.get("normal");
+                String normalStr = (normalRaw != null ? normalRaw.toString() : "ATTACK_UP").toUpperCase();
+                try {
+                    normal = CircleDisplay.Normal.valueOf(normalStr);
+                } catch (IllegalArgumentException e) {
+                    normal = CircleDisplay.Normal.ATTACK_UP;
+                }
+                yield new CircleDisplay(anchor, originOffset, randomRange,
+                    repeatCount, repeatPeriodTicks, particles,
+                    outer, inner, sr, sa, normal);
+            }
+            default -> new PointDisplay(anchor, originOffset, randomRange,
+                repeatCount, repeatPeriodTicks, particles);
+        };
+    }
+
+    /**
+     * Serializes a {@link ParticleDisplay} to a raw YAML-compatible map.
+     *
+     * @param d the display to serialize
+     * @return a map suitable for writing with {@link org.bukkit.configuration.file.YamlConfiguration}
+     */
+    public static Map<String, Object> serialize(ParticleDisplay d) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        String shape = switch (d) {
+            case LineDisplay ignored -> "LINE";
+            case SphereDisplay ignored -> "SPHERE";
+            case CircleDisplay ignored -> "CIRCLE";
+            default -> "POINT";
+        };
+        map.put("shape", shape);
+        map.put("anchor", serializeAnchor(d.getAnchor()));
+        map.put("origin-offset", vecMap(d.getOriginOffset()));
+        map.put("random-offset-range", vecMap(d.getRandomOffsetRange()));
+        map.put("repeat-count", d.getRepeatCount());
+        map.put("repeat-period-ticks", d.getRepeatPeriodTicks());
+        List<Map<String, Object>> pList = new ArrayList<>();
+        for (ParticleEffect p : d.getParticles()) {
+            pList.add(serializeParticle(p));
+        }
+        map.put("particles", pList);
+        if (d instanceof LineDisplay ld) {
+            map.put("end-anchor", serializeAnchor(ld.getEndAnchor()));
+            map.put("end-offset", vecMap(ld.getEndOffset()));
+            map.put("end-random-range", vecMap(ld.getEndRandomRange()));
+            map.put("spacing", ld.getSpacing());
+        } else if (d instanceof SphereDisplay sd) {
+            map.put("radius", sd.getRadius());
+            map.put("density", sd.getDensity());
+            map.put("filled", sd.isFilled());
+        } else if (d instanceof CircleDisplay cd) {
+            map.put("outer-radius", cd.getOuterRadius());
+            map.put("inner-radius", cd.getInnerRadius());
+            map.put("spacing-radial", cd.getSpacingRadial());
+            map.put("spacing-arc", cd.getSpacingArc());
+            map.put("normal", cd.getNormal().name());
+        }
+        return map;
+    }
+
+    /**
+     * Deserializes an {@link OriginAnchor} from a raw YAML value.
+     *
+     * @param raw the raw object from the YAML map under the {@code anchor} key
+     * @return the resolved anchor, defaulting to {@link OriginAnchor#owning()}
+     */
+    public static OriginAnchor loadAnchor(Object raw) {
+        if (!(raw instanceof Map<?, ?> map)) return OriginAnchor.owning();
+        Object kindRaw = map.get("kind");
+        String kind = (kindRaw != null ? kindRaw.toString() : "OWNING").toUpperCase();
+        return switch (kind) {
+            case "KEYFRAME" -> OriginAnchor.keyframe(
+                map.get("index") instanceof Number n ? n.intValue() : 0);
+            case "BODY" -> {
+                Object pointRaw = map.get("point");
+                String pointStr = (pointRaw != null ? pointRaw.toString() : "EYE").toUpperCase();
+                OriginAnchor.BodyPoint bp;
+                try {
+                    bp = OriginAnchor.BodyPoint.valueOf(pointStr);
+                } catch (IllegalArgumentException e) {
+                    bp = OriginAnchor.BodyPoint.EYE;
+                }
+                yield OriginAnchor.body(bp);
+            }
+            case "LOCKED" -> OriginAnchor.fireLocked();
+            case "RAYCAST_ORIGIN" -> OriginAnchor.raycastOrigin();
+            default -> OriginAnchor.owning();
+        };
+    }
+
+    /**
+     * Serializes an {@link OriginAnchor} to a YAML-compatible map.
+     *
+     * @param anchor the anchor to serialize
+     * @return a map with a {@code kind} key and any additional fields
+     */
+    public static Map<String, Object> serializeAnchor(OriginAnchor anchor) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        switch (anchor) {
+            case OriginAnchor.OwningKeyframe ignored -> m.put("kind", "OWNING");
+            case OriginAnchor.KeyframeIndex ki -> {
+                m.put("kind", "KEYFRAME");
+                m.put("index", ki.index());
+            }
+            case OriginAnchor.EntityBodyPoint ebp -> {
+                m.put("kind", "BODY");
+                m.put("point", ebp.point().name());
+            }
+            case OriginAnchor.FireLockedOrigin ignored -> m.put("kind", "LOCKED");
+            case OriginAnchor.RaycastOrigin ignored -> m.put("kind", "RAYCAST_ORIGIN");
+            default -> m.put("kind", "OWNING");
+        }
+        return m;
+    }
+
+    /**
+     * Deserializes a {@link ParticleEffect} from a raw YAML map.
+     *
+     * @param map the raw map containing particle fields
+     * @return the deserialized effect
+     */
+    public static ParticleEffect loadParticleEffect(Map<?, ?> map) {
+        Particle type = Particle.valueOf(String.valueOf(map.get("type")).toUpperCase());
+        int count = map.get("count") instanceof Number n ? n.intValue() : 1;
+        Vector3f spreadOffset;
+        if (map.get("spreadOffset") instanceof Map<?, ?> soMap) {
+            spreadOffset = readVec(soMap);
+        } else {
+            spreadOffset = new Vector3f();
+        }
+        double speed = map.get("speed") instanceof Number n ? n.doubleValue() : -1.0;
+        Particle.DustOptions dustOptions = null;
+        if (map.get("dust") instanceof Map<?, ?> dustMap) {
+            int r = dustMap.get("r") instanceof Number n ? n.intValue() : 255;
+            int g = dustMap.get("g") instanceof Number n ? n.intValue() : 255;
+            int b = dustMap.get("b") instanceof Number n ? n.intValue() : 255;
+            float size = dustMap.get("size") instanceof Number n ? n.floatValue() : 1.0f;
+            dustOptions = new Particle.DustOptions(Color.fromRGB(r, g, b), size);
+        }
+        return new ParticleEffect(type, count, spreadOffset, speed, dustOptions);
+    }
+
+    /**
+     * Serializes a {@link ParticleEffect} to a YAML-compatible map.
+     *
+     * @param p the effect to serialize
+     * @return a map containing all particle fields
+     */
+    public static Map<String, Object> serializeParticle(ParticleEffect p) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("type", p.type().name());
+        map.put("count", p.count());
+        map.put("spreadOffset", vecMap(p.spreadOffset()));
+        map.put("speed", p.speed());
+        if (p.dustOptions() != null) {
+            Particle.DustOptions d = p.dustOptions();
+            map.put("dust", Map.of(
+                "r", d.getColor().getRed(),
+                "g", d.getColor().getGreen(),
+                "b", d.getColor().getBlue(),
+                "size", (double) d.getSize()
+            ));
+        }
+        return map;
+    }
+
+    static Vector3f readVec(Map<?, ?> m) {
+        float x = m.get("x") instanceof Number n ? n.floatValue() : 0f;
+        float y = m.get("y") instanceof Number n ? n.floatValue() : 0f;
+        float z = m.get("z") instanceof Number n ? n.floatValue() : 0f;
+        return new Vector3f(x, y, z);
+    }
+
+    static Map<String, Object> vecMap(Vector3f v) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("x", (double) v.x);
+        m.put("y", (double) v.y);
+        m.put("z", (double) v.z);
+        return m;
+    }
+}

--- a/src/main/java/btm/sword/system/attack/def/VolumeType.java
+++ b/src/main/java/btm/sword/system/attack/def/VolumeType.java
@@ -5,7 +5,7 @@ import btm.sword.system.attack.simulation.ObbVolume;
 import btm.sword.system.attack.simulation.Volume;
 
 /**
- * Classifies the collision primitive used by an {@link AttackDef}.
+ * Classifies the collision primitive used by an {@link AttackInstance}.
  * Determines which {@link Volume} subtype is allocated when the attack is activated.
  */
 public enum VolumeType {

--- a/src/main/java/btm/sword/system/attack/dev/AnimationMode.java
+++ b/src/main/java/btm/sword/system/attack/dev/AnimationMode.java
@@ -6,7 +6,6 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 import btm.sword.system.entity.impl.DevSwordPlayer;
-import btm.sword.system.entity.umbral.input.BladeRequest;
 import btm.sword.system.inventory.menu.dev.AttackBrowserMenu;
 import btm.sword.system.item.ItemStackBuilder;
 import net.kyori.adventure.text.Component;
@@ -47,7 +46,8 @@ public final class AnimationMode {
      * Enters AnimationMode on the given {@link DevSwordPlayer}.
      *
      * <ol>
-     *   <li>Requests {@link BladeRequest#DEACTIVATE} to hide the blade via {@code InactiveState} (blade FSM keeps ticking; display viewRange set to 0).</li>
+     *   <li>Suppresses the blade via {@link DevSwordPlayer#setUmbralBladeActive(boolean)} —
+     *       {@code Combatant.handleUmbralBladeTick()} destroys the blade on the next tick.</li>
      *   <li>Saves the current inventory to {@link AttackDevSession#getSavedAnimationInventory()}.</li>
      *   <li>Suppresses all anchored-item upkeep so managed items cannot refill the hotbar.</li>
      *   <li>Clears the inventory and populates the animation hotbar (slots 0–8).</li>
@@ -61,8 +61,8 @@ public final class AnimationMode {
      * @param session   the active attack editing session
      */
     public static void enter(DevSwordPlayer devPlayer, AttackDevSession session) {
-        // 1. Request INACTIVE — hides blade via InactiveState without destroying it
-        devPlayer.requestUmbralBladeState(BladeRequest.DEACTIVATE);
+        // 1. Suppress the blade via the lifecycle owner — blade is destroyed on the next tick.
+        devPlayer.setUmbralBladeActive(false);
 
         // 2. Snapshot the current creative-dev inventory
         session.setSavedAnimationInventory(devPlayer.player().getInventory().getContents().clone());
@@ -104,7 +104,8 @@ public final class AnimationMode {
      *   <li>Clears the AnimationMode flag.</li>
      *   <li>Restores the inventory from {@link AttackDevSession#getSavedAnimationInventory()}.</li>
      *   <li>Keeps anchored-item upkeep suppressed (player is still in creative dev mode).</li>
-     *   <li>Requests {@link BladeRequest#ACTIVATE_TO_PREVIOUS} to restore blade.</li>
+     *   <li>Re-enables the blade via {@link DevSwordPlayer#setUmbralBladeActive(boolean)} —
+     *       the lifecycle owner respawns it on the next tick.</li>
      * </ol>
      *
      * @param devPlayer the currently active {@link DevSwordPlayer} in AnimationMode
@@ -120,7 +121,7 @@ public final class AnimationMode {
         }
 
         devPlayer.setAllAnchoredItemUpkeep(false);
-        devPlayer.requestUmbralBladeState(BladeRequest.ACTIVATE_TO_PREVIOUS);
+        devPlayer.setUmbralBladeActive(true);
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────

--- a/src/main/java/btm/sword/system/attack/dev/AttackDevSession.java
+++ b/src/main/java/btm/sword/system/attack/dev/AttackDevSession.java
@@ -15,13 +15,13 @@ import org.joml.Vector3f;
 
 import btm.sword.config.Config;
 import btm.sword.system.attack.HitValuePacket;
-import btm.sword.system.attack.def.AttackDef;
+import btm.sword.system.attack.def.AttackInstance;
 import btm.sword.system.attack.def.VolumeType;
 import btm.sword.system.attack.simulation.ControlMode;
 import btm.sword.system.attack.simulation.ControlPoint;
-import btm.sword.system.attack.simulation.ControlPointTrajectory;
+import btm.sword.system.attack.simulation.ControlPointSequence;
 import btm.sword.system.attack.simulation.KeyframeEffect;
-import btm.sword.system.attack.simulation.KeyframedTrajectory;
+import btm.sword.system.attack.simulation.KeyframedSequence;
 import btm.sword.system.attack.simulation.VolumeKeyframe;
 import btm.sword.system.attack.visuals.ParticleDisplay;
 import lombok.AccessLevel;
@@ -51,7 +51,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
  *
  * <p>During EDITING, the mutable {@link #editKeyframes} list and {@link #editDurationMs}
  * field are the primary working state. Call {@link #buildCurrentAttack()} to materialise
- * the current state into an {@link AttackDef}, and {@link #loadIntoWand()} to cache that
+ * the current state into an {@link AttackInstance}, and {@link #loadIntoWand()} to cache that
  * definition so the test wand fires it on left-click.</p>
  */
 @Getter
@@ -178,10 +178,10 @@ public final class AttackDevSession {
     @Setter
     private LinkedHashSet<Integer> selectedKeyframeIndices = new LinkedHashSet<>();
     /**
-     * The most recently built {@link AttackDef} loaded into the test wand.
+     * The most recently built {@link AttackInstance} loaded into the test wand.
      * {@code null} means the wand fires the default {@code test_volume_attack}.
      */
-    private AttackDef loadedAttackDef = null;
+    private AttackInstance loadedAttackInstance = null;
 
     /**
      * Control points for the current CTRL_POINT edit session, or {@code null} when
@@ -550,16 +550,16 @@ public final class AttackDevSession {
     }
 
     /**
-     * Constructs an immutable {@link AttackDef} from the current edit state.
+     * Constructs an immutable {@link AttackInstance} from the current edit state.
      * Delegates to a control-point build when the session holds CTRL_POINT data;
      * otherwise builds a keyframe-based VOLUME attack.
      *
      * @return the built attack definition
      * @throws IllegalStateException if there is neither keyframe nor control-point data
      */
-    public AttackDef buildCurrentAttack() {
+    public AttackInstance buildCurrentAttack() {
         if (editControlPoints != null && !editControlPoints.isEmpty()) {
-            return new AttackDef.Builder(currentAttackName)
+            return new AttackInstance.Builder(currentAttackName)
                 .controlPoints(editControlPoints, editControlMode)
                 .duration(editDurationMs)
                 .onHit(editHitValue != null ? editHitValue
@@ -571,7 +571,7 @@ public final class AttackDevSession {
         if (editKeyframes.isEmpty()) {
             throw new IllegalStateException("Cannot build AttackDef: no keyframes defined");
         }
-        return new AttackDef.Builder(currentAttackName)
+        return new AttackInstance.Builder(currentAttackName)
             .type(VolumeType.VOLUME)
             .keyframes(editKeyframes)
             .duration(editDurationMs)
@@ -584,34 +584,44 @@ public final class AttackDevSession {
 
     /**
      * Builds the current attack definition from edit state and stores it as the
-     * {@linkplain #loadedAttackDef wand-loaded attack}. The next left-click with the
+     * {@linkplain #loadedAttackInstance wand-loaded attack}. The next left-click with the
      * test wand will fire this definition instead of the default {@code test_volume_attack}.
      */
     public void loadIntoWand() {
-        this.loadedAttackDef = buildCurrentAttack();
+        this.loadedAttackInstance = buildCurrentAttack();
     }
 
     /**
-     * Starts an editing session from an existing {@link AttackDef}.
-     * Supports {@link KeyframedTrajectory} and {@link ControlPointTrajectory}.
+     * Starts an editing session from an existing {@link AttackInstance}.
+     * Supports {@link KeyframedSequence} and {@link ControlPointSequence}.
      *
      * @param def the attack definition to edit
      * @throws IllegalArgumentException if the trajectory type is not editable
      */
-    public void startEditingFromDef(AttackDef def) {
-        if (def.getTrajectory() instanceof ControlPointTrajectory cpt) {
+    public void startEditingFromDef(AttackInstance def) {
+        if (def.getTrajectory() instanceof ControlPointSequence cpt) {
             startEditingCtrlPoint(def.getId(), cpt.getPoints(), cpt.getMode(),
                 def.getDurationMs(), def.getHitValue());
             this.editOrientWithPitch = def.isOrientWithPitch();
             this.editLockOriginOnFire = def.isLockOriginOnFire();
             return;
         }
-        if (!(def.getTrajectory() instanceof KeyframedTrajectory kt)) {
+        if (!(def.getTrajectory() instanceof KeyframedSequence kt)) {
             throw new IllegalArgumentException("Cannot edit attack with unsupported trajectory: " + def.getId());
         }
-        startEditing(def.getId(), kt.getKeyframes(), def.getDurationMs(), def.getHitValue());
+        startEditing(def.getId(), kt.keyframes(), def.getDurationMs(), def.getHitValue());
         this.editOrientWithPitch = def.isOrientWithPitch();
         this.editLockOriginOnFire = def.isLockOriginOnFire();
+    }
+
+    /**
+     * Updates the attack name for the current session — used after a rename operation to keep
+     * the session's name in sync with the new id on disk and in the registry.
+     *
+     * @param name the new attack id
+     */
+    public void renameCurrentAttack(String name) {
+        this.currentAttackName = name;
     }
 
     /**

--- a/src/main/java/btm/sword/system/attack/dev/AttackDevSession.java
+++ b/src/main/java/btm/sword/system/attack/dev/AttackDevSession.java
@@ -208,6 +208,41 @@ public final class AttackDevSession {
      */
     @Getter @Setter private boolean editLockOriginOnFire = Config.Combat.ATTACKS_LOCK_ORIGIN_ON_FIRE;
 
+    // ── Pending multi-kf display copy ─────────────────────────────────────────
+    /**
+     * Keyframe indices to receive a copy of the display at {@link #pendingCopyDisplayIndex}
+     * when {@link btm.sword.system.inventory.menu.dev.KeyframeVisualsMenu} next opens.
+     * Set by add-shape actions that span multiple selected keyframes; consumed and cleared
+     * immediately by the menu so the copy only happens once.
+     */
+    @Getter private final List<Integer> pendingCopyTargets = new ArrayList<>();
+    /** Source keyframe index for the pending multi-kf copy. {@code -1} = none pending. */
+    @Getter @Setter private int pendingCopySourceKfIndex = -1;
+    /** Display index within the source keyframe for the pending multi-kf copy. {@code -1} = none pending. */
+    @Getter @Setter private int pendingCopyDisplayIndex = -1;
+
+    /**
+     * Stores a pending multi-kf display copy: sets the source kf/display indices and
+     * populates the target list.
+     *
+     * @param targets     keyframe indices that should receive a copy of the display
+     * @param sourceKfIdx source keyframe index
+     * @param displayIdx  display index within the source keyframe
+     */
+    public void setPendingCopy(List<Integer> targets, int sourceKfIdx, int displayIdx) {
+        pendingCopyTargets.clear();
+        pendingCopyTargets.addAll(targets);
+        pendingCopySourceKfIndex = sourceKfIdx;
+        pendingCopyDisplayIndex = displayIdx;
+    }
+
+    /** Clears all pending multi-kf copy state. */
+    public void clearPendingCopy() {
+        pendingCopyTargets.clear();
+        pendingCopySourceKfIndex = -1;
+        pendingCopyDisplayIndex = -1;
+    }
+
     private AttackDevSession(Player player) {
         this.player = player;
     }

--- a/src/main/java/btm/sword/system/attack/dev/SaveConfirmDialog.java
+++ b/src/main/java/btm/sword/system/attack/dev/SaveConfirmDialog.java
@@ -7,10 +7,10 @@ import org.bukkit.Material;
 import org.bukkit.configuration.file.YamlConfiguration;
 
 import btm.sword.Sword;
-import btm.sword.system.attack.def.AttackDef;
 import btm.sword.system.attack.def.AttackDefSerializer;
+import btm.sword.system.attack.def.AttackInstance;
 import btm.sword.system.attack.def.AttackRegistry;
-import btm.sword.system.attack.simulation.KeyframedTrajectory;
+import btm.sword.system.attack.simulation.KeyframedSequence;
 import btm.sword.system.entity.impl.DevSwordPlayer;
 import btm.sword.system.item.ItemStackBuilder;
 import net.kyori.adventure.text.Component;
@@ -115,7 +115,7 @@ public final class SaveConfirmDialog {
 
     private static void saveAndExit(DevSwordPlayer player, AttackDevSession session) {
         try {
-            AttackDef def = session.buildCurrentAttack();
+            AttackInstance def = session.buildCurrentAttack();
             AttackRegistry.register(def);
 
             File attacksDir = new File(Sword.getInstance().getDataFolder(), "attacks");
@@ -143,9 +143,9 @@ public final class SaveConfirmDialog {
                     var section = attacksSection.getConfigurationSection(name);
                     if (section != null) {
                         try {
-                            AttackDef loaded = AttackDefSerializer.load(section, name);
-                            if (loaded.getTrajectory() instanceof KeyframedTrajectory kt) {
-                                session.setEditKeyframes(kt.getKeyframes());
+                            AttackInstance loaded = AttackDefSerializer.load(section, name);
+                            if (loaded.getTrajectory() instanceof KeyframedSequence kt) {
+                                session.setEditKeyframes(kt.keyframes());
                             }
                         } catch (Exception e) {
                             player.message(Component.text(

--- a/src/main/java/btm/sword/system/attack/dev/SweepRecordingAction.java
+++ b/src/main/java/btm/sword/system/attack/dev/SweepRecordingAction.java
@@ -16,7 +16,7 @@ import btm.sword.Sword;
 import btm.sword.system.attack.HitValuePacket;
 import btm.sword.system.attack.def.AttackRegistry;
 import btm.sword.system.attack.simulation.KeyframeType;
-import btm.sword.system.attack.simulation.KeyframedTrajectory;
+import btm.sword.system.attack.simulation.KeyframedSequence;
 import btm.sword.system.attack.simulation.VolumeKeyframe;
 import btm.sword.system.attack.simulation.VolumeShape;
 import btm.sword.system.control.PredicateRunnablePair;
@@ -158,14 +158,14 @@ public final class SweepRecordingAction {
             Prefab.Particles.CREATE_DUST.apply(dustForNewPoint(session.getPendingPoints())).display(tip);
             Prefab.Particles.CREATE_DUST.apply(DUST_RAYCAST_ORIGIN).display(rayOrigin);
         } else if (mode == PlacementMode.ORIGIN_RAY) {
-            tip = computeWorldTip(player, 1);
+            tip = getLookPosition(player, 1);
             Vector to = tip.toVector().subtract(session.getLockedOrigin().toVector()).normalize();
             Location rayOrigin = session.getLockedOrigin().clone().add(to.multiply(session.getRayOffset()));
             session.addPendingPoint(new PlacedPoint(tip, mode, rayOrigin));
             Prefab.Particles.CREATE_DUST.apply(dustForNewPoint(session.getPendingPoints())).display(tip);
             Prefab.Particles.CREATE_DUST.apply(DUST_RAYCAST_ORIGIN).display(rayOrigin);
         } else {
-            tip = computeWorldTip(player, 1);
+            tip = getLookPosition(player, 1);
             session.addPendingPoint(tip);
             // Immediate placement marker — color matches what the render loop assigns this point
             Prefab.Particles.CREATE_DUST.apply(dustForNewPoint(session.getPendingPoints())).display(tip);
@@ -201,7 +201,7 @@ public final class SweepRecordingAction {
     // ── Saving ────────────────────────────────────────────────────────────────
 
     /**
-     * Converts the session's pending points into a {@link KeyframedTrajectory} edit session.
+     * Converts the session's pending points into a {@link KeyframedSequence} edit session.
      *
      * <p>No YAML is written here — the file is only persisted when the user explicitly saves
      * via {@link btm.sword.system.attack.dev.SaveConfirmDialog}. Each pending point is
@@ -457,7 +457,7 @@ public final class SweepRecordingAction {
      * Returns the world-space tip position at {@code distance} blocks from the player's eye
      * along the current look direction.
      */
-    static Location computeWorldTip(SwordPlayer player, float distance) {
+    static Location getLookPosition(SwordPlayer player, float distance) {
         return player.locFromEyeDir(distance);
     }
 

--- a/src/main/java/btm/sword/system/attack/dev/VolumeEditorMode.java
+++ b/src/main/java/btm/sword/system/attack/dev/VolumeEditorMode.java
@@ -23,19 +23,20 @@ import org.joml.Vector3f;
 import btm.sword.Sword;
 import btm.sword.config.Config;
 import btm.sword.system.attack.simulation.ControlPoint;
-import btm.sword.system.attack.simulation.ControlPointTrajectory;
+import btm.sword.system.attack.simulation.ControlPointSequence;
 import btm.sword.system.attack.simulation.KeyframeType;
-import btm.sword.system.attack.simulation.KeyframedTrajectory;
+import btm.sword.system.attack.simulation.KeyframedSequence;
 import btm.sword.system.attack.simulation.ObbVolume;
 import btm.sword.system.attack.simulation.VolumeKeyframe;
+import btm.sword.system.attack.simulation.VolumeSequence;
 import btm.sword.system.attack.simulation.VolumeShape;
-import btm.sword.system.attack.simulation.VolumeTrajectory;
 import btm.sword.system.control.PredicateRunnablePair;
 import btm.sword.system.control.TimeArbiter;
 import btm.sword.system.item.KeyRegistry;
 import btm.sword.utility.Debug;
 import btm.sword.utility.Prefab;
 import btm.sword.utility.display.DrawUtil;
+import btm.sword.utility.display.ObbWireframe;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -64,8 +65,6 @@ import net.kyori.adventure.text.format.TextDecoration;
 public final class VolumeEditorMode {
 
     private static final int TICK_MS = 100;
-    private static final float EDGE_SPACING = 0.18f;
-    private static final int SPHERE_SEGMENTS = 16;
 
     /** How many ticks to skip between grey (non-selected) keyframe renders. */
     private static final int GREY_RENDER_PERIOD = 3;
@@ -147,12 +146,12 @@ public final class VolumeEditorMode {
      * Starts a 50 ms main-thread loop that renders the live interpolated OBB of a wand
      * test attack as it plays out.
      *
-     * <p>Only supports {@link KeyframedTrajectory} — silently no-ops for other trajectory
+     * <p>Only supports {@link KeyframedSequence} — silently no-ops for other trajectory
      * types. The OBB is rendered with a bright cyan outline at each tick.</p>
      *
      * <p>When {@code lockOriginOnFire} is {@code true}, the world transform is captured once
      * at call time and reused every tick — matching the simulation's frozen origin behaviour.
-     * Otherwise the player's live position and yaw are sampled each tick.</p>
+     * Otherwise, the player's live position and yaw are sampled each tick.</p>
      *
      * <p>The attack ray is drawn from the keyframe's stored ray origin (or the attacker's
      * bounding-box centre when none is stored) to the current volume centre. This matches
@@ -163,16 +162,16 @@ public final class VolumeEditorMode {
      * No cleanup is required by the caller.</p>
      *
      * @param player           the player who fired the wand attack
-     * @param trajectory       the attack's trajectory (must be {@link KeyframedTrajectory})
+     * @param sequence       the attack's trajectory (must be {@link KeyframedSequence})
      * @param startMs          wall-clock start time matching the {@link btm.sword.system.attack.simulation.SimulationAttack}
      * @param durationMs       total attack duration in milliseconds
      * @param lockOriginOnFire when {@code true}, origin is frozen at call time instead of
      *                         following the player each tick
      * @param orientWithPitch  whether the world transform should include pitch rotation
      */
-    public static void startPlaybackVisualization(Player player, VolumeTrajectory trajectory,
+    public static void startPlaybackVisualization(Player player, VolumeSequence sequence,
             long startMs, long durationMs, boolean lockOriginOnFire, boolean orientWithPitch) {
-        if (!(trajectory instanceof KeyframedTrajectory) && !(trajectory instanceof ControlPointTrajectory)) return;
+        if (!(sequence instanceof KeyframedSequence) && !(sequence instanceof ControlPointSequence)) return;
 
         ObbVolume buffer = new ObbVolume();
 
@@ -203,17 +202,17 @@ public final class VolumeEditorMode {
                 }
 
                 // Live position wireframe
-                trajectory.sample(t, worldTransform, buffer);
+                sequence.sample(t, worldTransform, buffer);
                 if (buffer.isSphere) {
-                    renderSphereWireframe(world, buffer.center, buffer.halfExtents.x, DUST_LIVE);
+                    ObbWireframe.renderSphere(world, buffer.center, buffer.halfExtents.x, DUST_LIVE);
                 } else {
-                    renderObbWireframe(world, buffer.center, buffer.halfExtents, buffer.rotation, DUST_LIVE);
+                    ObbWireframe.renderObb(world, buffer.center, buffer.halfExtents, buffer.rotation, DUST_LIVE);
                 }
 
                 // Attack ray: only drawn when the sampled keyframe is RAYCAST or ORIGIN_RAY
                 // (buffer.rayOrigin is non-null only for those types).
-                if (buffer.rayOrigin != null) {
-                    drawEdge(world, buffer.rayOrigin, new Vector3f(buffer.center), DUST_GHOST_PATH);
+                if (buffer.rayOrigin != null && Config.Debug.VISUALIZATION_SHOW_HITBOXES) {
+                    ObbWireframe.drawEdge(world, buffer.rayOrigin, new Vector3f(buffer.center), DUST_GHOST_PATH);
                 }
             },
             null,
@@ -408,7 +407,7 @@ public final class VolumeEditorMode {
             Particle.DustOptions dust = isSelected ? DUST_SELECTED : dustForType(kf.keyframeType());
 
             if (kf.shape() == VolumeShape.SPHERE) {
-                totalParticles += renderSphereWireframe(world, worldCenter, kf.halfExtents().x, dust);
+                totalParticles += ObbWireframe.renderSphere(world, worldCenter, kf.halfExtents().x, dust);
             } else {
                 // OBB
                 Quaternionf worldRot = new Quaternionf(worldBaseRot).mul(kf.rotation());
@@ -418,7 +417,7 @@ public final class VolumeEditorMode {
                         + " half=" + fmtVec(kf.halfExtents())
                         + (isSelected ? " [SELECTED]" : ""));
                 }
-                totalParticles += renderObbWireframe(world, worldCenter, kf.halfExtents(), worldRot, dust);
+                totalParticles += ObbWireframe.renderObb(world, worldCenter, kf.halfExtents(), worldRot, dust);
             }
 
             // RAYCAST: orange dot at ray origin + secant from origin to tip
@@ -452,7 +451,8 @@ public final class VolumeEditorMode {
         boolean holdingWand = KeyRegistry.hasKey(
             session.getPlayer().getInventory().getItemInMainHand(),
             KeyRegistry.TEST_VOLUME_ATTACK_KEY);
-        if (holdingWand && keyframes.size() >= 2 && tickCount % GREY_RENDER_PERIOD == 0) {
+        if (holdingWand && keyframes.size() >= 2 && tickCount % GREY_RENDER_PERIOD == 0
+                && Config.Debug.VISUALIZATION_SHOW_HITBOXES) {
             for (VolumeKeyframe kf : keyframes) {
                 if (kf.keyframeType() != KeyframeType.RAYCAST && kf.keyframeType() != KeyframeType.ORIGIN_RAY) {
                     continue;
@@ -462,7 +462,7 @@ public final class VolumeEditorMode {
                     new Vector3f(kf.localPosition()), new Vector3f());
                 Vector3f rayStart = worldTransform.transformPosition(
                     new Vector3f(kf.localRayOrigin()), new Vector3f());
-                drawEdge(world, rayStart, worldCenter, DUST_GHOST_PATH);
+                ObbWireframe.drawEdge(world, rayStart, worldCenter, DUST_GHOST_PATH);
             }
         }
     }
@@ -481,20 +481,22 @@ public final class VolumeEditorMode {
         if (points == null || points.isEmpty()) return;
 
         // Render each control point handle as a dark blue OBB
-        for (ControlPoint cp : points) {
-            Vector3f worldCenter = worldTransform.transformPosition(
-                new Vector3f(cp.position()), new Vector3f());
-            renderObbWireframe(world, worldCenter, cp.halfExtents(), worldBaseRot, DUST_CTRL_POINT);
+        if (Config.Debug.VISUALIZATION_SHOW_HITBOXES) {
+            for (ControlPoint cp : points) {
+                Vector3f worldCenter = worldTransform.transformPosition(
+                    new Vector3f(cp.position()), new Vector3f());
+                ObbWireframe.renderObb(world, worldCenter, cp.halfExtents(), worldBaseRot, DUST_CTRL_POINT);
+            }
         }
 
         // Ghost interpolated path at 10 t-values, rendered every 3rd tick
-        if (tickCount % GREY_RENDER_PERIOD == 0) {
-            ControlPointTrajectory traj = new ControlPointTrajectory(points, session.getEditControlMode());
+        if (Config.Debug.VISUALIZATION_SHOW_HITBOXES && tickCount % GREY_RENDER_PERIOD == 0) {
+            ControlPointSequence traj = new ControlPointSequence(points, session.getEditControlMode());
             ObbVolume buffer = new ObbVolume();
             for (int i = 0; i <= 9; i++) {
                 float t = i / 9.0f;
                 traj.sample(t, worldTransform, buffer);
-                renderObbWireframe(world, buffer.center, buffer.halfExtents, buffer.rotation, DUST_GHOST_PATH);
+                ObbWireframe.renderObb(world, buffer.center, buffer.halfExtents, buffer.rotation, DUST_GHOST_PATH);
             }
         }
     }
@@ -659,117 +661,6 @@ public final class VolumeEditorMode {
     private static int getLastInSelection(AttackDevSession session) {
         return session.getSelectedKeyframeIndices().stream()
             .mapToInt(Integer::intValue).max().orElse(-1);
-    }
-
-    // ── OBB wireframe renderer ────────────────────────────────────────────────
-
-    /**
-     * Draws the 12 edges of an oriented bounding box using spaced dust particles.
-     *
-     * @param world       the world to spawn particles in
-     * @param center      world-space OBB centre
-     * @param halfExtents OBB half-extents along its local axes
-     * @param rotation    OBB orientation as a unit quaternion
-     * @param dust        the {@link Particle.DustOptions} colour/size to use
-     * @return total number of particle spawn calls made
-     */
-    private static int renderObbWireframe(World world, Vector3f center, Vector3f halfExtents,
-            Quaternionf rotation, Particle.DustOptions dust) {
-        // Compute the three scaled local-axis vectors
-        Vector3f ax = rotation.transform(new Vector3f(halfExtents.x, 0, 0), new Vector3f());
-        Vector3f ay = rotation.transform(new Vector3f(0, halfExtents.y, 0), new Vector3f());
-        Vector3f az = rotation.transform(new Vector3f(0, 0, halfExtents.z), new Vector3f());
-
-        // 8 corners: bit pattern i → (±ax, ±ay, ±az)
-        Vector3f[] corners = new Vector3f[8];
-        for (int i = 0; i < 8; i++) {
-            float sx = (i & 1) != 0 ? 1f : -1f;
-            float sy = (i & 2) != 0 ? 1f : -1f;
-            float sz = (i & 4) != 0 ? 1f : -1f;
-            corners[i] = new Vector3f(center)
-                .add(ax.x * sx, ax.y * sx, ax.z * sx)
-                .add(ay.x * sy, ay.y * sy, ay.z * sy)
-                .add(az.x * sz, az.y * sz, az.z * sz);
-        }
-
-        // 12 edges: pairs of corners that differ in exactly one bit
-        int count = 0;
-        count += drawEdge(world, corners[0], corners[1], dust);
-        count += drawEdge(world, corners[2], corners[3], dust);
-        count += drawEdge(world, corners[4], corners[5], dust);
-        count += drawEdge(world, corners[6], corners[7], dust);
-        count += drawEdge(world, corners[0], corners[2], dust);
-        count += drawEdge(world, corners[1], corners[3], dust);
-        count += drawEdge(world, corners[4], corners[6], dust);
-        count += drawEdge(world, corners[5], corners[7], dust);
-        count += drawEdge(world, corners[0], corners[4], dust);
-        count += drawEdge(world, corners[1], corners[5], dust);
-        count += drawEdge(world, corners[2], corners[6], dust);
-        count += drawEdge(world, corners[3], corners[7], dust);
-        return count;
-    }
-
-    // ── Sphere wireframe renderer ─────────────────────────────────────────────
-
-    /**
-     * Draws three orthogonal great circles (XZ, XY, YZ planes) to represent a sphere.
-     *
-     * @param world  the world to spawn particles in
-     * @param center world-space sphere centre
-     * @param radius sphere radius
-     * @param dust   the {@link Particle.DustOptions} colour/size to use
-     * @return total number of particle spawn calls made
-     */
-    private static int renderSphereWireframe(World world, Vector3f center, float radius,
-            Particle.DustOptions dust) {
-        int count = 0;
-        for (int ring = 0; ring < 3; ring++) {
-            for (int i = 0; i < SPHERE_SEGMENTS; i++) {
-                float a0 = (float) (2 * Math.PI * i / SPHERE_SEGMENTS);
-                float a1 = (float) (2 * Math.PI * (i + 1) / SPHERE_SEGMENTS);
-                float cos0 = (float) Math.cos(a0);
-                float sin0 = (float) Math.sin(a0);
-                float cos1 = (float) Math.cos(a1);
-                float sin1 = (float) Math.sin(a1);
-
-                Vector3f p0;
-                Vector3f p1;
-                if (ring == 0) { // XZ plane
-                    p0 = new Vector3f(center.x + radius * cos0, center.y, center.z + radius * sin0);
-                    p1 = new Vector3f(center.x + radius * cos1, center.y, center.z + radius * sin1);
-                } else if (ring == 1) { // XY plane
-                    p0 = new Vector3f(center.x + radius * cos0, center.y + radius * sin0, center.z);
-                    p1 = new Vector3f(center.x + radius * cos1, center.y + radius * sin1, center.z);
-                } else { // YZ plane
-                    p0 = new Vector3f(center.x, center.y + radius * cos0, center.z + radius * sin0);
-                    p1 = new Vector3f(center.x, center.y + radius * cos1, center.z + radius * sin1);
-                }
-                count += drawEdge(world, p0, p1, dust);
-            }
-        }
-        return count;
-    }
-
-    // ── Shared utilities ──────────────────────────────────────────────────────
-
-    private static int drawEdge(World world, Vector3f a, Vector3f b, Particle.DustOptions dust) {
-        float dx = b.x - a.x;
-        float dy = b.y - a.y;
-        float dz = b.z - a.z;
-        float len = (float) Math.sqrt(dx * dx + dy * dy + dz * dz);
-        if (len < 1e-4f) return 0;
-
-        int steps = Math.max(1, (int) (len / EDGE_SPACING));
-        float sx = dx / steps;
-        float sy = dy / steps;
-        float sz = dz / steps;
-
-        for (int i = 0; i <= steps; i++) {
-            world.spawnParticle(Particle.DUST,
-                a.x + sx * i, a.y + sy * i, a.z + sz * i,
-                1, 0, 0, 0, 0, dust);
-        }
-        return steps + 1;
     }
 
     private static String fmtVec(Vector3f v) {

--- a/src/main/java/btm/sword/system/attack/dev/WandActions.java
+++ b/src/main/java/btm/sword/system/attack/dev/WandActions.java
@@ -1,6 +1,6 @@
 package btm.sword.system.attack.dev;
 
-import btm.sword.system.attack.def.AttackDef;
+import btm.sword.system.attack.def.AttackInstance;
 import btm.sword.system.entity.impl.Combatant;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.inventory.menu.dev.AttackBrowserMenu;
@@ -55,7 +55,7 @@ public final class WandActions {
      *
      * <ul>
      *   <li>If already in {@link DevMode#EDITING}: opens the editor directly.</li>
-     *   <li>If a wand-loaded {@link AttackDef} exists: calls
+     *   <li>If a wand-loaded {@link AttackInstance} exists: calls
      *       {@link AttackDevSession#startEditingFromDef} then opens the editor.</li>
      *   <li>Otherwise: opens {@link AttackBrowserMenu} so the player can pick an attack.</li>
      * </ul>
@@ -72,7 +72,7 @@ public final class WandActions {
             return;
         }
 
-        AttackDef loaded = session.getLoadedAttackDef();
+        AttackInstance loaded = session.getLoadedAttackInstance();
         if (loaded != null) {
             try {
                 session.startEditingFromDef(loaded);

--- a/src/main/java/btm/sword/system/attack/simulation/CapsuleVolume.java
+++ b/src/main/java/btm/sword/system/attack/simulation/CapsuleVolume.java
@@ -4,7 +4,7 @@ import org.joml.Vector3f;
 
 /**
  * A {@link Volume} representing a capsule (swept sphere along a line segment).
- * Used as the output buffer for {@link SweepTrajectory}.
+ * Used as the output buffer for {@link SweepSequence}.
  */
 public final class CapsuleVolume extends Volume {
 

--- a/src/main/java/btm/sword/system/attack/simulation/ControlMode.java
+++ b/src/main/java/btm/sword/system/attack/simulation/ControlMode.java
@@ -1,19 +1,19 @@
 package btm.sword.system.attack.simulation;
 
 /**
- * Specifies the interpolation mode for a {@link ControlPointTrajectory}.
+ * Specifies the interpolation mode for a {@link ControlPointSequence}.
  */
 public enum ControlMode {
 
     /**
      * Linear interpolation between two control points.
-     * {@link ControlPointTrajectory} requires exactly 2 {@link ControlPoint}s.
+     * {@link ControlPointSequence} requires exactly 2 {@link ControlPoint}s.
      */
     LINEAR,
 
     /**
      * Cubic Bézier interpolation across four control points.
-     * {@link ControlPointTrajectory} requires exactly 4 {@link ControlPoint}s:
+     * {@link ControlPointSequence} requires exactly 4 {@link ControlPoint}s:
      * start, two interior tangent handles, and end.
      */
     BEZIER

--- a/src/main/java/btm/sword/system/attack/simulation/ControlPoint.java
+++ b/src/main/java/btm/sword/system/attack/simulation/ControlPoint.java
@@ -3,11 +3,11 @@ package btm.sword.system.attack.simulation;
 import org.joml.Vector3f;
 
 /**
- * A single control point for a {@link ControlPointTrajectory}.
+ * A single control point for a {@link ControlPointSequence}.
  *
  * <p>Stores a local-space position and the half-extents of the OBB at this point.
  * Positions are in the attacker's local coordinate system; they are transformed to
- * world space at sample time by {@link ControlPointTrajectory#sample}.</p>
+ * world space at sample time by {@link ControlPointSequence#sample}.</p>
  *
  * @param position    local-space position of this control point
  * @param halfExtents half-extents of the OBB at this control point

--- a/src/main/java/btm/sword/system/attack/simulation/ControlPointSequence.java
+++ b/src/main/java/btm/sword/system/attack/simulation/ControlPointSequence.java
@@ -9,7 +9,7 @@ import org.joml.Vector3f;
 import btm.sword.utility.math.BezierUtil;
 
 /**
- * A {@link VolumeTrajectory} that interpolates an OBB between a small set of
+ * A {@link VolumeSequence} that interpolates an OBB between a small set of
  * {@link ControlPoint}s at runtime, storing only the defining curve points rather
  * than baked keyframe data.
  *
@@ -28,7 +28,7 @@ import btm.sword.utility.math.BezierUtil;
  * <p>Use with an {@link ObbVolume} buffer passed to
  * {@link btm.sword.system.attack.simulation.ActiveAttack}.</p>
  */
-public final class ControlPointTrajectory implements VolumeTrajectory {
+public final class ControlPointSequence implements VolumeSequence {
 
     private final List<ControlPoint> points;
     private final ControlMode mode;
@@ -41,7 +41,7 @@ public final class ControlPointTrajectory implements VolumeTrajectory {
      * @param mode   interpolation mode
      * @throws IllegalArgumentException if the point count does not match the mode requirement
      */
-    public ControlPointTrajectory(List<ControlPoint> points, ControlMode mode) {
+    public ControlPointSequence(List<ControlPoint> points, ControlMode mode) {
         int required = mode == ControlMode.LINEAR ? 2 : 4;
         if (points.size() != required) {
             throw new IllegalArgumentException(

--- a/src/main/java/btm/sword/system/attack/simulation/EffectsDispatcher.java
+++ b/src/main/java/btm/sword/system/attack/simulation/EffectsDispatcher.java
@@ -49,6 +49,9 @@ public final class EffectsDispatcher {
             Vector3f worldPos = worldTransform.transformPosition(new Vector3f(kf.localPosition()));
             Location loc = new Location(world, worldPos.x, worldPos.y, worldPos.z);
 
+            float nextT = (i + 1 < keyframes.size()) ? keyframes.get(i + 1).t() : 1.0f;
+            long windowMs = (long) ((nextT - kf.t()) * attack.getDurationMs());
+
             EffectsContext ctx = new EffectsContext(
                 new Matrix4f(worldTransform),
                 world,
@@ -61,6 +64,16 @@ public final class EffectsDispatcher {
                 if (effect.displays() != null) {
                     for (ParticleDisplay display : effect.displays()) {
                         display.render(ctx);
+                        int bkr = display.getBetweenKfRepeat();
+                        if (bkr > 1 && windowMs > 0) {
+                            for (int r = 1; r < bkr; r++) {
+                                long delayTicks = Math.max(1, (windowMs * r / bkr) / 50);
+                                Bukkit.getScheduler().runTaskLater(
+                                    Sword.getInstance(),
+                                    () -> display.renderOnce(ctx),
+                                    delayTicks);
+                            }
+                        }
                     }
                 }
                 if (effect.sound() != null) {

--- a/src/main/java/btm/sword/system/attack/simulation/EffectsDispatcher.java
+++ b/src/main/java/btm/sword/system/attack/simulation/EffectsDispatcher.java
@@ -30,18 +30,19 @@ public final class EffectsDispatcher {
      * Checks all keyframes in {@code trajectory} for effects that should fire in the
      * {@code (prevT, currentT]} window and schedules them on the main thread.
      *
-     * @param trajectory     the keyframed trajectory to scan
+     * @param seq     the keyframed trajectory to scan
      * @param attack         the running attack — source of attacker UUID and locked origin
      * @param prevT          normalized time at the previous tick (negative on the first tick)
      * @param currentT       normalized time at the current tick
      * @param worldTransform local-to-world transform at this tick
      * @param world          world in which to spawn effects
      */
-    public static void dispatch(KeyframedTrajectory trajectory, SimulationAttack attack,
-            float prevT, float currentT, Matrix4f worldTransform, World world) {
-        List<VolumeKeyframe> keyframes = trajectory.getKeyframes();
+    public static void dispatch(KeyframedSequence seq, SimulationAttack attack,
+                                float prevT, float currentT, Matrix4f worldTransform, World world) {
+        List<VolumeKeyframe> keyframes = seq.keyframes();
         for (int i = 0; i < keyframes.size(); i++) {
             VolumeKeyframe kf = keyframes.get(i);
+            // Run all keyframes in between the time steps
             if (kf.t() <= prevT || kf.t() > currentT) continue;
             KeyframeEffect effect = kf.effect();
             if (effect == null) continue;
@@ -56,7 +57,7 @@ public final class EffectsDispatcher {
                 new Matrix4f(worldTransform),
                 world,
                 attack.getAttackerUuid(),
-                trajectory,
+                seq,
                 attack.getLockedCenter(),
                 i);
 

--- a/src/main/java/btm/sword/system/attack/simulation/KeyframedSequence.java
+++ b/src/main/java/btm/sword/system/attack/simulation/KeyframedSequence.java
@@ -10,7 +10,7 @@ import org.joml.Vector3f;
 import btm.sword.utility.math.BezierUtil;
 
 /**
- * A {@link VolumeTrajectory} that animates an OBB volume through a sequence of
+ * A {@link VolumeSequence} that animates an OBB volume through a sequence of
  * {@link VolumeKeyframe}s using Catmull-Rom interpolation.
  *
  * <p>Position is interpolated with a Catmull-Rom spline across the keyframe sequence.
@@ -19,10 +19,11 @@ import btm.sword.utility.math.BezierUtil;
  * to world space via the supplied {@code worldTransform}.</p>
  *
  * <p>Use with an {@link ObbVolume} buffer passed to {@link ActiveAttack}.</p>
+ *
+ * @param keyframes -- GETTER --
+ *                  Returns the immutable keyframe list.
  */
-public final class KeyframedTrajectory implements VolumeTrajectory {
-
-    private final List<VolumeKeyframe> keyframes;
+public record KeyframedSequence(List<VolumeKeyframe> keyframes) implements VolumeSequence {
 
     /**
      * Creates a keyframed OBB trajectory.
@@ -30,20 +31,11 @@ public final class KeyframedTrajectory implements VolumeTrajectory {
      * @param keyframes ordered list of keyframes; must contain at least one entry
      * @throws IllegalArgumentException if the list is empty
      */
-    public KeyframedTrajectory(List<VolumeKeyframe> keyframes) {
+    public KeyframedSequence(List<VolumeKeyframe> keyframes) {
         if (keyframes.isEmpty()) {
             throw new IllegalArgumentException("KeyframedTrajectory requires at least one keyframe");
         }
         this.keyframes = List.copyOf(keyframes);
-    }
-
-    /**
-     * Returns the immutable keyframe list.
-     *
-     * @return keyframes in order
-     */
-    public List<VolumeKeyframe> getKeyframes() {
-        return keyframes;
     }
 
     /**
@@ -98,7 +90,7 @@ public final class KeyframedTrajectory implements VolumeTrajectory {
         Vector3f localPos = kb.linearToNext()
             ? new Vector3f(kb.localPosition()).lerp(kc.localPosition(), localT)
             : BezierUtil.catmullRom(
-                ka.localPosition(), kb.localPosition(), kc.localPosition(), kd.localPosition(), localT);
+            ka.localPosition(), kb.localPosition(), kc.localPosition(), kd.localPosition(), localT);
         Quaternionf localRot = new Quaternionf(kb.rotation()).slerp(kc.rotation(), localT);
         Vector3f he = new Vector3f(kb.halfExtents()).lerp(kc.halfExtents(), localT);
         if (sphere) {
@@ -114,9 +106,9 @@ public final class KeyframedTrajectory implements VolumeTrajectory {
             Vector3f interp = kb.linearToNext()
                 ? new Vector3f(originA).lerp(originB, localT)
                 : BezierUtil.catmullRom(
-                    ka.localRayOrigin() != null ? ka.localRayOrigin() : originA,
-                    originA, originB,
-                    kd.localRayOrigin() != null ? kd.localRayOrigin() : originB, localT);
+                ka.localRayOrigin() != null ? ka.localRayOrigin() : originA,
+                originA, originB,
+                kd.localRayOrigin() != null ? kd.localRayOrigin() : originB, localT);
             obbOut.rayOrigin = worldTransform.transformPosition(interp, new Vector3f());
         } else if (originB != null) {
             obbOut.rayOrigin = worldTransform.transformPosition(new Vector3f(originB), new Vector3f());

--- a/src/main/java/btm/sword/system/attack/simulation/ObbVolume.java
+++ b/src/main/java/btm/sword/system/attack/simulation/ObbVolume.java
@@ -6,7 +6,7 @@ import org.joml.Vector3f;
 
 /**
  * A {@link Volume} representing an oriented bounding box (OBB) or sphere.
- * Used as the output buffer for {@link KeyframedTrajectory}.
+ * Used as the output buffer for {@link KeyframedSequence}.
  *
  * <p>When {@link #isSphere} is {@code true}, the volume was produced from a
  * {@link VolumeShape#SPHERE} keyframe. In that case {@link #halfExtents} holds a uniform
@@ -28,14 +28,14 @@ public final class ObbVolume extends Volume {
     /**
      * When {@code true} this volume came from a {@link VolumeShape#SPHERE} keyframe.
      * Collision delegates to sphere-vs-AABB rather than the full OBB SAT test.
-     * Written each tick by {@link KeyframedTrajectory#sample}.
+     * Written each tick by {@link KeyframedSequence#sample}.
      */
     public boolean isSphere = false;
 
     /**
      * World-space ray start for {@link KeyframeType#ORIGIN_RAY} and
      * {@link KeyframeType#RAYCAST} keyframes, written each tick by
-     * {@link KeyframedTrajectory#sample}. {@code null} when the keyframe has no stored
+     * {@link KeyframedSequence#sample}. {@code null} when the keyframe has no stored
      * ray origin — the simulation falls back to the player BB center.
      */
     @Nullable

--- a/src/main/java/btm/sword/system/attack/simulation/ParticleEffect.java
+++ b/src/main/java/btm/sword/system/attack/simulation/ParticleEffect.java
@@ -63,7 +63,9 @@ public record ParticleEffect(
             double s = speed;
             wrapper.withSpeed(() -> s);
         }
-        if (dustOptions != null) {
+        if (dustOptions instanceof Particle.DustTransition dt) {
+            wrapper.withTransition(() -> 1.0, () -> dt);
+        } else if (dustOptions != null) {
             Particle.DustOptions opts = dustOptions;
             wrapper.withOptions(() -> opts);
         }
@@ -101,11 +103,12 @@ public record ParticleEffect(
      * @return a new {@link ParticleEffect} capturing the wrapper's current values
      */
     public static ParticleEffect fromWrapper(ParticleWrapper w) {
+        Particle.DustOptions dust = w.getDustTransition() != null ? w.getDustTransition() : w.getDustOptions();
         return new ParticleEffect(
             w.getParticle(),
             w.getCount(),
             new Vector3f((float) w.getXOffset(), (float) w.getYOffset(), (float) w.getZOffset()),
             w.getSpeed(),
-            w.getDustOptions());
+            dust);
     }
 }

--- a/src/main/java/btm/sword/system/attack/simulation/ParticleEffect.java
+++ b/src/main/java/btm/sword/system/attack/simulation/ParticleEffect.java
@@ -3,13 +3,16 @@ package btm.sword.system.attack.simulation;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.bukkit.Color;
 import org.bukkit.Particle;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Vector3f;
 
 import btm.sword.system.attack.visuals.OriginAnchor;
 import btm.sword.system.attack.visuals.PointDisplay;
+import btm.sword.utility.Debug;
 import btm.sword.utility.display.ParticleWrapper;
+import lombok.Getter;
 
 /**
  * Specification for a single particle burst emitted by a
@@ -36,13 +39,16 @@ import btm.sword.utility.display.ParticleWrapper;
  *                     omits the speed parameter from the Bukkit call
  * @param dustOptions  colour/size options for {@link Particle#DUST} or
  *                     {@link Particle#DUST_COLOR_TRANSITION}; {@code null} otherwise
+ * @param entityColor  colour for {@link Particle#ENTITY_EFFECT}; {@code null} otherwise
  */
 public record ParticleEffect(
+    @Getter
     Particle type,
     int count,
     Vector3f spreadOffset,
     double speed,
-    @Nullable Particle.DustOptions dustOptions
+    @Nullable Particle.DustOptions dustOptions,
+    @Nullable Color entityColor
 ) {
 
     /**
@@ -64,10 +70,25 @@ public record ParticleEffect(
             wrapper.withSpeed(() -> s);
         }
         if (dustOptions instanceof Particle.DustTransition dt) {
+            Debug.particleDisplay("toWrapper type=" + type + " dustOptions=DustTransition from="
+                + dt.getColor() + " to=" + dt.getToColor() + " -> withTransition");
             wrapper.withTransition(() -> 1.0, () -> dt);
+        } else if (dustOptions != null && type == Particle.DUST_COLOR_TRANSITION) {
+            // Mismatched data from old YAML: DUST_COLOR_TRANSITION with a plain DustOptions.
+            // Promote it to a DustTransition (same from/to colour) so it dispatches correctly.
+            Particle.DustTransition promoted =
+                new Particle.DustTransition(dustOptions.getColor(), dustOptions.getColor(), dustOptions.getSize());
+            wrapper.withTransition(() -> 1.0, () -> promoted);
         } else if (dustOptions != null) {
+            Debug.particleDisplay("toWrapper type=" + type + " dustOptions=DustOptions color="
+                + dustOptions.getColor() + " -> withOptions");
             Particle.DustOptions opts = dustOptions;
             wrapper.withOptions(() -> opts);
+        } else if (entityColor != null) {
+            Color ec = entityColor;
+            wrapper.withEntityColor(() -> ec);
+        } else {
+            Debug.particleDisplay("toWrapper type=" + type + " dustOptions=null -> no data");
         }
         return wrapper;
     }
@@ -109,6 +130,7 @@ public record ParticleEffect(
             w.getCount(),
             new Vector3f((float) w.getXOffset(), (float) w.getYOffset(), (float) w.getZOffset()),
             w.getSpeed(),
-            dust);
+            dust,
+            w.getEntityColor());
     }
 }

--- a/src/main/java/btm/sword/system/attack/simulation/ParticleEffect.java
+++ b/src/main/java/btm/sword/system/attack/simulation/ParticleEffect.java
@@ -92,4 +92,20 @@ public record ParticleEffect(
         Vector3f origin = originOffset != null ? new Vector3f(originOffset) : new Vector3f();
         return new PointDisplay(OriginAnchor.owning(), origin, new Vector3f(), 1, 0, list);
     }
+
+    /**
+     * Snapshots a {@link ParticleWrapper}'s current supplier values into a {@link ParticleEffect}.
+     * Config-driven suppliers are evaluated once at call time.
+     *
+     * @param w the wrapper to convert
+     * @return a new {@link ParticleEffect} capturing the wrapper's current values
+     */
+    public static ParticleEffect fromWrapper(ParticleWrapper w) {
+        return new ParticleEffect(
+            w.getParticle(),
+            w.getCount(),
+            new Vector3f((float) w.getXOffset(), (float) w.getYOffset(), (float) w.getZOffset()),
+            w.getSpeed(),
+            w.getDustOptions());
+    }
 }

--- a/src/main/java/btm/sword/system/attack/simulation/SimulationAttack.java
+++ b/src/main/java/btm/sword/system/attack/simulation/SimulationAttack.java
@@ -33,7 +33,7 @@ import lombok.Setter;
 public final class SimulationAttack {
 
     private final UUID attackerUuid;
-    private final VolumeTrajectory trajectory;
+    private final VolumeSequence trajectory;
     private final Volume volume;
     private final long startMs;
     private final long durationMs;
@@ -69,7 +69,7 @@ public final class SimulationAttack {
     /**
      * Pre-allocated capsule buffer for the origin-to-tip ray collision check.
      * Populated each simulation tick for {@link ObbVolume}-based trajectories.
-     * {@code null} for other trajectory types (e.g. {@link SweepTrajectory}).
+     * {@code null} for other trajectory types (e.g. {@link SweepSequence}).
      */
     @Nullable
     @Setter
@@ -109,7 +109,7 @@ public final class SimulationAttack {
      */
     public SimulationAttack(
             UUID attackerUuid,
-            VolumeTrajectory trajectory,
+            VolumeSequence trajectory,
             Volume volume,
             long startMs,
             long durationMs,

--- a/src/main/java/btm/sword/system/attack/simulation/SweepSequence.java
+++ b/src/main/java/btm/sword/system/attack/simulation/SweepSequence.java
@@ -8,7 +8,7 @@ import org.joml.Vector3f;
 import btm.sword.utility.math.BezierUtil;
 
 /**
- * A {@link VolumeTrajectory} that sweeps a capsule along a Catmull-Rom spline defined
+ * A {@link VolumeSequence} that sweeps a capsule along a Catmull-Rom spline defined
  * by a {@link SweepCurve}.
  *
  * <p>At each sample, the curve is evaluated at {@code t} and {@code t + dt} to produce
@@ -18,7 +18,7 @@ import btm.sword.utility.math.BezierUtil;
  *
  * <p>Use with a {@link CapsuleVolume} buffer passed to {@link ActiveAttack}.</p>
  */
-public final class SweepTrajectory implements VolumeTrajectory {
+public final class SweepSequence implements VolumeSequence {
 
     /** Step size used to derive the capsule's second endpoint from the curve. */
     private static final float DT = 0.01f;
@@ -30,7 +30,7 @@ public final class SweepTrajectory implements VolumeTrajectory {
      *
      * @param curve the Catmull-Rom path and radius profile for this attack
      */
-    public SweepTrajectory(SweepCurve curve) {
+    public SweepSequence(SweepCurve curve) {
         this.curve = curve;
     }
 

--- a/src/main/java/btm/sword/system/attack/simulation/Volume.java
+++ b/src/main/java/btm/sword/system/attack/simulation/Volume.java
@@ -3,7 +3,7 @@ package btm.sword.system.attack.simulation;
 import org.joml.Vector3f;
 
 /**
- * Mutable, reusable output buffer populated by {@link VolumeTrajectory#sample} each simulation tick.
+ * Mutable, reusable output buffer populated by {@link VolumeSequence#sample} each simulation tick.
  * <p>
  * Instances are allocated once per {@link ActiveAttack} and reused across ticks to avoid
  * per-frame heap allocation in the 200 Hz simulation loop.
@@ -15,10 +15,10 @@ import org.joml.Vector3f;
  */
 public abstract class Volume {
 
-    /** World-space AABB minimum corner — written by {@link VolumeTrajectory#sample}, read by {@link SpatialGrid}. */
+    /** World-space AABB minimum corner — written by {@link VolumeSequence#sample}, read by {@link SpatialGrid}. */
     public final Vector3f aabbMin = new Vector3f();
 
-    /** World-space AABB maximum corner — written by {@link VolumeTrajectory#sample}, read by {@link SpatialGrid}. */
+    /** World-space AABB maximum corner — written by {@link VolumeSequence#sample}, read by {@link SpatialGrid}. */
     public final Vector3f aabbMax = new Vector3f();
 
     /**

--- a/src/main/java/btm/sword/system/attack/simulation/VolumeSequence.java
+++ b/src/main/java/btm/sword/system/attack/simulation/VolumeSequence.java
@@ -11,11 +11,11 @@ import org.joml.Matrix4fc;
  * </p>
  *
  * <p>Declared as a {@code @FunctionalInterface} so simple one-off attack shapes can be
- * expressed as lambdas. Concrete implementations: {@link KeyframedTrajectory} (OBB volumes)
- * and {@link SweepTrajectory} (Catmull-Rom capsule sweeps).</p>
+ * expressed as lambdas. Concrete implementations: {@link KeyframedSequence} (OBB volumes)
+ * and {@link SweepSequence} (Catmull-Rom capsule sweeps).</p>
  */
 @FunctionalInterface
-public interface VolumeTrajectory {
+public interface VolumeSequence {
 
     /**
      * Populates {@code out} with the volume's world-space geometry at normalized time {@code t}.

--- a/src/main/java/btm/sword/system/attack/simulation/VolumeSimulation.java
+++ b/src/main/java/btm/sword/system/attack/simulation/VolumeSimulation.java
@@ -11,12 +11,17 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Color;
+import org.bukkit.Particle;
 import org.bukkit.World;
 import org.joml.Matrix4f;
+import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
 import btm.sword.Sword;
+import btm.sword.config.Config;
 import btm.sword.utility.Debug;
+import btm.sword.utility.display.ObbWireframe;
 
 /**
  * Off-thread 5ms fixed-rate collision loop for the new attack system.
@@ -146,6 +151,20 @@ public final class VolumeSimulation {
 
             attack.getTrajectory().sample(t, worldTransform, attack.getVolume());
 
+            if (Config.Debug.VISUALIZATION_SHOW_HITBOXES
+                    && attack.getVolume() instanceof ObbVolume obbSnapshot) {
+                World world = Bukkit.getWorld(attack.getWorldUuid());
+                if (world != null) {
+                    Vector3f sc = new Vector3f(obbSnapshot.center);
+                    Vector3f she = new Vector3f(obbSnapshot.halfExtents);
+                    Quaternionf sr = new Quaternionf(obbSnapshot.rotation);
+                    // TODO: Config
+                    Particle.DustOptions dust = new Particle.DustOptions(Color.fromRGB(255, 80, 80), 0.4f);
+                    Bukkit.getScheduler().runTask(Sword.getInstance(),
+                        () -> ObbWireframe.renderObb(world, sc, she, sr, dust));
+                }
+            }
+
             // For RAYCAST / ORIGIN_RAY keyframes only, build a thin ray capsule from the
             // recorded origin to the keyframe tip for line-of-attack detection. obbVol.rayOrigin
             // is non-null only for those keyframe types (written by KeyframedTrajectory.sample).
@@ -182,10 +201,11 @@ public final class VolumeSimulation {
                     attack.getVolume().aabbMax);
             }
 
-            if (attack.getTrajectory() instanceof KeyframedTrajectory kt) {
+            if (attack.getTrajectory() instanceof KeyframedSequence kfs) {
                 World world = Bukkit.getWorld(attack.getWorldUuid());
                 if (world != null) {
-                    EffectsDispatcher.dispatch(kt, attack, attack.getPrevT(), t, worldTransform, world);
+                    // Effects are performed from here **!**
+                    EffectsDispatcher.dispatch(kfs, attack, attack.getPrevT(), t, worldTransform, world);
                 }
             }
             if (expired) {

--- a/src/main/java/btm/sword/system/attack/simulation/VolumeSimulation.java
+++ b/src/main/java/btm/sword/system/attack/simulation/VolumeSimulation.java
@@ -116,10 +116,8 @@ public final class VolumeSimulation {
     private void processBroadPhase(long now, List<SimulationAttack> finished) {
         for (SimulationAttack attack : activeAttacks) {
             float t = (float) ((now - attack.getStartMs()) / (double) attack.getDurationMs());
-            if (t >= 1.0f) {
-                finished.add(attack);
-                continue;
-            }
+            boolean expired = t >= 1.0f;
+            if (expired) t = 1.0f;
 
             // Determine origin: locked (captured at fire time) or live snapshot
             Vector3f origin;
@@ -189,6 +187,10 @@ public final class VolumeSimulation {
                 if (world != null) {
                     EffectsDispatcher.dispatch(kt, attack, attack.getPrevT(), t, worldTransform, world);
                 }
+            }
+            if (expired) {
+                finished.add(attack);
+                continue;
             }
             attack.setPrevT(t);
 

--- a/src/main/java/btm/sword/system/attack/visuals/CircleDisplay.java
+++ b/src/main/java/btm/sword/system/attack/visuals/CircleDisplay.java
@@ -106,9 +106,11 @@ public final class CircleDisplay extends ParticleDisplay {
 
     @Override
     public CircleDisplay copy() {
-        return new CircleDisplay(anchor,
+        CircleDisplay c = new CircleDisplay(anchor,
             new Vector3f(originOffset), new Vector3f(randomOffsetRange),
             repeatCount, repeatPeriodTicks, copyParticles(),
             outerRadius, innerRadius, spacingRadial, spacingArc, normal);
+        c.betweenKfRepeat = betweenKfRepeat;
+        return c;
     }
 }

--- a/src/main/java/btm/sword/system/attack/visuals/EffectsContext.java
+++ b/src/main/java/btm/sword/system/attack/visuals/EffectsContext.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4f;
 import org.joml.Vector3f;
 
-import btm.sword.system.attack.simulation.KeyframedTrajectory;
+import btm.sword.system.attack.simulation.KeyframedSequence;
 
 /**
  * Context passed to {@link ParticleDisplay#render} during effect dispatch.
@@ -27,7 +27,7 @@ public record EffectsContext(
     Matrix4f worldTransform,
     World world,
     UUID attackerId,
-    KeyframedTrajectory trajectory,
+    KeyframedSequence trajectory,
     @Nullable Vector3f lockedOrigin,
     int owningKeyframeIndex
 ) {}

--- a/src/main/java/btm/sword/system/attack/visuals/LineDisplay.java
+++ b/src/main/java/btm/sword/system/attack/visuals/LineDisplay.java
@@ -82,9 +82,11 @@ public final class LineDisplay extends ParticleDisplay {
 
     @Override
     public LineDisplay copy() {
-        return new LineDisplay(anchor,
+        LineDisplay c = new LineDisplay(anchor,
             new Vector3f(originOffset), new Vector3f(randomOffsetRange),
             repeatCount, repeatPeriodTicks, copyParticles(),
             endAnchor, new Vector3f(endOffset), new Vector3f(endRandomRange), spacing);
+        c.betweenKfRepeat = betweenKfRepeat;
+        return c;
     }
 }

--- a/src/main/java/btm/sword/system/attack/visuals/OriginAnchor.java
+++ b/src/main/java/btm/sword/system/attack/visuals/OriginAnchor.java
@@ -39,6 +39,12 @@ public sealed interface OriginAnchor {
         public static final RaycastOrigin INSTANCE = new RaycastOrigin();
     }
 
+    /**
+     * Resolves to the keyframe {@code offset} positions after the owning keyframe.
+     * Clamped to the last keyframe when the computed index exceeds the trajectory length.
+     */
+    record NextKeyframe(int offset) implements OriginAnchor {}
+
     /** Points on the attacker's body that an anchor can reference. */
     enum BodyPoint { EYE, CHEST, FEET }
 
@@ -56,4 +62,7 @@ public sealed interface OriginAnchor {
 
     /** Convenience factory: raycast-origin anchor (start of ray on RAYCAST keyframes). */
     static OriginAnchor raycastOrigin() { return RaycastOrigin.INSTANCE; }
+
+    /** Convenience factory: nth-next-keyframe anchor. */
+    static OriginAnchor nextKeyframe(int offset) { return new NextKeyframe(Math.max(1, offset)); }
 }

--- a/src/main/java/btm/sword/system/attack/visuals/OriginAnchor.java
+++ b/src/main/java/btm/sword/system/attack/visuals/OriginAnchor.java
@@ -6,6 +6,9 @@ package btm.sword.system.attack.visuals;
  * point on the attacker's body, or the origin captured when the attack was fired.
  *
  * <p>Resolved by {@link OriginResolver} against an {@link EffectsContext} at dispatch time.</p>
+ *
+ * <p>The {@link RaycastOrigin} variant is only meaningful for {@link btm.sword.system.attack.simulation.KeyframeType#RAYCAST}
+ * keyframes — it resolves to the local-space start of the cast ray rather than the tip.</p>
  */
 public sealed interface OriginAnchor {
 
@@ -27,6 +30,15 @@ public sealed interface OriginAnchor {
         public static final FireLockedOrigin INSTANCE = new FireLockedOrigin();
     }
 
+    /**
+     * Resolves to the ray-cast origin ({@code localRayOrigin}) of the owning RAYCAST keyframe.
+     * Falls back to the owning keyframe tip position for non-RAYCAST keyframes.
+     */
+    record RaycastOrigin() implements OriginAnchor {
+        /** Shared singleton — all RaycastOrigin anchors are equivalent. */
+        public static final RaycastOrigin INSTANCE = new RaycastOrigin();
+    }
+
     /** Points on the attacker's body that an anchor can reference. */
     enum BodyPoint { EYE, CHEST, FEET }
 
@@ -41,4 +53,7 @@ public sealed interface OriginAnchor {
 
     /** Convenience factory: fire-locked origin anchor. */
     static OriginAnchor fireLocked() { return FireLockedOrigin.INSTANCE; }
+
+    /** Convenience factory: raycast-origin anchor (start of ray on RAYCAST keyframes). */
+    static OriginAnchor raycastOrigin() { return RaycastOrigin.INSTANCE; }
 }

--- a/src/main/java/btm/sword/system/attack/visuals/OriginResolver.java
+++ b/src/main/java/btm/sword/system/attack/visuals/OriginResolver.java
@@ -39,11 +39,12 @@ public final class OriginResolver {
                 ? toLoc(ctx, ctx.lockedOrigin())
                 : resolveKeyframe(ctx.owningKeyframeIndex(), ctx);
             case OriginAnchor.RaycastOrigin ignored -> resolveRaycastOrigin(ctx);
+            case OriginAnchor.NextKeyframe nk -> resolveKeyframe(ctx.owningKeyframeIndex() + nk.offset(), ctx);
         };
     }
 
     private static Location resolveKeyframe(int index, EffectsContext ctx) {
-        List<VolumeKeyframe> kfs = ctx.trajectory().getKeyframes();
+        List<VolumeKeyframe> kfs = ctx.trajectory().keyframes();
         if (kfs.isEmpty()) return new Location(ctx.world(), 0, 0, 0);
         int clamped = Math.max(0, Math.min(index, kfs.size() - 1));
         Vector3f local = new Vector3f(kfs.get(clamped).localPosition());
@@ -65,7 +66,7 @@ public final class OriginResolver {
     }
 
     private static Location resolveRaycastOrigin(EffectsContext ctx) {
-        List<VolumeKeyframe> kfs = ctx.trajectory().getKeyframes();
+        List<VolumeKeyframe> kfs = ctx.trajectory().keyframes();
         if (kfs.isEmpty()) return new Location(ctx.world(), 0, 0, 0);
         int clamped = Math.max(0, Math.min(ctx.owningKeyframeIndex(), kfs.size() - 1));
         VolumeKeyframe kf = kfs.get(clamped);

--- a/src/main/java/btm/sword/system/attack/visuals/OriginResolver.java
+++ b/src/main/java/btm/sword/system/attack/visuals/OriginResolver.java
@@ -38,6 +38,7 @@ public final class OriginResolver {
             case OriginAnchor.FireLockedOrigin ignored -> ctx.lockedOrigin() != null
                 ? toLoc(ctx, ctx.lockedOrigin())
                 : resolveKeyframe(ctx.owningKeyframeIndex(), ctx);
+            case OriginAnchor.RaycastOrigin ignored -> resolveRaycastOrigin(ctx);
         };
     }
 
@@ -61,6 +62,16 @@ public final class OriginResolver {
             case CHEST -> swordEntity.getChestLocation();
             case FEET -> living.getLocation();
         };
+    }
+
+    private static Location resolveRaycastOrigin(EffectsContext ctx) {
+        List<VolumeKeyframe> kfs = ctx.trajectory().getKeyframes();
+        if (kfs.isEmpty()) return new Location(ctx.world(), 0, 0, 0);
+        int clamped = Math.max(0, Math.min(ctx.owningKeyframeIndex(), kfs.size() - 1));
+        VolumeKeyframe kf = kfs.get(clamped);
+        Vector3f local = kf.localRayOrigin() != null ? new Vector3f(kf.localRayOrigin()) : new Vector3f(kf.localPosition());
+        Vector3f world = ctx.worldTransform().transformPosition(local);
+        return toLoc(ctx, world);
     }
 
     private static Location toLoc(EffectsContext ctx, Vector3f v) {

--- a/src/main/java/btm/sword/system/attack/visuals/OriginResolver.java
+++ b/src/main/java/btm/sword/system/attack/visuals/OriginResolver.java
@@ -69,7 +69,9 @@ public final class OriginResolver {
         if (kfs.isEmpty()) return new Location(ctx.world(), 0, 0, 0);
         int clamped = Math.max(0, Math.min(ctx.owningKeyframeIndex(), kfs.size() - 1));
         VolumeKeyframe kf = kfs.get(clamped);
-        Vector3f local = kf.localRayOrigin() != null ? new Vector3f(kf.localRayOrigin()) : new Vector3f(kf.localPosition());
+        // Null fallback: use body-center (0,0,0 in local space) rather than the tip so the
+        // line has a non-zero length if localRayOrigin was never recorded.
+        Vector3f local = kf.localRayOrigin() != null ? new Vector3f(kf.localRayOrigin()) : new Vector3f();
         Vector3f world = ctx.worldTransform().transformPosition(local);
         return toLoc(ctx, world);
     }

--- a/src/main/java/btm/sword/system/attack/visuals/ParticleDisplay.java
+++ b/src/main/java/btm/sword/system/attack/visuals/ParticleDisplay.java
@@ -126,7 +126,7 @@ public abstract sealed class ParticleDisplay
         List<ParticleEffect> out = new ArrayList<>(particles.size());
         for (ParticleEffect e : particles) {
             out.add(new ParticleEffect(e.type(), e.count(),
-                new Vector3f(e.spreadOffset()), e.speed(), e.dustOptions()));
+                new Vector3f(e.spreadOffset()), e.speed(), e.dustOptions(), e.entityColor()));
         }
         return out;
     }

--- a/src/main/java/btm/sword/system/attack/visuals/ParticleDisplay.java
+++ b/src/main/java/btm/sword/system/attack/visuals/ParticleDisplay.java
@@ -41,6 +41,13 @@ public abstract sealed class ParticleDisplay
     protected int repeatCount;
     /** Ticks between repeat emissions. Ignored when {@link #repeatCount} &lt;= 1. */
     protected int repeatPeriodTicks;
+    /**
+     * When &gt; 1, fire this display this many total times evenly distributed across the window
+     * from this keyframe's {@code t} to the next keyframe's {@code t} (scheduled by
+     * {@link btm.sword.system.attack.simulation.EffectsDispatcher}).
+     * {@code 0} means inactive — normal {@link #repeatCount}/{@link #repeatPeriodTicks} logic applies.
+     */
+    protected int betweenKfRepeat = 0;
     /** Particles to display at each point this shape emits to. Never {@code null}. */
     protected List<ParticleEffect> particles;
 
@@ -77,6 +84,11 @@ public abstract sealed class ParticleDisplay
             int delayMs = i * repeatPeriodTicks * 50;
             SwordScheduler.runBukkitTaskLater(() -> emitOnce(ctx), delayMs, TimeUnit.MILLISECONDS);
         }
+    }
+
+    /** Fires a single emission without scheduling any repeats — used by between-kf repeat scheduling. */
+    public final void renderOnce(EffectsContext ctx) {
+        emitOnce(ctx);
     }
 
     private void emitOnce(EffectsContext ctx) {

--- a/src/main/java/btm/sword/system/attack/visuals/PointDisplay.java
+++ b/src/main/java/btm/sword/system/attack/visuals/PointDisplay.java
@@ -49,8 +49,10 @@ public final class PointDisplay extends ParticleDisplay {
 
     @Override
     public PointDisplay copy() {
-        return new PointDisplay(anchor,
+        PointDisplay c = new PointDisplay(anchor,
             new Vector3f(originOffset), new Vector3f(randomOffsetRange),
             repeatCount, repeatPeriodTicks, copyParticles());
+        c.betweenKfRepeat = betweenKfRepeat;
+        return c;
     }
 }

--- a/src/main/java/btm/sword/system/attack/visuals/SphereDisplay.java
+++ b/src/main/java/btm/sword/system/attack/visuals/SphereDisplay.java
@@ -68,9 +68,11 @@ public final class SphereDisplay extends ParticleDisplay {
 
     @Override
     public SphereDisplay copy() {
-        return new SphereDisplay(anchor,
+        SphereDisplay c = new SphereDisplay(anchor,
             new Vector3f(originOffset), new Vector3f(randomOffsetRange),
             repeatCount, repeatPeriodTicks, copyParticles(),
             radius, density, filled);
+        c.betweenKfRepeat = betweenKfRepeat;
+        return c;
     }
 }

--- a/src/main/java/btm/sword/system/entity/impl/Combatant.java
+++ b/src/main/java/btm/sword/system/entity/impl/Combatant.java
@@ -5,11 +5,13 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
+import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -81,6 +83,7 @@ public abstract class Combatant extends SwordEntity {
     private UmbralBlade umbralBlade;
     private boolean startingBlade;
     private boolean bladeEnabled = true;
+    private boolean umbralBladeActive = true;
 
     private ThrownItem thrownItem;
     private ItemStack offHandItemStackDuringThrow;
@@ -134,11 +137,8 @@ public abstract class Combatant extends SwordEntity {
         super.onDeath();
 
         if (umbralBlade == null) return;
-        if (umbralBlade.getDisplay().isValid()) {
+        if (umbralBlade.getDisplay() != null && umbralBlade.getDisplay().isValid()) {
             Prefab.Particles.UMBRAL_BLADE_POOF.display(umbralBlade.getDisplay().getLocation());
-        }
-        if (umbralBlade.getDisplay() == null || !umbralBlade.getDisplay().isValid()) {
-            message("Display is null.");
         }
         umbralBlade.dispose();
         umbralBlade = null;
@@ -147,11 +147,12 @@ public abstract class Combatant extends SwordEntity {
     @Override
     public void onZeroHealth() {
         super.onZeroHealth();
-        if (umbralBlade != null && umbralBlade.getDisplay().isValid()) {
+        if (umbralBlade == null) return;
+        if (umbralBlade.getDisplay() != null && umbralBlade.getDisplay().isValid()) {
             Prefab.Particles.UMBRAL_BLADE_POOF.display(umbralBlade.getDisplay().getLocation());
-            umbralBlade.dispose();
-            umbralBlade = null;
         }
+        umbralBlade.dispose();
+        umbralBlade = null;
     }
 
     @Override
@@ -170,9 +171,34 @@ public abstract class Combatant extends SwordEntity {
      * </p>
      */
     public void handleUmbralBladeTick() {
-        if (!self().isValid() || !bladeEnabled) return;
-
-        if (umbralBlade == null && !isStartingBlade()) {
+        if (!self().isValid() || !bladeEnabled) {
+            if (umbralBlade != null) {
+                Debug.umbralStates(self().getName() + " lifecycle: invalid/disabled — ending blade");
+                endUmbralBlade();
+            }
+            return;
+        }
+        if (self() instanceof Player p && p.getGameMode() == GameMode.SPECTATOR) {
+            if (umbralBlade != null) {
+                Debug.umbralStates(self().getName() + " lifecycle: spectator — ending blade");
+                endUmbralBlade();
+            }
+            return;
+        }
+        if (!umbralBladeActive) {
+            if (umbralBlade != null) {
+                Debug.umbralStates(self().getName() + " lifecycle: suppressed — ending blade");
+                endUmbralBlade();
+            }
+            return;
+        }
+        if (umbralBlade != null && umbralBlade.getBladeStateMachine().isDeactivated()) {
+            Debug.umbralStates(self().getName() + " lifecycle: FSM deactivated — ending blade for recreation");
+            endUmbralBlade();
+            return;
+        }
+        if (umbralBlade == null && !startingBlade) {
+            Debug.umbralStates(self().getName() + " lifecycle: spawning blade");
             setupUmbralBlade();
             return;
         }

--- a/src/main/java/btm/sword/system/entity/impl/Combatant.java
+++ b/src/main/java/btm/sword/system/entity/impl/Combatant.java
@@ -196,6 +196,9 @@ public abstract class Combatant extends SwordEntity {
             }
             message("Starting Umbral Blade");
             umbralBlade = new UmbralBlade(this, ItemStack.of(Material.STONE_SWORD));
+
+            umbralBlade.setup(5);
+
             setStartingBlade(false);
             }, 200, TimeUnit.MILLISECONDS
         );
@@ -207,6 +210,7 @@ public abstract class Combatant extends SwordEntity {
      * spawning a new one. Call {@link #activateUmbralBlade()} to re-enable spawning.
      */
     public void deactivateUmbralBlade() {
+        Debug.throwing("Deactivating Blade");
         bladeEnabled = false;
         startingBlade = false;
         if (umbralBlade != null) {
@@ -221,6 +225,7 @@ public abstract class Combatant extends SwordEntity {
      * the normal deferred-spawn path.
      */
     public void activateUmbralBlade() {
+        Debug.throwing("Activating Blade");
         bladeEnabled = true;
     }
 

--- a/src/main/java/btm/sword/system/entity/impl/Combatant.java
+++ b/src/main/java/btm/sword/system/entity/impl/Combatant.java
@@ -22,7 +22,7 @@ import btm.sword.system.action.ActionCaster;
 import btm.sword.system.action.movement.MovementAction;
 import btm.sword.system.action.throwing.types.ThrownItem;
 import btm.sword.system.attack.ActiveAttack;
-import btm.sword.system.attack.def.AttackDef;
+import btm.sword.system.attack.def.AttackInstance;
 import btm.sword.system.attack.simulation.EntitySnapshotMap;
 import btm.sword.system.attack.simulation.SimulationAttack;
 import btm.sword.system.attack.simulation.VolumeSimulation;
@@ -67,7 +67,6 @@ public abstract class Combatant extends SwordEntity {
      *  if an
      * -driven attack is currently running.
      *
-     * @return {@code true} while an attack is active
      */
     private boolean isAttacking = false;
 
@@ -617,38 +616,38 @@ public abstract class Combatant extends SwordEntity {
     }
 
     /**
-     * Launches an {@link AttackDef}-driven attack for this combatant.
+     * Launches an {@link AttackInstance}-driven attack for this combatant.
      *
      * <p>Builds a shared {@code hitThisAttack} set, records the game-layer
      * {@link ActiveAttack}, and registers a {@link SimulationAttack} with
      * {@link VolumeSimulation} to begin the 200 Hz collision loop.
      * {@link #onAttackEnd()} is posted back to the main thread when the attack expires.</p>
      *
-     * @param def the attack definition to execute
+     * @param a the attack definition to execute
      */
-    public void launchAttackDef(AttackDef def) {
+    public void launchAttack(AttackInstance a) {
         long startMs = System.currentTimeMillis();
         Set<UUID> hitThisAttack = ConcurrentHashMap.newKeySet();
 
-        currentAttack = new ActiveAttack(def, uuid, startMs, hitThisAttack);
+        currentAttack = new ActiveAttack(a, uuid, startMs, hitThisAttack);
         isAttacking = true;
 
         // Damp XZ momentum and apply slow-falling for the attack window
         Vector vel = self().getVelocity();
         self().setVelocity(new Vector(vel.getX() * 0.3, vel.getY(), vel.getZ() * 0.3));
-        int durationTicks = def.getDurationMs() / 50;
+        int durationTicks = a.getDurationMs() / 50;
         self().addPotionEffect(new PotionEffect(PotionEffectType.SLOW_FALLING, durationTicks, 0, true, false));
 
-        Debug.attackVolume("LAUNCH id=" + def.getId()
+        Debug.attackVolume("LAUNCH id=" + a.getId()
             + " owner=" + self().getName()
-            + " duration=" + def.getDurationMs() + "ms"
-            + " type=" + def.getType());
+            + " duration=" + a.getDurationMs() + "ms"
+            + " type=" + a.getType());
 
         // Capture locked origin if the attack requires it
         Vector3f lockedCenter = null;
         Float lockedYaw = null;
         Float lockedPitch = null;
-        if (def.isLockOriginOnFire()) {
+        if (a.isLockOriginOnFire()) {
             EntitySnapshotMap.EntityBoundingBoxSnapshot snap =
                 EntitySnapshotMap.INSTANCE.get(uuid);
             if (snap != null) {
@@ -660,17 +659,17 @@ public abstract class Combatant extends SwordEntity {
 
         SimulationAttack simAttack = new SimulationAttack(
             uuid,
-            def.getTrajectory(),
-            def.createVolume(),
+            a.getTrajectory(),
+            a.createVolume(),
             startMs,
-            def.getDurationMs(),
-            def.getHitValue(),
-            def.getKnockbackFunction(),
+            a.getDurationMs(),
+            a.getHitValue(),
+            a.getKnockbackFunction(),
             self().getWorld().getUID(),
             hitThisAttack,
             this::onAttackEnd,
-            def.isOrientWithPitch(),
-            def.isLockOriginOnFire(),
+            a.isOrientWithPitch(),
+            a.isLockOriginOnFire(),
             lockedCenter,
             lockedYaw,
             lockedPitch

--- a/src/main/java/btm/sword/system/entity/impl/DevSwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/DevSwordPlayer.java
@@ -18,6 +18,7 @@ import org.bukkit.plugin.Plugin;
 import btm.sword.system.attack.dev.AnimationModeInputHandler;
 import btm.sword.system.attack.dev.AttackDevSession;
 import btm.sword.system.attack.dev.SaveConfirmDialog;
+import btm.sword.system.entity.umbral.input.BladeRequest;
 import btm.sword.system.input.InputType;
 import btm.sword.system.inventory.menu.dev.SweepGeneratorMenu;
 import btm.sword.system.item.KeyRegistry;
@@ -149,31 +150,31 @@ public final class DevSwordPlayer extends SwordPlayer {
      *   <li>All other slots fall through to the normal handler.</li>
      * </ul>
      *
-     * @param e the inventory click event to handle
+     * @param event the inventory click event to handle
      * @return {@code true} if the event was handled and should be cancelled
      */
     @Override
-    public boolean handleInventoryInput(InventoryClickEvent e) {
+    public boolean handleInventoryInput(InventoryClickEvent event) {
         if (!inAnimationMode) {
             // Volume-attack wand click → open Sweep Generator
-            if (e.getClickedInventory() == player().getInventory()) {
-                ItemStack clicked = e.getCurrentItem();
+            if (event.getClickedInventory() == player().getInventory()) {
+                ItemStack clicked = event.getCurrentItem();
                 if (clicked != null && KeyRegistry.hasKey(clicked, KeyRegistry.TEST_VOLUME_ATTACK_KEY)) {
                     new SweepGeneratorMenu(this).open();
                     return true;
                 }
             }
-            return super.handleInventoryInput(e);
+            return super.handleInventoryInput(event);
         }
 
-        if (e.getClickedInventory() != player().getInventory()) {
-            return super.handleInventoryInput(e);
+        if (event.getClickedInventory() != player().getInventory()) {
+            return super.handleInventoryInput(event);
         }
 
-        int slot = e.getSlot();
+        int slot = event.getSlot();
 
         if (slot == 35) {
-            if (e.getClick() == ClickType.LEFT) {
+            if (event.getClick() == ClickType.LEFT) {
                 AttackDevSession session = AttackDevSession.get(player().getUniqueId());
                 SaveConfirmDialog.open(this, session);
             }
@@ -184,6 +185,6 @@ public final class DevSwordPlayer extends SwordPlayer {
             return true;
         }
 
-        return super.handleInventoryInput(e);
+        return super.handleInventoryInput(event);
     }
 }

--- a/src/main/java/btm/sword/system/entity/impl/DevSwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/DevSwordPlayer.java
@@ -18,7 +18,6 @@ import org.bukkit.plugin.Plugin;
 import btm.sword.system.attack.dev.AnimationModeInputHandler;
 import btm.sword.system.attack.dev.AttackDevSession;
 import btm.sword.system.attack.dev.SaveConfirmDialog;
-import btm.sword.system.entity.umbral.input.BladeRequest;
 import btm.sword.system.input.InputType;
 import btm.sword.system.inventory.menu.dev.SweepGeneratorMenu;
 import btm.sword.system.item.KeyRegistry;
@@ -38,8 +37,8 @@ import lombok.Setter;
  * <h2>AnimationMode behaviour</h2>
  * <ul>
  *   <li>The UmbralBlade FSM ticks identically to a normal {@link SwordPlayer} at all times.
- *       When AnimationMode is entered, {@link BladeRequest#DEACTIVATE} hides the blade via
- *       {@code InactiveState}; {@link BladeRequest#ACTIVATE_TO_PREVIOUS} restores it on exit.</li>
+ *       When AnimationMode is entered, {@link Combatant#setUmbralBladeActive(boolean)} suppresses
+ *       the blade; setting it back to {@code true} on exit causes the lifecycle owner to respawn it.</li>
  *   <li>{@link #act(InputType)} routes to {@link AnimationModeInputHandler} when
  *       {@link #isInAnimationMode()} is {@code true}; otherwise falls through to the
  *       normal input execution tree so non-animation dev interactions still work.</li>
@@ -136,7 +135,41 @@ public final class DevSwordPlayer extends SwordPlayer {
             AnimationModeInputHandler.handle(this, input);
             return;
         }
+        if (handleUmbralBladeTesterInput(input)) {
+            return;
+        }
         super.act(input);
+    }
+
+    /**
+     * Routes lifecycle commands while the player holds the UmbralBlade tester item
+     * (BREEZE_ROD tagged with {@link KeyRegistry#UMBRAL_BLADE_TESTER_KEY}).
+     *
+     * <ul>
+     *   <li>{@link InputType#LEFT}: deactivates the blade — destroys the instance and
+     *       blocks recreation until activate is called.</li>
+     *   <li>{@link InputType#DROP}: activates the blade — the lifecycle owner respawns
+     *       it on the next tick.</li>
+     * </ul>
+     *
+     * @param input the input received from the player
+     * @return {@code true} if the input was handled by the tester and should not fall
+     *         through to the normal input tree
+     */
+    private boolean handleUmbralBladeTesterInput(InputType input) {
+        ItemStack mainHand = player().getInventory().getItemInMainHand();
+        if (mainHand == null || mainHand.isEmpty()
+            || !KeyRegistry.hasKey(mainHand, KeyRegistry.UMBRAL_BLADE_TESTER_KEY)) {
+            return false;
+        }
+        switch (input) {
+            case LEFT -> deactivateUmbralBlade();
+            case DROP -> activateUmbralBlade();
+            default -> {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
+++ b/src/main/java/btm/sword/system/entity/impl/SwordPlayer.java
@@ -411,6 +411,7 @@ public class SwordPlayer extends Combatant {
         }
         if (getUmbralBlade() != null) {
             getUmbralBlade().dispose();
+            setUmbralBlade(null);
         }
         endStatusDisplay();
         endIndicatorDisplay();

--- a/src/main/java/btm/sword/system/entity/umbral/UmbralBlade.java
+++ b/src/main/java/btm/sword/system/entity/umbral/UmbralBlade.java
@@ -79,6 +79,7 @@ public class UmbralBlade extends ThrownItem {
         FORWARD_RUSH // otherwise?
     }
 
+    @Getter
     private final UmbralStateMachine bladeStateMachine;
     @Getter
     private Function<Combatant, Attack>[] basicAttacks;
@@ -652,9 +653,10 @@ public class UmbralBlade extends ThrownItem {
     public void dispose() {
         bladeStateMachine.getState().onExit(this);
         bladeStateMachine.setDeactivated(true);
-        if (display != null) {
+        if (display != null && display.isValid()) {
             display.remove();
         }
+        display = null;
     }
 
     /** Clears all mid-flight flags so the blade can be launched again cleanly. */

--- a/src/main/java/btm/sword/system/entity/umbral/UmbralBlade.java
+++ b/src/main/java/btm/sword/system/entity/umbral/UmbralBlade.java
@@ -209,7 +209,9 @@ public class UmbralBlade extends ThrownItem {
 
             thrower.self().addPassenger(display);
             display.setBillboard(Display.Billboard.FIXED);
-        }, 5);
+        });
+
+        // TODO: Removed the setup call; must set up elsewhere now.
 
         this.weapon = weapon;
 
@@ -235,6 +237,15 @@ public class UmbralBlade extends ThrownItem {
     /** Returns {@code true} and consumes the request if it is present in the input buffer. */
     public boolean isRequested(BladeRequest request) {
         return inputBuffer.consumeIfPresent(request);
+    }
+
+    public boolean isRequested(BladeRequest... requests) {
+        for (BladeRequest  request : requests) {
+            if (inputBuffer.consumeIfPresent(request)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /** Returns {@code true} and consumes the request if present and the blade is not in {@link InactiveState}. */
@@ -562,7 +573,9 @@ public class UmbralBlade extends ThrownItem {
             TimeArbiter.runFixedIterationTaskTimer(
                 null,
                 () -> request(BladeRequest.WIELD),
-                Config.UmbralBlade.WIELD_ON_GRAB_DELAY, Config.UmbralBlade.WIELD_ON_GRAB_PERIOD, Config.UmbralBlade.WIELD_ON_GRAB_ITERATIONS,
+                Config.UmbralBlade.WIELD_ON_GRAB_DELAY,
+                Config.UmbralBlade.WIELD_ON_GRAB_PERIOD,
+                Config.UmbralBlade.WIELD_ON_GRAB_ITERATIONS,
                 UmbralBlade.class,
                 "onGrab",
                 null,
@@ -637,8 +650,11 @@ public class UmbralBlade extends ThrownItem {
 
     @Override
     public void dispose() {
-        super.dispose();
+        bladeStateMachine.getState().onExit(this);
         bladeStateMachine.setDeactivated(true);
+        if (display != null) {
+            display.remove();
+        }
     }
 
     /** Clears all mid-flight flags so the blade can be launched again cleanly. */

--- a/src/main/java/btm/sword/system/entity/umbral/input/BladeRequest.java
+++ b/src/main/java/btm/sword/system/entity/umbral/input/BladeRequest.java
@@ -19,7 +19,6 @@ public enum BladeRequest {
     RECALL,
     WAITING,
 
-    ACTIVATE_TO_PREVIOUS,
     DEACTIVATE,
     RESUME_FROM_REPAIR
 }

--- a/src/main/java/btm/sword/system/entity/umbral/statemachine/UmbralStateMachine.java
+++ b/src/main/java/btm/sword/system/entity/umbral/statemachine/UmbralStateMachine.java
@@ -78,9 +78,7 @@ public class UmbralStateMachine extends StateMachine<UmbralBlade> {
         addTransition(new Transition<>(
             UmbralStateFacade.class,
             InactiveState.class,
-            b -> (b.getThrower().self() instanceof SwordPlayer sp &&
-                sp.player().getGameMode().equals(GameMode.SPECTATOR)) ||
-                b.isRequested(BladeRequest.DEACTIVATE),
+            b -> b.isRequested(BladeRequest.DEACTIVATE),
             b -> {}
         ));
 
@@ -98,7 +96,7 @@ public class UmbralStateMachine extends StateMachine<UmbralBlade> {
         addTransition(new Transition<>(
             InactiveState.class,
             StandbyState.class,
-            b -> b.isRequested(BladeRequest.ACTIVATE_TO_PREVIOUS),
+            b -> b.isRequested(BladeRequest.ACTIVATE_TO_PREVIOUS, BladeRequest.STANDBY),
             b -> {}
         ));
 
@@ -462,19 +460,24 @@ public class UmbralStateMachine extends StateMachine<UmbralBlade> {
 
     @Override
     public void onAnyTransition() {
-
+        Debug.debug("[Old State] " + getPreviousState() + " | [New State] " + getState());
     }
 
     @Override
     public void tick() {
-        if (deactivated) return;
+        if (deactivated) {
+            Debug.umbral("      > > > deactivated");
+            if (context.getDisplay().isValid()) {
+            }
+            return;
+        }
 
         currentState.onTick(context);
         for (var t : transitions) {
             if (t.from().isAssignableFrom(currentState.getClass())
                 && t.condition().test(context)) {
-
                 t.onTransition().accept(context);
+                onAnyTransition();
                 if (t.to() == PreviousState.class) {
                     setState(previousState);
                 } else {

--- a/src/main/java/btm/sword/system/entity/umbral/statemachine/UmbralStateMachine.java
+++ b/src/main/java/btm/sword/system/entity/umbral/statemachine/UmbralStateMachine.java
@@ -5,13 +5,11 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import org.bukkit.Color;
-import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
 
 import btm.sword.config.Config;
 import btm.sword.system.control.TimeArbiter;
-import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.entity.umbral.UmbralBlade;
 import btm.sword.system.entity.umbral.input.BladeRequest;
 import btm.sword.system.entity.umbral.statemachine.state.AttackingHeavyState;
@@ -41,6 +39,7 @@ import lombok.Setter;
 public class UmbralStateMachine extends StateMachine<UmbralBlade> {
     @Getter
     private UmbralStateFacade previousState;
+    @Getter
     @Setter
     private boolean deactivated;
 
@@ -87,16 +86,6 @@ public class UmbralStateMachine extends StateMachine<UmbralBlade> {
             UmbralStateFacade.class,
             RecoverState.class,
             b -> b.getDisplay() == null || b.getDisplay().isDead() || !b.getDisplay().isValid(),
-            b -> {}
-        ));
-
-        // =====================================================================
-        // INACTIVE
-        // =====================================================================
-        addTransition(new Transition<>(
-            InactiveState.class,
-            StandbyState.class,
-            b -> b.isRequested(BladeRequest.ACTIVATE_TO_PREVIOUS, BladeRequest.STANDBY),
             b -> {}
         ));
 
@@ -499,6 +488,8 @@ public class UmbralStateMachine extends StateMachine<UmbralBlade> {
     public void setState(State<UmbralBlade> next) {
         previousState = (UmbralStateFacade) currentState;
         Debug.system(currentState.getClass().getSimpleName() + " -> " + next.getClass().getSimpleName());
+        Debug.umbralStates("[" + context.getThrower().self().getName() + "] "
+            + currentState.getClass().getSimpleName() + " -> " + next.getClass().getSimpleName());
         super.setState(next);
 
         applyGlowForState(next, context);

--- a/src/main/java/btm/sword/system/entity/umbral/statemachine/state/InactiveState.java
+++ b/src/main/java/btm/sword/system/entity/umbral/statemachine/state/InactiveState.java
@@ -3,7 +3,16 @@ package btm.sword.system.entity.umbral.statemachine.state;
 import btm.sword.system.entity.umbral.UmbralBlade;
 import btm.sword.system.entity.umbral.statemachine.UmbralStateFacade;
 
-/** State representing a fully deactivated UmbralBlade with no display entity or active behaviour. */
+/**
+ * Behavioural suspend state for the UmbralBlade.
+ * <p>
+ * Removes the visible display entity and freezes the FSM. Does NOT dispose the
+ * blade instance — that is the lifecycle layer's responsibility
+ * ({@link btm.sword.system.entity.impl.Combatant#handleUmbralBladeTick()}). Once
+ * the FSM is frozen here, the lifecycle layer detects the deactivated flag and
+ * destroys the blade, allowing it to be respawned cleanly when conditions allow.
+ * </p>
+ */
 public class InactiveState extends UmbralStateFacade {
     @Override
     public String name() {
@@ -12,21 +21,19 @@ public class InactiveState extends UmbralStateFacade {
 
     @Override
     public void onEnter(UmbralBlade blade) {
-        blade.dispose();
+        if (blade.getDisplay() != null && blade.getDisplay().isValid()) {
+            blade.getDisplay().remove();
+        }
+        blade.getBladeStateMachine().setDeactivated(true);
     }
 
     @Override
     public void onExit(UmbralBlade blade) {
+        // FSM is frozen while in InactiveState — onExit is only invoked through dispose().
     }
 
     @Override
     public void onTick(UmbralBlade blade) {
-        // since we turn the FSM off entirely upon entering,
-        // the inactive state must run its own checks to turn the
-        // system back on.
-
-        // check if we should turn this thing back on;
-        // the knowledge of which comes from one bool in Combatant
-        // setting that bool will turn
+        // No-op: FSM is frozen via setDeactivated(true). Lifecycle layer handles recreation.
     }
 }

--- a/src/main/java/btm/sword/system/entity/umbral/statemachine/state/InactiveState.java
+++ b/src/main/java/btm/sword/system/entity/umbral/statemachine/state/InactiveState.java
@@ -12,20 +12,21 @@ public class InactiveState extends UmbralStateFacade {
 
     @Override
     public void onEnter(UmbralBlade blade) {
-        if (blade.getDisplay() != null) {
-            blade.getDisplay().setViewRange(0f);
-        }
+        blade.dispose();
     }
 
     @Override
     public void onExit(UmbralBlade blade) {
-        if (blade.getDisplay() != null) {
-            blade.getDisplay().setViewRange(300f);
-        }
     }
 
     @Override
     public void onTick(UmbralBlade blade) {
+        // since we turn the FSM off entirely upon entering,
+        // the inactive state must run its own checks to turn the
+        // system back on.
 
+        // check if we should turn this thing back on;
+        // the knowledge of which comes from one bool in Combatant
+        // setting that bool will turn
     }
 }

--- a/src/main/java/btm/sword/system/entity/umbral/statemachine/state/StandbyState.java
+++ b/src/main/java/btm/sword/system/entity/umbral/statemachine/state/StandbyState.java
@@ -44,9 +44,8 @@ public class StandbyState extends UmbralStateFacade {
             followTask.cancel();
     }
 
-    // TODO: #240 - Move idle movement into this onTick method ?
     @Override
     public void onTick(UmbralBlade blade) {
-        // Idle movement handled by BukkitRunnable; tick may monitor attack triggers
+        // Idle movement handled by a TaskHandle
     }
 }

--- a/src/main/java/btm/sword/system/inventory/InventoryMenuManager.java
+++ b/src/main/java/btm/sword/system/inventory/InventoryMenuManager.java
@@ -17,6 +17,7 @@ import btm.sword.system.inventory.menu.MainMenu;
 import btm.sword.system.inventory.menu.MaterialPouchMenu;
 import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.inventory.menu.MovesetMenu;
+import btm.sword.system.inventory.menu.dev.AllKeyframeEffectsMenu;
 import btm.sword.system.inventory.menu.dev.AnimationBrowserMenu;
 import btm.sword.system.inventory.menu.dev.ConfigMenu;
 import btm.sword.system.inventory.menu.dev.CreativeInventoryMenu;
@@ -57,6 +58,7 @@ public final class InventoryMenuManager {
         register(ItemLibraryMenu.class, ItemLibraryMenu::new);
         register(WeaponDisplayEditorMenu.class, WeaponDisplayEditorMenu::new);
         register(KeyframeVisualsMenu.class, KeyframeVisualsMenu::new);
+        register(AllKeyframeEffectsMenu.class, AllKeyframeEffectsMenu::new);
         register(TestingMenu.class, TestingMenu::new);
         // SkillSelectionMenu is constructed with a slot index and is opened directly
     }

--- a/src/main/java/btm/sword/system/inventory/menu/Menu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/Menu.java
@@ -50,6 +50,12 @@ public abstract class Menu {
             .build()
     );
 
+    public static final SimpleItem EMPTY = new SimpleItem(
+        new ItemStackBuilder(Material.AIR)
+            .name(Component.text("]|["))
+            .build()
+    );
+
     public static final SimpleItem WALL = new SimpleItem(
         new ItemStackBuilder(Material.LIGHT_BLUE_STAINED_GLASS_PANE)
             .name(Component.text("|||", Config.SwordColor.TEXT_COOL_DARK))

--- a/src/main/java/btm/sword/system/inventory/menu/dev/AllKeyframeEffectsMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/AllKeyframeEffectsMenu.java
@@ -1,0 +1,147 @@
+package btm.sword.system.inventory.menu.dev;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.Material;
+import org.bukkit.event.inventory.ClickType;
+
+import btm.sword.system.attack.dev.AttackDevSession;
+import btm.sword.system.attack.simulation.VolumeKeyframe;
+import btm.sword.system.attack.visuals.ParticleDisplay;
+import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.inventory.item.ForwardItem;
+import btm.sword.system.inventory.item.PreviousItem;
+import btm.sword.system.inventory.menu.Menu;
+import btm.sword.system.item.ItemStackBuilder;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import xyz.xenondevs.invui.gui.PagedGui;
+import xyz.xenondevs.invui.gui.structure.Markers;
+import xyz.xenondevs.invui.item.Item;
+import xyz.xenondevs.invui.item.impl.SimpleItem;
+import xyz.xenondevs.invui.window.Window;
+
+/**
+ * Paginated view of every {@link ParticleDisplay} attached to every keyframe in the current
+ * editing session.
+ *
+ * <p>Each entry shows the keyframe index, display index, and shape type. Left-click or
+ * SWAP opens that display in {@link ParticleDisplayEditorMenu}. SHIFT+LEFT deletes it.</p>
+ */
+public class AllKeyframeEffectsMenu extends Menu {
+
+    /** @param player the player viewing the menu */
+    public AllKeyframeEffectsMenu(SwordPlayer player) {
+        super(player);
+    }
+
+    @Override
+    public void open() {
+        AttackDevSession session = AttackDevSession.getOrCreate(swordPlayer.player());
+        List<VolumeKeyframe> keyframes = session.getEditKeyframes();
+
+        SimpleItem back = new SimpleItem(
+            new ItemStackBuilder(Material.COPPER_TRAPDOOR)
+                .name(Component.text("Back", NamedTextColor.GRAY))
+                .build(),
+            click -> new KeyframeVisualsMenu(swordPlayer).open());
+
+        int totalEffects = 0;
+        for (VolumeKeyframe kf : keyframes) {
+            if (kf.effect() != null && kf.effect().displays() != null) {
+                totalEffects += kf.effect().displays().size();
+            }
+        }
+
+        SimpleItem info = new SimpleItem(
+            new ItemStackBuilder(Material.PAPER)
+                .name(Component.text("All Effects", NamedTextColor.LIGHT_PURPLE, TextDecoration.BOLD))
+                .lore(List.of(
+                    Component.text("Total: " + totalEffects + " effect(s)", NamedTextColor.GRAY),
+                    Component.text("Across " + keyframes.size() + " keyframe(s)", NamedTextColor.DARK_GRAY),
+                    Component.empty(),
+                    Component.text("LEFT / SWAP: edit", NamedTextColor.YELLOW),
+                    Component.text("SHIFT+LEFT: delete", NamedTextColor.RED)))
+                .build());
+
+        List<Item> entries = buildEffectEntries(session, keyframes);
+
+        PagedGui<Item> gui = PagedGui.items()
+            .setStructure(
+                "B . I . . . . . .",
+                "x x x x x x x x x",
+                "x x x x x x x x x",
+                "x x x x x x x x x",
+                "< # # # # # # # >")
+            .addIngredient('#', BORDER)
+            .addIngredient('B', back)
+            .addIngredient('I', info)
+            .addIngredient('x', Markers.CONTENT_LIST_SLOT_HORIZONTAL)
+            .addIngredient('<', new PreviousItem())
+            .addIngredient('>', new ForwardItem())
+            .setContent(entries)
+            .build();
+
+        Window.single()
+            .setViewer(swordPlayer.player())
+            .setTitle("All Effects — " + session.getCurrentAttackName())
+            .setGui(gui)
+            .build()
+            .open();
+    }
+
+    private List<Item> buildEffectEntries(AttackDevSession session, List<VolumeKeyframe> keyframes) {
+        List<Item> items = new ArrayList<>();
+        for (int kfIdx = 0; kfIdx < keyframes.size(); kfIdx++) {
+            VolumeKeyframe kf = keyframes.get(kfIdx);
+            if (kf.effect() == null || kf.effect().displays() == null) continue;
+            List<ParticleDisplay> displays = kf.effect().displays();
+            for (int dIdx = 0; dIdx < displays.size(); dIdx++) {
+                final int finalKf = kfIdx;
+                final int finalD = dIdx;
+                ParticleDisplay d = displays.get(dIdx);
+                List<Component> lore = new ArrayList<>();
+                lore.add(Component.text("Keyframe: ", NamedTextColor.DARK_GRAY)
+                    .append(Component.text("#" + kfIdx, NamedTextColor.GOLD)));
+                lore.add(Component.text("Display:  ", NamedTextColor.DARK_GRAY)
+                    .append(Component.text("#" + dIdx, NamedTextColor.YELLOW)));
+                lore.add(Component.text("Particles: " + d.getParticles().size(), NamedTextColor.GRAY));
+                lore.add(Component.text("Repeat: " + d.getRepeatCount()
+                    + " × " + d.getRepeatPeriodTicks() + "t", NamedTextColor.GRAY));
+                lore.add(Component.empty());
+                lore.add(Component.text("LEFT / SWAP: edit", NamedTextColor.YELLOW));
+                lore.add(Component.text("SHIFT+LEFT: delete", NamedTextColor.RED));
+
+                items.add(new SimpleItem(
+                    new ItemStackBuilder(iconFor(d))
+                        .name(Component.text(d.shapeTypeLabel() + "  KF#" + kfIdx + "  D#" + dIdx,
+                            NamedTextColor.YELLOW, TextDecoration.BOLD))
+                        .lore(lore)
+                        .build(),
+                    click -> {
+                        ClickType type = click.getClickType();
+                        if (type == ClickType.SHIFT_LEFT) {
+                            session.setCurrentKeyframeIndex(finalKf);
+                            session.removeKeyframeDisplay(finalKf, finalD);
+                            open();
+                            return;
+                        }
+                        session.setCurrentKeyframeIndex(finalKf);
+                        new ParticleDisplayEditorMenu(swordPlayer, finalKf, finalD).open();
+                    }));
+            }
+        }
+        return items;
+    }
+
+    private static Material iconFor(ParticleDisplay d) {
+        return switch (d.shapeTypeLabel()) {
+            case "Line" -> Material.STICK;
+            case "Sphere" -> Material.SLIME_BALL;
+            case "Circle" -> Material.ENDER_PEARL;
+            default -> Material.REDSTONE;
+        };
+    }
+}

--- a/src/main/java/btm/sword/system/inventory/menu/dev/AttackBrowserMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/AttackBrowserMenu.java
@@ -9,18 +9,23 @@ import org.bukkit.Material;
 import org.bukkit.event.inventory.ClickType;
 
 import btm.sword.Sword;
-import btm.sword.system.attack.def.AttackDef;
+import btm.sword.config.Config;
+import btm.sword.system.attack.def.AttackDefSerializer;
+import btm.sword.system.attack.def.AttackInstance;
 import btm.sword.system.attack.def.AttackRegistry;
 import btm.sword.system.attack.dev.AnimationMode;
 import btm.sword.system.attack.dev.AttackDevSession;
 import btm.sword.system.attack.dev.DevMode;
-import btm.sword.system.attack.simulation.KeyframedTrajectory;
+import btm.sword.system.attack.simulation.ControlPointSequence;
+import btm.sword.system.attack.simulation.KeyframedSequence;
+import btm.sword.system.attack.simulation.SweepSequence;
 import btm.sword.system.entity.impl.DevSwordPlayer;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.inventory.item.ForwardItem;
 import btm.sword.system.inventory.item.PreviousItem;
 import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.item.ItemStackBuilder;
+import btm.sword.utility.ChatInputCapture;
 import btm.sword.utility.Prefab;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -90,16 +95,23 @@ public class AttackBrowserMenu extends Menu {
 
         SimpleItem giveWand = giveItem(Prefab.Items.testVolumeWand());
 
+        SimpleItem showHitboxes = toggle(
+            "Hitbox Outlines (live attacks)",
+            () -> Config.Debug.VISUALIZATION_SHOW_HITBOXES,
+            () -> Config.Debug.VISUALIZATION_SHOW_HITBOXES = !Config.Debug.VISUALIZATION_SHOW_HITBOXES
+        );
+
         PagedGui<Item> gui = PagedGui.items()
             .setStructure(
                 "P # # # # # # # #",
                 "x x x x x x x x x",
                 "x x x x x x x x x",
-                "N G # < # > # # #")
+                "N G H < # > # # #")
             .addIngredient('#', BORDER)
             .addIngredient('P', back)
             .addIngredient('N', newRecording)
             .addIngredient('G', giveWand)
+            .addIngredient('H', showHitboxes)
             .addIngredient('<', new PreviousItem())
             .addIngredient('>', new ForwardItem())
             .addIngredient('x', Markers.CONTENT_LIST_SLOT_HORIZONTAL)
@@ -114,22 +126,92 @@ public class AttackBrowserMenu extends Menu {
             .open();
     }
 
+    private void openRenamePrompt(AttackInstance def) {
+        ChatInputCapture.prompt(
+            swordPlayer.player(),
+            Component.text("[Dev] Enter new name for '" + def.getId() + "':", NamedTextColor.YELLOW),
+            input -> {
+                if (input.equalsIgnoreCase("cancel")) {
+                    new AttackBrowserMenu(swordPlayer).open();
+                    return;
+                }
+                String newId = input.trim().toLowerCase().replace(' ', '_');
+                if (newId.isEmpty() || newId.equals(def.getId())) {
+                    new AttackBrowserMenu(swordPlayer).open();
+                    return;
+                }
+                if (AttackRegistry.contains(newId)) {
+                    swordPlayer.message(Component.text("[Dev] '" + newId + "' is already taken.", NamedTextColor.RED));
+                    new AttackBrowserMenu(swordPlayer).open();
+                    return;
+                }
+                performRename(def, newId);
+            });
+    }
+
+    private void performRename(AttackInstance old, String newId) {
+        File attacksDir = new File(Sword.getInstance().getDataFolder(), "attacks");
+        attacksDir.mkdirs();
+        try {
+            AttackInstance renamed = rebuildWithId(old, newId);
+
+            File newFile = new File(attacksDir, newId + ".yml");
+            AttackDefSerializer.save(newFile, renamed);
+
+            File oldFile = new File(attacksDir, old.getId() + ".yml");
+            if (oldFile.exists() && !oldFile.getCanonicalPath().equals(newFile.getCanonicalPath())) {
+                oldFile.delete();
+            }
+
+            AttackRegistry.unregister(old.getId());
+            AttackRegistry.register(renamed);
+
+            AttackDevSession session = AttackDevSession.get(swordPlayer.player().getUniqueId());
+            if (session != null && old.getId().equals(session.getCurrentAttackName())) {
+                session.renameCurrentAttack(newId);
+            }
+
+            swordPlayer.message(Component.text(
+                "[Dev] Renamed '" + old.getId() + "' → '" + newId + "'.", NamedTextColor.GREEN));
+        } catch (Exception e) {
+            swordPlayer.message(Component.text("[Dev] Rename failed: " + e.getMessage(), NamedTextColor.RED));
+        }
+        new AttackBrowserMenu(swordPlayer).open();
+    }
+
+    private static AttackInstance rebuildWithId(AttackInstance old, String newId) {
+        AttackInstance.Builder b = new AttackInstance.Builder(newId)
+            .duration(old.getDurationMs())
+            .onHit(old.getHitValue())
+            .orientWithPitch(old.isOrientWithPitch())
+            .lockOriginOnFire(old.isLockOriginOnFire());
+        switch (old.getType()) {
+            case VOLUME -> b.keyframes(((KeyframedSequence) old.getTrajectory()).keyframes());
+            case SWEEP -> b.sweep(((SweepSequence) old.getTrajectory()).getCurve());
+            case CTRL_POINT -> {
+                ControlPointSequence cps = (ControlPointSequence) old.getTrajectory();
+                b.controlPoints(cps.getPoints(), cps.getMode());
+            }
+        }
+        return b.build();
+    }
+
     private List<Item> buildAttackItems() {
-        List<AttackDef> sorted = AttackRegistry.getAll().stream()
-            .sorted(Comparator.comparing(AttackDef::getId))
+        List<AttackInstance> sorted = AttackRegistry.getAll().stream()
+            .sorted(Comparator.comparing(AttackInstance::getId))
             .toList();
 
         List<Item> items = new ArrayList<>(sorted.size());
-        for (AttackDef def : sorted) {
+        for (AttackInstance def : sorted) {
             items.add(buildAttackItem(def));
         }
         return items;
     }
 
-    private Item buildAttackItem(AttackDef def) {
-        boolean editable = def.getTrajectory() instanceof KeyframedTrajectory;
+    private Item buildAttackItem(AttackInstance def) {
+        boolean editable = def.getTrajectory() instanceof KeyframedSequence;
         int frameCount = editable
-            ? ((KeyframedTrajectory) def.getTrajectory()).getKeyframes().size()
+            ? ((KeyframedSequence) def.getTrajectory()).keyframes().size()
             : -1;
 
         List<Component> lore = new ArrayList<>();
@@ -149,6 +231,7 @@ public class AttackBrowserMenu extends Menu {
         } else {
             lore.add(Component.text("SWEEP attacks cannot be edited here", NamedTextColor.RED));
         }
+        lore.add(Component.text("Swap-click to rename", NamedTextColor.LIGHT_PURPLE));
 
         Material icon = editable ? Material.PAPER : Material.BOOK;
         ItemStackBuilder builder = new ItemStackBuilder(icon)
@@ -156,29 +239,36 @@ public class AttackBrowserMenu extends Menu {
             .lore(lore);
 
         if (!editable) {
-            return new SimpleItem(builder.build(), click -> swordPlayer.message(
-                Component.text("SWEEP attacks cannot be edited via the menu.", NamedTextColor.RED)));
+            return new SimpleItem(builder.build(), click -> {
+                if (click.getClickType() == ClickType.SWAP_OFFHAND) {
+                    openRenamePrompt(def);
+                } else {
+                    swordPlayer.message(Component.text("SWEEP attacks cannot be edited via the menu.", NamedTextColor.RED));
+                }
+            });
         }
 
         return new SimpleItem(builder.build(), click -> {
-            KeyframedTrajectory kt = (KeyframedTrajectory) def.getTrajectory();
+            KeyframedSequence kt = (KeyframedSequence) def.getTrajectory();
             AttackDevSession session = AttackDevSession.getOrCreate(swordPlayer.player());
-            if (click.getClickType() == ClickType.SHIFT_LEFT) {
+            if (click.getClickType() == ClickType.SWAP_OFFHAND) {
+                openRenamePrompt(def);
+            } else if (click.getClickType() == ClickType.SHIFT_LEFT) {
                 if (!(swordPlayer instanceof DevSwordPlayer dev)) {
                     swordPlayer.message(Component.text("[Dev] Not a dev player — cannot enter Animation Mode.", NamedTextColor.RED));
                     return;
                 }
-                session.startEditing(def.getId(), kt.getKeyframes(), def.getDurationMs(), def.getHitValue());
+                session.startEditing(def.getId(), kt.keyframes(), def.getDurationMs(), def.getHitValue());
                 swordPlayer.player().closeInventory();
                 AnimationMode.enter(dev, session);
             } else if (click.getClickType().isRightClick()) {
-                session.startViewing(def.getId(), kt.getKeyframes());
+                session.startViewing(def.getId(), kt.keyframes());
                 swordPlayer.player().closeInventory();
                 swordPlayer.message(Component.text(
                     "[Dev] Visualizing '" + def.getId() + "' — close your inventory to stop.",
                     NamedTextColor.YELLOW));
             } else {
-                session.startEditing(def.getId(), kt.getKeyframes(), def.getDurationMs(), def.getHitValue());
+                session.startEditing(def.getId(), kt.keyframes(), def.getDurationMs(), def.getHitValue());
                 new AttackEditorMenu(swordPlayer).open();
             }
         });

--- a/src/main/java/btm/sword/system/inventory/menu/dev/AttackEditorMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/AttackEditorMenu.java
@@ -14,8 +14,8 @@ import org.joml.Vector3f;
 
 import btm.sword.Sword;
 import btm.sword.system.attack.HitValuePacket;
-import btm.sword.system.attack.def.AttackDef;
 import btm.sword.system.attack.def.AttackDefSerializer;
+import btm.sword.system.attack.def.AttackInstance;
 import btm.sword.system.attack.def.AttackRegistry;
 import btm.sword.system.attack.dev.AttackDevSession;
 import btm.sword.system.attack.simulation.KeyframeType;
@@ -908,7 +908,7 @@ public class AttackEditorMenu extends Menu {
      */
     static void saveAttack(AttackDevSession session, SwordPlayer player) {
         try {
-            AttackDef def = session.buildCurrentAttack();
+            AttackInstance def = session.buildCurrentAttack();
             AttackRegistry.register(def);
 
             File attacksDir = new File(Sword.getInstance().getDataFolder(), "attacks");

--- a/src/main/java/btm/sword/system/inventory/menu/dev/AttackEditorMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/AttackEditorMenu.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import org.bukkit.Material;
 import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.ItemStack;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
@@ -619,11 +620,15 @@ public class AttackEditorMenu extends Menu {
 
             String typeTag = kf.keyframeType() != KeyframeType.STANDARD
                 ? " [" + kf.keyframeType().name() + "]" : "";
+            int effectCount = kf.effect() != null && kf.effect().displays() != null
+                ? kf.effect().displays().size() : 0;
+            ItemStack kfItem = new ItemStackBuilder(mat)
+                .name(Component.text("Frame " + idx + typeTag, nameColor, TextDecoration.BOLD))
+                .lore(lore)
+                .build();
+            if (effectCount > 0) kfItem.setAmount(Math.min(effectCount, 64));
             items.add(new SimpleItem(
-                new ItemStackBuilder(mat)
-                    .name(Component.text("Frame " + idx + typeTag, nameColor, TextDecoration.BOLD))
-                    .lore(lore)
-                    .build(),
+                kfItem,
                 click -> {
                     ClickType type = click.getClickType();
                     if (type == ClickType.SWAP_OFFHAND) {

--- a/src/main/java/btm/sword/system/inventory/menu/dev/DevMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/DevMenu.java
@@ -10,6 +10,7 @@ import btm.sword.system.inventory.menu.ItemLibraryMenu;
 import btm.sword.system.inventory.menu.MainMenu;
 import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.item.ItemStackBuilder;
+import btm.sword.utility.Prefab;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -169,6 +170,11 @@ public class DevMenu extends Menu {
             click -> new HitPacketLibraryMenu(swordPlayer).open()
         );
 
+        SimpleItem umbralBladeTester = new SimpleItem(
+            Prefab.Items.umbralBladeTester(),
+            click -> click.getPlayer().getInventory().addItem(Prefab.Items.umbralBladeTester())
+        );
+
 
         Gui gui = Gui.normal()
             .setStructure(
@@ -177,7 +183,7 @@ public class DevMenu extends Menu {
                 ". H V . ? . . E .",
                 ". . K . A . . P .",
                 "# R I . . . M W #",
-                "< > # . . . # # #")
+                "< > # . . . U # #")
             .addIngredient('#', BORDER)
             .addIngredient('T', toggles)
             .addIngredient('R', reloadInventoryButtons)
@@ -195,6 +201,7 @@ public class DevMenu extends Menu {
             .addIngredient('H', weaponDisplay)
             .addIngredient('V', attackEditor)
             .addIngredient('K', hitPackets)
+            .addIngredient('U', umbralBladeTester)
             .addIngredient('<', generatePreviousButtonOrDefault())
             .addIngredient('>', generateForwardPreviousButtonOrDefault())
             .build();

--- a/src/main/java/btm/sword/system/inventory/menu/dev/KeyframeVisualsMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/KeyframeVisualsMenu.java
@@ -2,6 +2,7 @@ package btm.sword.system.inventory.menu.dev;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.bukkit.Material;
 import org.bukkit.Registry;
@@ -11,7 +12,10 @@ import org.bukkit.event.inventory.ClickType;
 
 import btm.sword.system.attack.dev.AttackDevSession;
 import btm.sword.system.attack.simulation.KeyframeEffect;
+import btm.sword.system.attack.simulation.KeyframeType;
 import btm.sword.system.attack.simulation.SoundCue;
+import btm.sword.system.attack.visuals.LineDisplay;
+import btm.sword.system.attack.visuals.OriginAnchor;
 import btm.sword.system.attack.visuals.ParticleDisplay;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.inventory.menu.Menu;
@@ -26,11 +30,18 @@ import xyz.xenondevs.invui.window.Window;
 
 /**
  * Per-keyframe visuals editor — shows the {@link ParticleDisplay}s attached to the
- * current keyframe along with sound-cue controls and add-shape shortcuts.
+ * current keyframe along with sound-cue controls, add-shape shortcuts, and keyframe
+ * navigation arrows.
  *
  * <p>Display entries respond to LEFT / SWAP_OFFHAND (edit in
  * {@link ParticleDisplayEditorMenu}) and SHIFT_LEFT (delete). Swap-click on a keyframe
  * item in {@link AttackEditorMenu} opens this menu for that keyframe.</p>
+ *
+ * <p>When the session has a multi-selection active, add-shape buttons create independent
+ * copies of the new display on every selected keyframe in addition to the current one.</p>
+ *
+ * <p>The bottom row provides prev/next keyframe arrows and a button to open the
+ * {@link AllKeyframeEffectsMenu} for a cross-keyframe view of all effects.</p>
  */
 public class KeyframeVisualsMenu extends Menu {
 
@@ -55,10 +66,14 @@ public class KeyframeVisualsMenu extends Menu {
             new AttackEditorMenu(swordPlayer).open();
             return;
         }
+        int kfCount = session.getEditKeyframes().size();
         KeyframeEffect current = session.getEditKeyframes().get(kfIdx).effect();
         List<ParticleDisplay> displays = current != null && current.displays() != null
             ? current.displays() : List.of();
         SoundCue currentSound = current != null ? current.sound() : null;
+        Set<Integer> multiSel = session.getSelectedKeyframeIndices();
+        KeyframeType kfType = session.getEditKeyframes().get(kfIdx).keyframeType();
+        boolean isRaycast = kfType == KeyframeType.RAYCAST || kfType == KeyframeType.ORIGIN_RAY;
 
         SimpleItem back = new SimpleItem(
             new ItemStackBuilder(Material.COPPER_TRAPDOOR)
@@ -73,13 +88,20 @@ public class KeyframeVisualsMenu extends Menu {
             click -> AttackEditorMenu.saveAttack(
                 AttackDevSession.getOrCreate(swordPlayer.player()), swordPlayer));
 
+        List<Component> infoLore = new ArrayList<>();
+        infoLore.add(Component.text("Displays: " + displays.size(), NamedTextColor.GRAY));
+        infoLore.add(Component.text("Sound: " + (currentSound != null ? soundKey(currentSound) : "none"),
+            NamedTextColor.GRAY));
+        infoLore.add(Component.text("Type: " + kfType.name(), NamedTextColor.DARK_GRAY));
+        if (!multiSel.isEmpty()) {
+            infoLore.add(Component.empty());
+            infoLore.add(Component.text("Selection: " + multiSel.size() + " frame(s)", NamedTextColor.YELLOW));
+            infoLore.add(Component.text("Add buttons will copy to all selected.", NamedTextColor.YELLOW));
+        }
         SimpleItem info = new SimpleItem(
             new ItemStackBuilder(Material.PAPER)
                 .name(Component.text("Keyframe #" + kfIdx, NamedTextColor.GOLD, TextDecoration.BOLD))
-                .lore(List.of(
-                    Component.text("Displays: " + displays.size(), NamedTextColor.GRAY),
-                    Component.text("Sound: " + (currentSound != null ? soundKey(currentSound) : "none"),
-                        NamedTextColor.GRAY)))
+                .lore(infoLore)
                 .build());
 
         SimpleItem soundCycle = new SimpleItem(
@@ -102,15 +124,19 @@ public class KeyframeVisualsMenu extends Menu {
                 .name(Component.text("Clear Sound", NamedTextColor.RED, TextDecoration.BOLD)).build(),
             click -> {
                 if (currentSound == null) return;
-                session.setKeyframeEffect(kfIdx, new KeyframeEffect(
-                    displays, null));
+                session.setKeyframeEffect(kfIdx, new KeyframeEffect(displays, null));
                 open();
             });
 
-        SimpleItem addPoint = addShape("Add Point", Material.REDSTONE, "POINT");
-        SimpleItem addLine = addShape("Add Line", Material.STICK, "LINE");
-        SimpleItem addSphere = addShape("Add Sphere", Material.SLIME_BALL, "SPHERE");
-        SimpleItem addCircle = addShape("Add Circle", Material.ENDER_PEARL, "CIRCLE");
+        int extraTargets = (int) multiSel.stream().filter(idx -> idx != kfIdx).count();
+        SimpleItem addPoint = addShape("Add Point", Material.REDSTONE, "POINT", extraTargets);
+        SimpleItem addLine = addShape("Add Line", Material.STICK, "LINE", extraTargets);
+        SimpleItem addSphere = addShape("Add Sphere", Material.SLIME_BALL, "SPHERE", extraTargets);
+        SimpleItem addCircle = addShape("Add Circle", Material.ENDER_PEARL, "CIRCLE", extraTargets);
+
+        SimpleItem addRaycastLine = isRaycast ? buildRaycastLineButton(extraTargets) : new SimpleItem(
+            new ItemStackBuilder(Material.GRAY_STAINED_GLASS_PANE)
+                .name(Component.text("—", NamedTextColor.DARK_GRAY)).build());
 
         Item[] slots = new Item[18];
         for (int i = 0; i < 18; i++) {
@@ -145,13 +171,50 @@ public class KeyframeVisualsMenu extends Menu {
             }
         }
 
+        // ── Nav arrows ────────────────────────────────────────────────────────
+        boolean hasPrev = kfIdx > 0;
+        boolean hasNext = kfIdx < kfCount - 1;
+
+        SimpleItem prevKf = new SimpleItem(
+            new ItemStackBuilder(hasPrev ? Material.ARROW : Material.GRAY_STAINED_GLASS_PANE)
+                .name(hasPrev
+                    ? Component.text("◀ Keyframe #" + (kfIdx - 1), NamedTextColor.YELLOW, TextDecoration.BOLD)
+                    : Component.text("—", NamedTextColor.DARK_GRAY))
+                .build(),
+            click -> {
+                if (!hasPrev) return;
+                session.setCurrentKeyframeIndex(kfIdx - 1);
+                new KeyframeVisualsMenu(swordPlayer).open();
+            });
+
+        SimpleItem nextKf = new SimpleItem(
+            new ItemStackBuilder(hasNext ? Material.ARROW : Material.GRAY_STAINED_GLASS_PANE)
+                .name(hasNext
+                    ? Component.text("Keyframe #" + (kfIdx + 1) + " ▶", NamedTextColor.YELLOW, TextDecoration.BOLD)
+                    : Component.text("—", NamedTextColor.DARK_GRAY))
+                .build(),
+            click -> {
+                if (!hasNext) return;
+                session.setCurrentKeyframeIndex(kfIdx + 1);
+                new KeyframeVisualsMenu(swordPlayer).open();
+            });
+
+        SimpleItem allEffects = new SimpleItem(
+            new ItemStackBuilder(Material.BOOK)
+                .name(Component.text("All Effects", NamedTextColor.LIGHT_PURPLE, TextDecoration.BOLD))
+                .lore(List.of(
+                    Component.text("View all effects across every keyframe.", NamedTextColor.DARK_GRAY),
+                    Component.text("Edit or delete any effect from here.", NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> new AllKeyframeEffectsMenu(swordPlayer).open());
+
         Gui gui = Gui.normal()
             .setStructure(
                 "B V I . . . . C L",
                 "1 2 3 4 5 6 7 8 9",
                 "a b c d e f g h i",
-                ". P . N . S . R .",
-                "# # # # # # # # #")
+                "Q P . N . S . R .",
+                "< # # # M # # # >")
             .addIngredient('#', BORDER)
             .addIngredient('.', BORDER)
             .addIngredient('B', back)
@@ -165,8 +228,12 @@ public class KeyframeVisualsMenu extends Menu {
             .addIngredient('a', slots[9]).addIngredient('b', slots[10]).addIngredient('c', slots[11])
             .addIngredient('d', slots[12]).addIngredient('e', slots[13]).addIngredient('f', slots[14])
             .addIngredient('g', slots[15]).addIngredient('h', slots[16]).addIngredient('i', slots[17])
+            .addIngredient('Q', addRaycastLine)
             .addIngredient('P', addPoint).addIngredient('N', addLine)
             .addIngredient('S', addSphere).addIngredient('R', addCircle)
+            .addIngredient('<', prevKf)
+            .addIngredient('M', allEffects)
+            .addIngredient('>', nextKf)
             .build();
 
         Window.single()
@@ -177,18 +244,61 @@ public class KeyframeVisualsMenu extends Menu {
             .open();
     }
 
-    private SimpleItem addShape(String label, Material mat, String shape) {
+    private SimpleItem addShape(String label, Material mat, String shape, int extraTargets) {
+        List<Component> lore = new ArrayList<>();
+        lore.add(Component.text("Appends a default " + shape.toLowerCase() + " display.",
+            NamedTextColor.DARK_GRAY));
+        if (extraTargets > 0) {
+            lore.add(Component.text("Also copies to " + extraTargets + " selected keyframe(s).",
+                NamedTextColor.YELLOW));
+        }
         return new SimpleItem(
             new ItemStackBuilder(mat)
                 .name(Component.text(label, NamedTextColor.GREEN, TextDecoration.BOLD))
-                .lore(List.of(Component.text("Appends a default " + shape.toLowerCase() + " display.",
-                    NamedTextColor.DARK_GRAY)))
+                .lore(lore)
                 .build(),
             click -> {
                 AttackDevSession session = AttackDevSession.getOrCreate(swordPlayer.player());
                 int kfIdx = session.getCurrentKeyframeIndex();
                 ParticleDisplay fresh = ParticleDisplayEditorMenu.createDefault(shape);
                 session.addKeyframeDisplay(kfIdx, fresh);
+                Set<Integer> sel = session.getSelectedKeyframeIndices();
+                for (int selIdx : sel) {
+                    if (selIdx != kfIdx) {
+                        session.addKeyframeDisplay(selIdx, fresh.copy());
+                    }
+                }
+                int newIndex = session.getEditKeyframes().get(kfIdx).effect().displays().size() - 1;
+                new ParticleDisplayEditorMenu(swordPlayer, kfIdx, newIndex).open();
+            });
+    }
+
+    private SimpleItem buildRaycastLineButton(int extraTargets) {
+        List<Component> lore = new ArrayList<>();
+        lore.add(Component.text("Adds a Line from the ray origin to the tip.", NamedTextColor.DARK_GRAY));
+        lore.add(Component.text("Uses RaycastOrigin + OwningKeyframe anchors.", NamedTextColor.DARK_GRAY));
+        if (extraTargets > 0) {
+            lore.add(Component.text("Also copies to " + extraTargets + " selected keyframe(s).",
+                NamedTextColor.YELLOW));
+        }
+        return new SimpleItem(
+            new ItemStackBuilder(Material.CHAIN)
+                .name(Component.text("Add Ray Line", NamedTextColor.GREEN, TextDecoration.BOLD))
+                .lore(lore)
+                .build(),
+            click -> {
+                AttackDevSession session = AttackDevSession.getOrCreate(swordPlayer.player());
+                int kfIdx = session.getCurrentKeyframeIndex();
+                LineDisplay rayLine = LineDisplay.defaults();
+                rayLine.setAnchor(OriginAnchor.raycastOrigin());
+                rayLine.setEndAnchor(OriginAnchor.owning());
+                session.addKeyframeDisplay(kfIdx, rayLine);
+                Set<Integer> sel = session.getSelectedKeyframeIndices();
+                for (int selIdx : sel) {
+                    if (selIdx != kfIdx) {
+                        session.addKeyframeDisplay(selIdx, rayLine.copy());
+                    }
+                }
                 int newIndex = session.getEditKeyframes().get(kfIdx).effect().displays().size() - 1;
                 new ParticleDisplayEditorMenu(swordPlayer, kfIdx, newIndex).open();
             });

--- a/src/main/java/btm/sword/system/inventory/menu/dev/KeyframeVisualsMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/KeyframeVisualsMenu.java
@@ -208,13 +208,22 @@ public class KeyframeVisualsMenu extends Menu {
                 .build(),
             click -> new AllKeyframeEffectsMenu(swordPlayer).open());
 
+        SimpleItem fromLibrary = new SimpleItem(
+            new ItemStackBuilder(Material.BOOKSHELF)
+                .name(Component.text("From Library...", NamedTextColor.AQUA, TextDecoration.BOLD))
+                .lore(List.of(
+                    Component.text("Browse and copy particle display presets", NamedTextColor.DARK_GRAY),
+                    Component.text("from the library, current attack, or Prefab.", NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> new ParticleDisplayLibraryMenu(swordPlayer, this::open).open());
+
         Gui gui = Gui.normal()
             .setStructure(
                 "B V I . . . . C L",
                 "1 2 3 4 5 6 7 8 9",
                 "a b c d e f g h i",
-                "Q P . N . S . R .",
-                "< # # # M # # # >")
+                "Q P . N . S . R F",
+                "# # # < M > # # #")
             .addIngredient('#', BORDER)
             .addIngredient('.', BORDER)
             .addIngredient('B', back)
@@ -231,6 +240,7 @@ public class KeyframeVisualsMenu extends Menu {
             .addIngredient('Q', addRaycastLine)
             .addIngredient('P', addPoint).addIngredient('N', addLine)
             .addIngredient('S', addSphere).addIngredient('R', addCircle)
+            .addIngredient('F', fromLibrary)
             .addIngredient('<', prevKf)
             .addIngredient('M', allEffects)
             .addIngredient('>', nextKf)

--- a/src/main/java/btm/sword/system/inventory/menu/dev/KeyframeVisualsMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/KeyframeVisualsMenu.java
@@ -135,7 +135,7 @@ public class KeyframeVisualsMenu extends Menu {
             click -> {
                 SoundCue next = nextSound(currentSound);
                 session.setKeyframeEffect(kfIdx, new KeyframeEffect(
-                    displays != null ? displays : new ArrayList<>(), next));
+                    displays, next));
                 open();
             });
 
@@ -239,13 +239,12 @@ public class KeyframeVisualsMenu extends Menu {
 
         Gui gui = Gui.normal()
             .setStructure(
-                "B V I . . . . C L",
+                "B V I # # # # C L",
                 "1 2 3 4 5 6 7 8 9",
                 "a b c d e f g h i",
                 "Q P . N . S . R F",
                 "# # # < M > # # #")
             .addIngredient('#', BORDER)
-            .addIngredient('.', BORDER)
             .addIngredient('B', back)
             .addIngredient('V', save)
             .addIngredient('I', info)

--- a/src/main/java/btm/sword/system/inventory/menu/dev/KeyframeVisualsMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/KeyframeVisualsMenu.java
@@ -14,6 +14,7 @@ import btm.sword.system.attack.dev.AttackDevSession;
 import btm.sword.system.attack.simulation.KeyframeEffect;
 import btm.sword.system.attack.simulation.KeyframeType;
 import btm.sword.system.attack.simulation.SoundCue;
+import btm.sword.system.attack.simulation.VolumeKeyframe;
 import btm.sword.system.attack.visuals.LineDisplay;
 import btm.sword.system.attack.visuals.OriginAnchor;
 import btm.sword.system.attack.visuals.ParticleDisplay;
@@ -61,6 +62,25 @@ public class KeyframeVisualsMenu extends Menu {
     @Override
     public void open() {
         AttackDevSession session = AttackDevSession.getOrCreate(swordPlayer.player());
+
+        // Execute any pending multi-kf display copy (deferred from initial addShape creation)
+        if (!session.getPendingCopyTargets().isEmpty()) {
+            int srcKf = session.getPendingCopySourceKfIndex();
+            int srcDi = session.getPendingCopyDisplayIndex();
+            List<VolumeKeyframe> kfsSnap = session.getEditKeyframes();
+            if (kfsSnap != null && srcKf >= 0 && srcKf < kfsSnap.size()) {
+                var effSnap = kfsSnap.get(srcKf).effect();
+                if (effSnap != null && effSnap.displays() != null
+                        && srcDi >= 0 && srcDi < effSnap.displays().size()) {
+                    ParticleDisplay srcDisplay = effSnap.displays().get(srcDi);
+                    for (int tgt : session.getPendingCopyTargets()) {
+                        session.addKeyframeDisplay(tgt, srcDisplay.copy());
+                    }
+                }
+            }
+            session.clearPendingCopy();
+        }
+
         int kfIdx = session.getCurrentKeyframeIndex();
         if (session.getEditKeyframes() == null || kfIdx < 0 || kfIdx >= session.getEditKeyframes().size()) {
             new AttackEditorMenu(swordPlayer).open();
@@ -276,7 +296,8 @@ public class KeyframeVisualsMenu extends Menu {
                 List<Integer> extras = session.getSelectedKeyframeIndices().stream()
                     .filter(idx -> idx != kfIdx)
                     .toList();
-                new ParticleDisplayEditorMenu(swordPlayer, kfIdx, newIndex, extras).open();
+                if (!extras.isEmpty()) session.setPendingCopy(extras, kfIdx, newIndex);
+                new ParticleDisplayEditorMenu(swordPlayer, kfIdx, newIndex).open();
             });
     }
 
@@ -304,7 +325,8 @@ public class KeyframeVisualsMenu extends Menu {
                 List<Integer> extras = session.getSelectedKeyframeIndices().stream()
                     .filter(idx -> idx != kfIdx)
                     .toList();
-                new ParticleDisplayEditorMenu(swordPlayer, kfIdx, newIndex, extras).open();
+                if (!extras.isEmpty()) session.setPendingCopy(extras, kfIdx, newIndex);
+                new ParticleDisplayEditorMenu(swordPlayer, kfIdx, newIndex).open();
             });
     }
 

--- a/src/main/java/btm/sword/system/inventory/menu/dev/KeyframeVisualsMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/KeyframeVisualsMenu.java
@@ -272,14 +272,11 @@ public class KeyframeVisualsMenu extends Menu {
                 int kfIdx = session.getCurrentKeyframeIndex();
                 ParticleDisplay fresh = ParticleDisplayEditorMenu.createDefault(shape);
                 session.addKeyframeDisplay(kfIdx, fresh);
-                Set<Integer> sel = session.getSelectedKeyframeIndices();
-                for (int selIdx : sel) {
-                    if (selIdx != kfIdx) {
-                        session.addKeyframeDisplay(selIdx, fresh.copy());
-                    }
-                }
                 int newIndex = session.getEditKeyframes().get(kfIdx).effect().displays().size() - 1;
-                new ParticleDisplayEditorMenu(swordPlayer, kfIdx, newIndex).open();
+                List<Integer> extras = session.getSelectedKeyframeIndices().stream()
+                    .filter(idx -> idx != kfIdx)
+                    .toList();
+                new ParticleDisplayEditorMenu(swordPlayer, kfIdx, newIndex, extras).open();
             });
     }
 
@@ -303,14 +300,11 @@ public class KeyframeVisualsMenu extends Menu {
                 rayLine.setAnchor(OriginAnchor.raycastOrigin());
                 rayLine.setEndAnchor(OriginAnchor.owning());
                 session.addKeyframeDisplay(kfIdx, rayLine);
-                Set<Integer> sel = session.getSelectedKeyframeIndices();
-                for (int selIdx : sel) {
-                    if (selIdx != kfIdx) {
-                        session.addKeyframeDisplay(selIdx, rayLine.copy());
-                    }
-                }
                 int newIndex = session.getEditKeyframes().get(kfIdx).effect().displays().size() - 1;
-                new ParticleDisplayEditorMenu(swordPlayer, kfIdx, newIndex).open();
+                List<Integer> extras = session.getSelectedKeyframeIndices().stream()
+                    .filter(idx -> idx != kfIdx)
+                    .toList();
+                new ParticleDisplayEditorMenu(swordPlayer, kfIdx, newIndex, extras).open();
             });
     }
 

--- a/src/main/java/btm/sword/system/inventory/menu/dev/OriginAnchorPickerMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/OriginAnchorPickerMenu.java
@@ -13,6 +13,7 @@ import btm.sword.system.inventory.item.ForwardItem;
 import btm.sword.system.inventory.item.PreviousItem;
 import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.item.ItemStackBuilder;
+import btm.sword.utility.ChatInputCapture;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -102,6 +103,30 @@ public class OriginAnchorPickerMenu extends Menu {
         SimpleItem bodyChest = bodyButton(OriginAnchor.BodyPoint.CHEST, Material.IRON_CHESTPLATE, "Attacker Chest");
         SimpleItem bodyFeet = bodyButton(OriginAnchor.BodyPoint.FEET, Material.IRON_BOOTS, "Attacker Feet");
 
+        SimpleItem nextKf = new SimpleItem(
+            new ItemStackBuilder(Material.ARROW)
+                .name(Component.text("Nth Next Keyframe", NamedTextColor.YELLOW, TextDecoration.BOLD))
+                .lore(List.of(
+                    Component.text("Resolves to the keyframe N positions", NamedTextColor.DARK_GRAY),
+                    Component.text("after the owning keyframe.", NamedTextColor.DARK_GRAY),
+                    Component.text("Clamped to the last keyframe.", NamedTextColor.DARK_GRAY),
+                    Component.empty(),
+                    Component.text("Click to enter offset.", NamedTextColor.YELLOW)))
+                .build(),
+            click -> ChatInputCapture.prompt(
+                swordPlayer.player(),
+                Component.text("Enter offset (e.g. 1 = next kf, 2 = two after, ...):", NamedTextColor.YELLOW),
+                input -> {
+                    if (!input.equalsIgnoreCase("cancel")) {
+                        try {
+                            int offset = Integer.parseInt(input.trim());
+                            onPick.accept(OriginAnchor.nextKeyframe(offset));
+                        } catch (NumberFormatException ignored) { }
+                    }
+                    returnTo.run();
+                })
+        );
+
         List<Item> kfItems = new ArrayList<>();
         for (int i = 0; i < kfCount; i++) {
             final int idx = i;
@@ -119,11 +144,12 @@ public class OriginAnchorPickerMenu extends Menu {
 
         PagedGui<Item> gui = PagedGui.items()
             .setStructure(
-                "B . O R E C F . L",
+                "B K O R E C F . L",
                 "x x x x x x x x x",
                 "< # # # # # # # >")
             .addIngredient('#', BORDER)
             .addIngredient('B', back)
+            .addIngredient('K', nextKf)
             .addIngredient('O', owning)
             .addIngredient('R', raycastOriginButton)
             .addIngredient('E', bodyEye)

--- a/src/main/java/btm/sword/system/inventory/menu/dev/OriginAnchorPickerMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/OriginAnchorPickerMenu.java
@@ -25,9 +25,9 @@ import xyz.xenondevs.invui.window.Window;
 /**
  * Picker menu for selecting an {@link OriginAnchor}.
  *
- * <p>Presents the four anchor kinds: owning keyframe, fire-locked origin, three body
- * points on the attacker, and a paged list of keyframe indices. Picking any entry
- * calls the supplied {@link Consumer} with the chosen anchor and then runs the
+ * <p>Presents the five anchor kinds: owning keyframe, fire-locked origin, raycast origin,
+ * three body points on the attacker, and a paged list of keyframe indices. Picking any
+ * entry calls the supplied {@link Consumer} with the chosen anchor and then runs the
  * {@code returnTo} runnable to restore the previous screen.</p>
  */
 public class OriginAnchorPickerMenu extends Menu {
@@ -84,6 +84,20 @@ public class OriginAnchorPickerMenu extends Menu {
             }
         );
 
+        SimpleItem raycastOriginButton = new SimpleItem(
+            new ItemStackBuilder(Material.LEAD)
+                .name(Component.text("Raycast Origin", NamedTextColor.GREEN, TextDecoration.BOLD))
+                .lore(List.of(
+                    Component.text("Resolves to the ray start point of a", NamedTextColor.DARK_GRAY),
+                    Component.text("RAYCAST keyframe. Falls back to the", NamedTextColor.DARK_GRAY),
+                    Component.text("keyframe tip for other types.", NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> {
+                onPick.accept(OriginAnchor.raycastOrigin());
+                returnTo.run();
+            }
+        );
+
         SimpleItem bodyEye = bodyButton(OriginAnchor.BodyPoint.EYE, Material.ENDER_EYE, "Attacker Eye");
         SimpleItem bodyChest = bodyButton(OriginAnchor.BodyPoint.CHEST, Material.IRON_CHESTPLATE, "Attacker Chest");
         SimpleItem bodyFeet = bodyButton(OriginAnchor.BodyPoint.FEET, Material.IRON_BOOTS, "Attacker Feet");
@@ -105,12 +119,13 @@ public class OriginAnchorPickerMenu extends Menu {
 
         PagedGui<Item> gui = PagedGui.items()
             .setStructure(
-                "B . O . E C F . L",
+                "B . O R E C F . L",
                 "x x x x x x x x x",
                 "< # # # # # # # >")
             .addIngredient('#', BORDER)
             .addIngredient('B', back)
             .addIngredient('O', owning)
+            .addIngredient('R', raycastOriginButton)
             .addIngredient('E', bodyEye)
             .addIngredient('C', bodyChest)
             .addIngredient('F', bodyFeet)

--- a/src/main/java/btm/sword/system/inventory/menu/dev/ParticleDisplayEditorMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/ParticleDisplayEditorMenu.java
@@ -237,8 +237,8 @@ public class ParticleDisplayEditorMenu extends Menu {
                     open();
                 }));
                 builder.addIngredient('V', BORDER);
-                builder.addIngredient('B', BORDER);
-                builder.addIngredient('N', BORDER);
+                builder.addIngredient('B', back);
+                builder.addIngredient('N', save);
                 builder.addIngredient('<', back);
                 builder.addIngredient('>', save);
             }
@@ -272,7 +272,7 @@ public class ParticleDisplayEditorMenu extends Menu {
                     open();
                 }));
                 builder.addIngredient('Z', BORDER).addIngredient('X', BORDER).addIngredient('C', BORDER);
-                builder.addIngredient('V', BORDER).addIngredient('B', BORDER).addIngredient('N', BORDER);
+                builder.addIngredient('V', back).addIngredient('B', save).addIngredient('N', BORDER);
                 builder.addIngredient('<', back).addIngredient('>', save);
             }
             case CircleDisplay cd -> {
@@ -309,7 +309,7 @@ public class ParticleDisplayEditorMenu extends Menu {
                     open();
                 }));
                 builder.addIngredient('X', cycleNormal(cd));
-                builder.addIngredient('C', BORDER).addIngredient('V', BORDER).addIngredient('B', BORDER);
+                builder.addIngredient('C', BORDER).addIngredient('V', save).addIngredient('B', back);
                 builder.addIngredient('N', BORDER).addIngredient('<', back).addIngredient('>', save);
             }
             case null, default -> {
@@ -317,7 +317,7 @@ public class ParticleDisplayEditorMenu extends Menu {
                 builder.addIngredient('v', BORDER).addIngredient('b', BORDER).addIngredient('n', BORDER);
                 builder.addIngredient(',', BORDER);
                 builder.addIngredient('Z', BORDER).addIngredient('X', BORDER).addIngredient('C', BORDER);
-                builder.addIngredient('V', BORDER).addIngredient('B', BORDER).addIngredient('N', BORDER);
+                builder.addIngredient('V', save).addIngredient('B', back).addIngredient('N', BORDER);
                 builder.addIngredient('<', back).addIngredient('>', save);
             }
         }
@@ -398,6 +398,7 @@ public class ParticleDisplayEditorMenu extends Menu {
             case OriginAnchor.EntityBodyPoint ebp -> "Body " + ebp.point().name();
             case OriginAnchor.FireLockedOrigin ignored -> "Locked";
             case OriginAnchor.RaycastOrigin ignored -> "Ray Origin";
+            case OriginAnchor.NextKeyframe nk -> "Next KF +" + nk.offset();
         };
     }
 

--- a/src/main/java/btm/sword/system/inventory/menu/dev/ParticleDisplayEditorMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/ParticleDisplayEditorMenu.java
@@ -40,7 +40,6 @@ public class ParticleDisplayEditorMenu extends Menu {
 
     private final int kfIndex;
     private final int displayIndex;
-    private final List<Integer> extraKfTargets;
 
     /**
      * @param player       the player opening the editor
@@ -48,22 +47,9 @@ public class ParticleDisplayEditorMenu extends Menu {
      * @param displayIndex display index within the keyframe's display list
      */
     public ParticleDisplayEditorMenu(SwordPlayer player, int kfIndex, int displayIndex) {
-        this(player, kfIndex, displayIndex, List.of());
-    }
-
-    /**
-     * @param player         the player opening the editor
-     * @param kfIndex        keyframe index within the edit session
-     * @param displayIndex   display index within the keyframe's display list
-     * @param extraKfTargets additional keyframe indices to receive a copy of the final
-     *                       display when the player clicks Back (initial multi-kf creation)
-     */
-    public ParticleDisplayEditorMenu(SwordPlayer player, int kfIndex, int displayIndex,
-                                     List<Integer> extraKfTargets) {
         super(player);
         this.kfIndex = kfIndex;
         this.displayIndex = displayIndex;
-        this.extraKfTargets = extraKfTargets;
     }
 
     @Override
@@ -78,18 +64,7 @@ public class ParticleDisplayEditorMenu extends Menu {
         SimpleItem back = new SimpleItem(
             new ItemStackBuilder(Material.COPPER_TRAPDOOR)
                 .name(Component.text("Back", NamedTextColor.GRAY)).build(),
-            click -> {
-                if (!extraKfTargets.isEmpty()) {
-                    AttackDevSession s = AttackDevSession.getOrCreate(swordPlayer.player());
-                    ParticleDisplay snap = fetch(s);
-                    if (snap != null) {
-                        for (int idx : extraKfTargets) {
-                            s.addKeyframeDisplay(idx, snap.copy());
-                        }
-                    }
-                }
-                new KeyframeVisualsMenu(swordPlayer).open();
-            }
+            click -> new KeyframeVisualsMenu(swordPlayer).open()
         );
 
         SimpleItem save = new SimpleItem(
@@ -176,6 +151,8 @@ public class ParticleDisplayEditorMenu extends Menu {
         SimpleItem pdDec = dec(click -> { display.setRepeatPeriodTicks(Math.max(0, display.getRepeatPeriodTicks() - stepInt(click))); open(); });
         SimpleItem pdDisp = displayInt("Period", display.getRepeatPeriodTicks(), Material.CLOCK, v -> { display.setRepeatPeriodTicks(Math.max(0, v)); open(); });
         SimpleItem pdInc = inc(click -> { display.setRepeatPeriodTicks(display.getRepeatPeriodTicks() + stepInt(click)); open(); });
+        SimpleItem bkrItem = displayInt("BtwKf", display.getBetweenKfRepeat(), Material.HOPPER,
+            v -> { display.setBetweenKfRepeat(Math.max(0, v)); open(); });
 
         Gui.Builder<?, ?> builder = Gui.normal()
             .setStructure(
@@ -200,7 +177,7 @@ public class ParticleDisplayEditorMenu extends Menu {
             .addIngredient('u', rndZDec).addIngredient('i', rndZDisp).addIngredient('o', rndZInc)
             .addIngredient('R', rcDec).addIngredient('+', rcDisp).addIngredient('M', rcInc)
             .addIngredient('P', pdDec).addIngredient('p', pdDisp).addIngredient('m', pdInc)
-            .addIngredient('N', anchor).addIngredient('K', BORDER);
+            .addIngredient('N', anchor).addIngredient('K', bkrItem);
 
         addShapeRows(builder, display, back, save);
 

--- a/src/main/java/btm/sword/system/inventory/menu/dev/ParticleDisplayEditorMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/ParticleDisplayEditorMenu.java
@@ -371,6 +371,7 @@ public class ParticleDisplayEditorMenu extends Menu {
             case OriginAnchor.KeyframeIndex ki -> "KF #" + ki.index();
             case OriginAnchor.EntityBodyPoint ebp -> "Body " + ebp.point().name();
             case OriginAnchor.FireLockedOrigin ignored -> "Locked";
+            case OriginAnchor.RaycastOrigin ignored -> "Ray Origin";
         };
     }
 

--- a/src/main/java/btm/sword/system/inventory/menu/dev/ParticleDisplayEditorMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/ParticleDisplayEditorMenu.java
@@ -40,6 +40,7 @@ public class ParticleDisplayEditorMenu extends Menu {
 
     private final int kfIndex;
     private final int displayIndex;
+    private final List<Integer> extraKfTargets;
 
     /**
      * @param player       the player opening the editor
@@ -47,9 +48,22 @@ public class ParticleDisplayEditorMenu extends Menu {
      * @param displayIndex display index within the keyframe's display list
      */
     public ParticleDisplayEditorMenu(SwordPlayer player, int kfIndex, int displayIndex) {
+        this(player, kfIndex, displayIndex, List.of());
+    }
+
+    /**
+     * @param player         the player opening the editor
+     * @param kfIndex        keyframe index within the edit session
+     * @param displayIndex   display index within the keyframe's display list
+     * @param extraKfTargets additional keyframe indices to receive a copy of the final
+     *                       display when the player clicks Back (initial multi-kf creation)
+     */
+    public ParticleDisplayEditorMenu(SwordPlayer player, int kfIndex, int displayIndex,
+                                     List<Integer> extraKfTargets) {
         super(player);
         this.kfIndex = kfIndex;
         this.displayIndex = displayIndex;
+        this.extraKfTargets = extraKfTargets;
     }
 
     @Override
@@ -64,7 +78,18 @@ public class ParticleDisplayEditorMenu extends Menu {
         SimpleItem back = new SimpleItem(
             new ItemStackBuilder(Material.COPPER_TRAPDOOR)
                 .name(Component.text("Back", NamedTextColor.GRAY)).build(),
-            click -> new KeyframeVisualsMenu(swordPlayer).open()
+            click -> {
+                if (!extraKfTargets.isEmpty()) {
+                    AttackDevSession s = AttackDevSession.getOrCreate(swordPlayer.player());
+                    ParticleDisplay snap = fetch(s);
+                    if (snap != null) {
+                        for (int idx : extraKfTargets) {
+                            s.addKeyframeDisplay(idx, snap.copy());
+                        }
+                    }
+                }
+                new KeyframeVisualsMenu(swordPlayer).open();
+            }
         );
 
         SimpleItem save = new SimpleItem(

--- a/src/main/java/btm/sword/system/inventory/menu/dev/ParticleDisplayEditorMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/ParticleDisplayEditorMenu.java
@@ -1,11 +1,14 @@
 package btm.sword.system.inventory.menu.dev;
 
+import java.io.File;
 import java.util.List;
 import java.util.function.Consumer;
 
 import org.bukkit.Material;
 import org.joml.Vector3f;
 
+import btm.sword.Sword;
+import btm.sword.system.attack.def.ParticleDisplayLibrary;
 import btm.sword.system.attack.dev.AttackDevSession;
 import btm.sword.system.attack.visuals.CircleDisplay;
 import btm.sword.system.attack.visuals.LineDisplay;
@@ -16,6 +19,7 @@ import btm.sword.system.attack.visuals.SphereDisplay;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.item.ItemStackBuilder;
+import btm.sword.utility.ChatInputCapture;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -99,6 +103,26 @@ public class ParticleDisplayEditorMenu extends Menu {
             }
         );
 
+        SimpleItem saveToLibrary = new SimpleItem(
+            new ItemStackBuilder(Material.BOOKSHELF)
+                .name(Component.text("Save to Library", NamedTextColor.AQUA, TextDecoration.BOLD))
+                .lore(List.of(
+                    Component.text("Saves a copy of this display to particles.yml.", NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> ChatInputCapture.prompt(
+                swordPlayer.player(),
+                Component.text("Enter a name for this preset:", NamedTextColor.AQUA),
+                name -> {
+                    if (name.equalsIgnoreCase("cancel")) return;
+                    String key = name.trim().toLowerCase().replace(' ', '_');
+                    if (key.isEmpty()) return;
+                    ParticleDisplayLibrary.register(key, display,
+                        new File(Sword.getInstance().getDataFolder(), "particles.yml"));
+                    swordPlayer.message(Component.text(
+                        "[Dev] Saved preset '" + key + "' to particles.yml", NamedTextColor.GREEN));
+                })
+        );
+
         Vector3f off = display.getOriginOffset();
         SimpleItem offXDec = dec(click -> { off.x -= stepFloat(click); display.setOriginOffset(off); open(); });
         SimpleItem offXDisp = displayFloat("Off X", off.x, Material.RED_STAINED_GLASS, v -> { off.x = v; display.setOriginOffset(off); open(); });
@@ -141,7 +165,7 @@ public class ParticleDisplayEditorMenu extends Menu {
             .addIngredient('V', save)
             .addIngredient('I', info)
             .addIngredient('a', editParticles)
-            .addIngredient('c', BORDER)
+            .addIngredient('c', saveToLibrary)
             .addIngredient('D', deleteDisplay)
             .addIngredient('1', offXDec).addIngredient('2', offXDisp).addIngredient('3', offXInc)
             .addIngredient('4', offYDec).addIngredient('5', offYDisp).addIngredient('6', offYInc)

--- a/src/main/java/btm/sword/system/inventory/menu/dev/ParticleDisplayLibraryMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/ParticleDisplayLibraryMenu.java
@@ -12,7 +12,7 @@ import btm.sword.Sword;
 import btm.sword.system.attack.def.AttackRegistry;
 import btm.sword.system.attack.def.ParticleDisplayLibrary;
 import btm.sword.system.attack.dev.AttackDevSession;
-import btm.sword.system.attack.simulation.KeyframedTrajectory;
+import btm.sword.system.attack.simulation.KeyframedSequence;
 import btm.sword.system.attack.simulation.ParticleEffect;
 import btm.sword.system.attack.simulation.VolumeKeyframe;
 import btm.sword.system.attack.visuals.OriginAnchor;
@@ -160,8 +160,8 @@ public class ParticleDisplayLibraryMenu extends Menu {
         List<Item> items = new ArrayList<>();
         for (var def : AttackRegistry.getAll()) {
             if (def.getId().equals(currentId)) continue;
-            if (!(def.getTrajectory() instanceof KeyframedTrajectory kt)) continue;
-            List<DisplayEntry> found = collectFromKeyframes(kt.getKeyframes(), def.getId());
+            if (!(def.getTrajectory() instanceof KeyframedSequence kt)) continue;
+            List<DisplayEntry> found = collectFromKeyframes(kt.keyframes(), def.getId());
             for (DisplayEntry e : found) {
                 total++;
                 items.add(makeEntry(session, e, NamedTextColor.YELLOW));
@@ -268,6 +268,7 @@ public class ParticleDisplayLibraryMenu extends Menu {
             case OriginAnchor.EntityBodyPoint ebp -> "Body." + ebp.point().name();
             case OriginAnchor.FireLockedOrigin ignored -> "Locked";
             case OriginAnchor.RaycastOrigin ignored -> "RayOrigin";
+            case OriginAnchor.NextKeyframe nk -> "Next+" + nk.offset();
         };
     }
 

--- a/src/main/java/btm/sword/system/inventory/menu/dev/ParticleDisplayLibraryMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/ParticleDisplayLibraryMenu.java
@@ -1,8 +1,6 @@
 package btm.sword.system.inventory.menu.dev;
 
 import java.io.File;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -17,16 +15,14 @@ import btm.sword.system.attack.dev.AttackDevSession;
 import btm.sword.system.attack.simulation.KeyframedTrajectory;
 import btm.sword.system.attack.simulation.ParticleEffect;
 import btm.sword.system.attack.simulation.VolumeKeyframe;
+import btm.sword.system.attack.visuals.OriginAnchor;
 import btm.sword.system.attack.visuals.ParticleDisplay;
-import btm.sword.system.attack.visuals.PointDisplay;
 import btm.sword.system.entity.impl.SwordPlayer;
 import btm.sword.system.inventory.item.ForwardItem;
 import btm.sword.system.inventory.item.PreviousItem;
 import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.item.ItemStackBuilder;
 import btm.sword.utility.ChatInputCapture;
-import btm.sword.utility.Prefab;
-import btm.sword.utility.display.ParticleWrapper;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -92,7 +88,6 @@ public class ParticleDisplayLibraryMenu extends Menu {
         buildLibraryEntries(entries, session);
         buildCurrentAttackEntries(entries, session);
         buildOtherAttackEntries(entries, session);
-        buildPrefabEntries(entries, session);
 
         PagedGui<Item> gui = PagedGui.items()
             .setStructure(
@@ -177,35 +172,6 @@ public class ParticleDisplayLibraryMenu extends Menu {
         out.addAll(items);
     }
 
-    private void buildPrefabEntries(List<Item> out, AttackDevSession session) {
-        List<Item> items = new ArrayList<>();
-        for (Field field : Prefab.Particles.class.getDeclaredFields()) {
-            if (!Modifier.isStatic(field.getModifiers())) continue;
-            if (!Modifier.isFinal(field.getModifiers())) continue;
-            if (!ParticleWrapper.class.isAssignableFrom(field.getType())) continue;
-            try {
-                ParticleWrapper wrapper = (ParticleWrapper) field.get(null);
-                ParticleEffect effect = ParticleEffect.fromWrapper(wrapper);
-                PointDisplay starter = effect.toPointDisplay(null);
-                String name = field.getName();
-                List<Component> lore = buildDisplayLore(starter);
-                lore.add(Component.text("Particle: " + effect.type().name(), NamedTextColor.DARK_GRAY));
-                lore.add(Component.empty());
-                lore.add(Component.text("LEFT / SWAP: copy to keyframe + edit", NamedTextColor.YELLOW));
-                items.add(new SimpleItem(
-                    new ItemStackBuilder(Material.REDSTONE)
-                        .name(Component.text("⬡ " + name, NamedTextColor.GREEN, TextDecoration.BOLD))
-                        .lore(lore)
-                        .build(),
-                    click -> copyToKeyframeAndEdit(session, starter.copy())));
-            } catch (IllegalAccessException ignored) {
-                // skip inaccessible fields
-            }
-        }
-        if (items.isEmpty()) return;
-        out.add(sectionHeader("Prefab Starters  (" + items.size() + ")", Material.NETHER_STAR));
-        out.addAll(items);
-    }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
@@ -275,10 +241,34 @@ public class ParticleDisplayLibraryMenu extends Menu {
     private static List<Component> buildDisplayLore(ParticleDisplay d) {
         List<Component> lore = new ArrayList<>();
         lore.add(Component.text("Shape: " + d.shapeTypeLabel(), NamedTextColor.GRAY));
-        lore.add(Component.text("Particles: " + d.getParticles().size(), NamedTextColor.GRAY));
+        lore.add(Component.text("Anchor: " + anchorLabel(d.getAnchor()), NamedTextColor.GRAY));
+        lore.add(Component.text(String.format("Origin offset: %.2f / %.2f / %.2f",
+            d.getOriginOffset().x, d.getOriginOffset().y, d.getOriginOffset().z), NamedTextColor.DARK_GRAY));
+        lore.add(Component.text(String.format("Rand range:   %.2f / %.2f / %.2f",
+            d.getRandomOffsetRange().x, d.getRandomOffsetRange().y, d.getRandomOffsetRange().z), NamedTextColor.DARK_GRAY));
         lore.add(Component.text("Repeat: " + d.getRepeatCount()
             + " × " + d.getRepeatPeriodTicks() + "t", NamedTextColor.GRAY));
+        lore.add(Component.text("Particles: " + d.getParticles().size(), NamedTextColor.GRAY));
+        for (ParticleEffect pe : d.getParticles()) {
+            String dust = pe.dustOptions() != null
+                ? String.format(" dust:#%06X sz%.1f", pe.dustOptions().getColor().asRGB(), pe.dustOptions().getSize())
+                : "";
+            lore.add(Component.text(String.format("  %s ×%d spr(%.2f,%.2f,%.2f) spd%.2f%s",
+                pe.type().name(), pe.count(),
+                pe.spreadOffset().x, pe.spreadOffset().y, pe.spreadOffset().z,
+                pe.speed(), dust), NamedTextColor.DARK_GRAY));
+        }
         return lore;
+    }
+
+    private static String anchorLabel(OriginAnchor a) {
+        return switch (a) {
+            case OriginAnchor.OwningKeyframe ignored -> "Owning";
+            case OriginAnchor.KeyframeIndex ki -> "KF#" + ki.index();
+            case OriginAnchor.EntityBodyPoint ebp -> "Body." + ebp.point().name();
+            case OriginAnchor.FireLockedOrigin ignored -> "Locked";
+            case OriginAnchor.RaycastOrigin ignored -> "RayOrigin";
+        };
     }
 
     private static Material iconFor(ParticleDisplay d) {

--- a/src/main/java/btm/sword/system/inventory/menu/dev/ParticleDisplayLibraryMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/ParticleDisplayLibraryMenu.java
@@ -1,0 +1,292 @@
+package btm.sword.system.inventory.menu.dev;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.bukkit.Material;
+import org.bukkit.event.inventory.ClickType;
+
+import btm.sword.Sword;
+import btm.sword.system.attack.def.AttackRegistry;
+import btm.sword.system.attack.def.ParticleDisplayLibrary;
+import btm.sword.system.attack.dev.AttackDevSession;
+import btm.sword.system.attack.simulation.KeyframedTrajectory;
+import btm.sword.system.attack.simulation.ParticleEffect;
+import btm.sword.system.attack.simulation.VolumeKeyframe;
+import btm.sword.system.attack.visuals.ParticleDisplay;
+import btm.sword.system.attack.visuals.PointDisplay;
+import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.inventory.item.ForwardItem;
+import btm.sword.system.inventory.item.PreviousItem;
+import btm.sword.system.inventory.menu.Menu;
+import btm.sword.system.item.ItemStackBuilder;
+import btm.sword.utility.ChatInputCapture;
+import btm.sword.utility.Prefab;
+import btm.sword.utility.display.ParticleWrapper;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import xyz.xenondevs.invui.gui.PagedGui;
+import xyz.xenondevs.invui.gui.structure.Markers;
+import xyz.xenondevs.invui.item.Item;
+import xyz.xenondevs.invui.item.impl.SimpleItem;
+import xyz.xenondevs.invui.window.Window;
+
+/**
+ * Paged library picker for {@link ParticleDisplay} presets.
+ *
+ * <p>Aggregates four sources in order:
+ * <ol>
+ *   <li><b>Library presets</b> — named entries from {@code particles.yml} via
+ *       {@link ParticleDisplayLibrary}; can be deleted from this menu.</li>
+ *   <li><b>Current attack</b> — every display attached to any keyframe in the
+ *       active editing session.</li>
+ *   <li><b>Other registered attacks</b> — displays from all other attacks in
+ *       {@link AttackRegistry}.</li>
+ *   <li><b>Prefab starters</b> — static {@link ParticleWrapper} fields from
+ *       {@link Prefab.Particles} snapshotted as {@link PointDisplay}s.</li>
+ * </ol>
+ *
+ * <p>Left-click or SWAP copies the selected display to the current keyframe and
+ * opens {@link ParticleDisplayEditorMenu}. Library entries also support
+ * SHIFT+LEFT to delete from the library and save.</p>
+ */
+public class ParticleDisplayLibraryMenu extends Menu {
+
+    private final Runnable returnTo;
+
+    /**
+     * @param player   the player opening the menu
+     * @param returnTo called when the player clicks Back
+     */
+    public ParticleDisplayLibraryMenu(SwordPlayer player, Runnable returnTo) {
+        super(player);
+        this.returnTo = returnTo;
+    }
+
+    @Override
+    public void open() {
+        AttackDevSession session = AttackDevSession.getOrCreate(swordPlayer.player());
+
+        SimpleItem back = new SimpleItem(
+            new ItemStackBuilder(Material.COPPER_TRAPDOOR)
+                .name(Component.text("Back", NamedTextColor.GRAY))
+                .build(),
+            click -> returnTo.run());
+
+        SimpleItem saveNew = new SimpleItem(
+            new ItemStackBuilder(Material.WRITABLE_BOOK)
+                .name(Component.text("Save Current Display to Library", NamedTextColor.AQUA, TextDecoration.BOLD))
+                .lore(List.of(
+                    Component.text("Opens the current display editor to choose", NamedTextColor.DARK_GRAY),
+                    Component.text("a display, then prompts for a name.", NamedTextColor.DARK_GRAY),
+                    Component.empty(),
+                    Component.text("Or: use Save to Library inside the display editor.", NamedTextColor.GRAY)))
+                .build());
+
+        List<Item> entries = new ArrayList<>();
+        buildLibraryEntries(entries, session);
+        buildCurrentAttackEntries(entries, session);
+        buildOtherAttackEntries(entries, session);
+        buildPrefabEntries(entries, session);
+
+        PagedGui<Item> gui = PagedGui.items()
+            .setStructure(
+                "B . . . . . . . W",
+                "x x x x x x x x x",
+                "x x x x x x x x x",
+                "x x x x x x x x x",
+                "< # # # # # # # >")
+            .addIngredient('#', BORDER)
+            .addIngredient('B', back)
+            .addIngredient('W', saveNew)
+            .addIngredient('x', Markers.CONTENT_LIST_SLOT_HORIZONTAL)
+            .addIngredient('<', new PreviousItem())
+            .addIngredient('>', new ForwardItem())
+            .setContent(entries)
+            .build();
+
+        Window.single()
+            .setViewer(swordPlayer.player())
+            .setTitle("Particle Display Library")
+            .setGui(gui)
+            .build()
+            .open();
+    }
+
+    // ── Section builders ──────────────────────────────────────────────────────
+
+    private void buildLibraryEntries(List<Item> out, AttackDevSession session) {
+        Map<String, ParticleDisplay> presets = ParticleDisplayLibrary.getAll();
+        if (presets.isEmpty()) return;
+        out.add(sectionHeader("Library Presets  (" + presets.size() + ")", Material.BOOKSHELF));
+        for (Map.Entry<String, ParticleDisplay> entry : presets.entrySet()) {
+            String name = entry.getKey();
+            ParticleDisplay d = entry.getValue();
+            List<Component> lore = buildDisplayLore(d);
+            lore.add(Component.empty());
+            lore.add(Component.text("LEFT / SWAP: copy to keyframe + edit", NamedTextColor.YELLOW));
+            lore.add(Component.text("SHIFT+LEFT: remove from library", NamedTextColor.RED));
+            out.add(new SimpleItem(
+                new ItemStackBuilder(iconFor(d))
+                    .name(Component.text("⬡ " + name, NamedTextColor.AQUA, TextDecoration.BOLD))
+                    .lore(lore)
+                    .build(),
+                click -> {
+                    if (click.getClickType() == ClickType.SHIFT_LEFT) {
+                        ParticleDisplayLibrary.remove(name,
+                            new File(Sword.getInstance().getDataFolder(), "particles.yml"));
+                        open();
+                        return;
+                    }
+                    copyToKeyframeAndEdit(session, d.copy());
+                }));
+        }
+    }
+
+    private void buildCurrentAttackEntries(List<Item> out, AttackDevSession session) {
+        List<VolumeKeyframe> kfs = session.getEditKeyframes();
+        if (kfs == null) return;
+        List<DisplayEntry> found = collectFromKeyframes(kfs, session.getCurrentAttackName());
+        if (found.isEmpty()) return;
+        out.add(sectionHeader("Current Attack  (" + found.size() + ")", Material.BLAZE_POWDER));
+        for (DisplayEntry e : found) {
+            out.add(makeEntry(session, e, NamedTextColor.LIGHT_PURPLE));
+        }
+    }
+
+    private void buildOtherAttackEntries(List<Item> out, AttackDevSession session) {
+        String currentId = session.getCurrentAttackName();
+        int total = 0;
+        List<Item> items = new ArrayList<>();
+        for (var def : AttackRegistry.getAll()) {
+            if (def.getId().equals(currentId)) continue;
+            if (!(def.getTrajectory() instanceof KeyframedTrajectory kt)) continue;
+            List<DisplayEntry> found = collectFromKeyframes(kt.getKeyframes(), def.getId());
+            for (DisplayEntry e : found) {
+                total++;
+                items.add(makeEntry(session, e, NamedTextColor.YELLOW));
+            }
+        }
+        if (items.isEmpty()) return;
+        out.add(sectionHeader("Other Attacks  (" + total + ")", Material.BOOK));
+        out.addAll(items);
+    }
+
+    private void buildPrefabEntries(List<Item> out, AttackDevSession session) {
+        List<Item> items = new ArrayList<>();
+        for (Field field : Prefab.Particles.class.getDeclaredFields()) {
+            if (!Modifier.isStatic(field.getModifiers())) continue;
+            if (!Modifier.isFinal(field.getModifiers())) continue;
+            if (!ParticleWrapper.class.isAssignableFrom(field.getType())) continue;
+            try {
+                ParticleWrapper wrapper = (ParticleWrapper) field.get(null);
+                ParticleEffect effect = ParticleEffect.fromWrapper(wrapper);
+                PointDisplay starter = effect.toPointDisplay(null);
+                String name = field.getName();
+                List<Component> lore = buildDisplayLore(starter);
+                lore.add(Component.text("Particle: " + effect.type().name(), NamedTextColor.DARK_GRAY));
+                lore.add(Component.empty());
+                lore.add(Component.text("LEFT / SWAP: copy to keyframe + edit", NamedTextColor.YELLOW));
+                items.add(new SimpleItem(
+                    new ItemStackBuilder(Material.REDSTONE)
+                        .name(Component.text("⬡ " + name, NamedTextColor.GREEN, TextDecoration.BOLD))
+                        .lore(lore)
+                        .build(),
+                    click -> copyToKeyframeAndEdit(session, starter.copy())));
+            } catch (IllegalAccessException ignored) {
+                // skip inaccessible fields
+            }
+        }
+        if (items.isEmpty()) return;
+        out.add(sectionHeader("Prefab Starters  (" + items.size() + ")", Material.NETHER_STAR));
+        out.addAll(items);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private record DisplayEntry(ParticleDisplay display, String sourceName, int kfIndex) {}
+
+    private static List<DisplayEntry> collectFromKeyframes(List<VolumeKeyframe> kfs, String source) {
+        List<DisplayEntry> out = new ArrayList<>();
+        for (int i = 0; i < kfs.size(); i++) {
+            var effect = kfs.get(i).effect();
+            if (effect == null || effect.displays() == null) continue;
+            for (ParticleDisplay d : effect.displays()) {
+                out.add(new DisplayEntry(d, source, i));
+            }
+        }
+        return out;
+    }
+
+    private Item makeEntry(AttackDevSession session, DisplayEntry e, NamedTextColor nameColor) {
+        List<Component> lore = buildDisplayLore(e.display());
+        lore.add(Component.text("Source: " + e.sourceName() + "  KF#" + e.kfIndex(), NamedTextColor.DARK_GRAY));
+        lore.add(Component.empty());
+        lore.add(Component.text("LEFT / SWAP: copy to keyframe + edit", NamedTextColor.YELLOW));
+        lore.add(Component.text("SHIFT+LEFT: save copy to library", NamedTextColor.AQUA));
+        return new SimpleItem(
+            new ItemStackBuilder(iconFor(e.display()))
+                .name(Component.text("⬡ " + e.display().shapeTypeLabel(), nameColor, TextDecoration.BOLD))
+                .lore(lore)
+                .build(),
+            click -> {
+                if (click.getClickType() == ClickType.SHIFT_LEFT) {
+                    promptSaveToLibrary(e.display().copy());
+                    return;
+                }
+                copyToKeyframeAndEdit(session, e.display().copy());
+            });
+    }
+
+    private void copyToKeyframeAndEdit(AttackDevSession session, ParticleDisplay copy) {
+        int kfIdx = session.getCurrentKeyframeIndex();
+        session.addKeyframeDisplay(kfIdx, copy);
+        int newIndex = session.getEditKeyframes().get(kfIdx).effect().displays().size() - 1;
+        new ParticleDisplayEditorMenu(swordPlayer, kfIdx, newIndex).open();
+    }
+
+    private void promptSaveToLibrary(ParticleDisplay display) {
+        ChatInputCapture.prompt(
+            swordPlayer.player(),
+            Component.text("Enter a name for this preset:", NamedTextColor.AQUA),
+            name -> {
+                if (name.equalsIgnoreCase("cancel")) return;
+                String key = name.trim().toLowerCase().replace(' ', '_');
+                if (key.isEmpty()) return;
+                ParticleDisplayLibrary.register(key, display,
+                    new File(Sword.getInstance().getDataFolder(), "particles.yml"));
+                swordPlayer.message(Component.text(
+                    "[Dev] Saved preset '" + key + "' to particles.yml", NamedTextColor.GREEN));
+            });
+    }
+
+    private static Item sectionHeader(String label, Material mat) {
+        return new SimpleItem(
+            new ItemStackBuilder(mat)
+                .name(Component.text("── " + label + " ──", NamedTextColor.WHITE, TextDecoration.BOLD))
+                .build());
+    }
+
+    private static List<Component> buildDisplayLore(ParticleDisplay d) {
+        List<Component> lore = new ArrayList<>();
+        lore.add(Component.text("Shape: " + d.shapeTypeLabel(), NamedTextColor.GRAY));
+        lore.add(Component.text("Particles: " + d.getParticles().size(), NamedTextColor.GRAY));
+        lore.add(Component.text("Repeat: " + d.getRepeatCount()
+            + " × " + d.getRepeatPeriodTicks() + "t", NamedTextColor.GRAY));
+        return lore;
+    }
+
+    private static Material iconFor(ParticleDisplay d) {
+        return switch (d.shapeTypeLabel()) {
+            case "Line" -> Material.STICK;
+            case "Sphere" -> Material.SLIME_BALL;
+            case "Circle" -> Material.ENDER_PEARL;
+            default -> Material.REDSTONE;
+        };
+    }
+}

--- a/src/main/java/btm/sword/system/inventory/menu/dev/ParticleEffectEditorMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/ParticleEffectEditorMenu.java
@@ -1,13 +1,18 @@
 package btm.sword.system.inventory.menu.dev;
 
+import java.io.File;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
+import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.entity.Player;
 import org.joml.Vector3f;
 
+import btm.sword.Sword;
+import btm.sword.system.attack.def.ParticleDisplayLibrary;
 import btm.sword.system.attack.dev.AttackDevSession;
 import btm.sword.system.attack.simulation.ParticleEffect;
 import btm.sword.system.attack.visuals.ParticleDisplay;
@@ -16,8 +21,10 @@ import btm.sword.system.inventory.menu.EnumPickerOptions;
 import btm.sword.system.inventory.menu.EnumSelectionMenu;
 import btm.sword.system.inventory.menu.Menu;
 import btm.sword.system.item.ItemStackBuilder;
+import btm.sword.utility.ChatInputCapture;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import xyz.xenondevs.invui.gui.Gui;
 import xyz.xenondevs.invui.item.Click;
@@ -31,11 +38,15 @@ import xyz.xenondevs.invui.window.Window;
  * {@code particleIndex} with a new record instance. The display's list is mutated
  * in-place; no separate draft is kept at this level.</p>
  *
- * <p>Controls: particle type (click → picker), count, spawn-offset X/Y/Z, and speed.
- * Speed {@code &lt; 0} means "omit speed from the Bukkit call" (shown as DEFAULT).</p>
+ * <p>Controls: particle type (click → picker), count, spawn-offset X/Y/Z, speed, and
+ * dust colour/size controls shown only for {@link Particle#DUST} and
+ * {@link Particle#DUST_COLOR_TRANSITION} types.</p>
+ *
+ * <p>Speed {@code &lt; 0} means "omit speed from the Bukkit call" (shown as DEFAULT).</p>
  */
 public class ParticleEffectEditorMenu extends Menu {
 
+    private final Particle particleType;
     private final int kfIndex;
     private final int displayIndex;
     private final int particleIndex;
@@ -46,8 +57,9 @@ public class ParticleEffectEditorMenu extends Menu {
      * @param displayIndex  display index within the keyframe's display list
      * @param particleIndex index of the {@link ParticleEffect} within the display's list
      */
-    public ParticleEffectEditorMenu(SwordPlayer player, int kfIndex, int displayIndex, int particleIndex) {
+    public ParticleEffectEditorMenu(SwordPlayer player, Particle type, int kfIndex, int displayIndex, int particleIndex) {
         super(player);
+        this.particleType = type;
         this.kfIndex = kfIndex;
         this.displayIndex = displayIndex;
         this.particleIndex = particleIndex;
@@ -80,6 +92,28 @@ public class ParticleEffectEditorMenu extends Menu {
                 .build(),
             click -> AttackEditorMenu.saveAttack(
                 AttackDevSession.getOrCreate(swordPlayer.player()), swordPlayer)
+        );
+
+        SimpleItem addToPreset = new SimpleItem(
+            new ItemStackBuilder(Material.NETHER_STAR)
+                .name(Component.text("Add to Preset", NamedTextColor.AQUA, TextDecoration.BOLD))
+                .lore(List.of(Component.text("Save this particle as a display preset.", NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> {
+                ParticleEffect snapshot = display.getParticles().get(particleIndex);
+                ChatInputCapture.prompt(
+                    swordPlayer.player(),
+                    Component.text("Enter preset name (or 'cancel'):", NamedTextColor.AQUA),
+                    name -> {
+                        if (name.equalsIgnoreCase("cancel")) return;
+                        String key = name.trim().toLowerCase().replace(' ', '_');
+                        if (key.isEmpty()) return;
+                        ParticleDisplayLibrary.register(key, snapshot.toPointDisplay(null),
+                            new File(Sword.getInstance().getDataFolder(), "particles.yml"));
+                        swordPlayer.message(Component.text(
+                            "[Dev] Saved preset '" + key + "' to particles.yml", NamedTextColor.GREEN));
+                    });
+            }
         );
 
         SimpleItem typeButton = new SimpleItem(
@@ -171,16 +205,88 @@ public class ParticleEffectEditorMenu extends Menu {
         SimpleItem szInc = inc(click -> commit(display, pe, pe.type(), pe.count(),
             new Vector3f(so.x, so.y, so.z + stepFloat(click)), pe.speed()));
 
+        // ── Colour controls (DUST, DUST_COLOR_TRANSITION, ENTITY_EFFECT) ─────
+        boolean isDust = pe.type() == Particle.DUST;
+        boolean isTransition = pe.type() == Particle.DUST_COLOR_TRANSITION;
+        boolean isEntityEffect = pe.type() == Particle.ENTITY_EFFECT;
+        boolean hasDustColor = isDust || isTransition;
+
+        Color fromColor = pe.dustOptions() != null ? pe.dustOptions().getColor() : Color.WHITE;
+        Color toColor = (pe.dustOptions() instanceof Particle.DustTransition dt) ? dt.getToColor() : Color.WHITE;
+        float dustSize = pe.dustOptions() != null ? pe.dustOptions().getSize() : 1.0f;
+        Color entityCol = pe.entityColor() != null ? pe.entityColor() : Color.WHITE;
+
+        SimpleItem fromR = hasDustColor
+            ? colorChannel("From R", fromColor.getRed(), Material.RED_CONCRETE, fromColor,
+                v -> commitDust(display, pe, Color.fromRGB(clamp(v), fromColor.getGreen(), fromColor.getBlue()),
+                    toColor, dustSize, isTransition))
+            : isEntityEffect
+            ? colorChannel("R", entityCol.getRed(), Material.RED_CONCRETE, entityCol,
+                v -> commitEntityColor(display, pe, Color.fromRGB(clamp(v), entityCol.getGreen(), entityCol.getBlue())))
+            : EMPTY;
+        SimpleItem fromG = hasDustColor
+            ? colorChannel("From G", fromColor.getGreen(), Material.LIME_CONCRETE, fromColor,
+                v -> commitDust(display, pe, Color.fromRGB(fromColor.getRed(), clamp(v), fromColor.getBlue()),
+                    toColor, dustSize, isTransition))
+            : isEntityEffect
+            ? colorChannel("G", entityCol.getGreen(), Material.LIME_CONCRETE, entityCol,
+                v -> commitEntityColor(display, pe, Color.fromRGB(entityCol.getRed(), clamp(v), entityCol.getBlue())))
+            : EMPTY;
+        SimpleItem fromB = hasDustColor
+            ? colorChannel("From B", fromColor.getBlue(), Material.LIGHT_BLUE_CONCRETE, fromColor,
+                v -> commitDust(display, pe, Color.fromRGB(fromColor.getRed(), fromColor.getGreen(), clamp(v)),
+                    toColor, dustSize, isTransition))
+            : isEntityEffect
+            ? colorChannel("B", entityCol.getBlue(), Material.LIGHT_BLUE_CONCRETE, entityCol,
+                v -> commitEntityColor(display, pe, Color.fromRGB(entityCol.getRed(), entityCol.getGreen(), clamp(v))))
+            : EMPTY;
+
+        SimpleItem toR = isTransition
+            ? colorChannel("To R", toColor.getRed(), Material.RED_CONCRETE, toColor,
+                v -> commitDust(display, pe, fromColor,
+                    Color.fromRGB(clamp(v), toColor.getGreen(), toColor.getBlue()), dustSize, true))
+            : EMPTY;
+        SimpleItem toG = isTransition
+            ? colorChannel("To G", toColor.getGreen(), Material.LIME_CONCRETE, toColor,
+                v -> commitDust(display, pe, fromColor,
+                    Color.fromRGB(toColor.getRed(), clamp(v), toColor.getBlue()), dustSize, true))
+            : EMPTY;
+        SimpleItem toB = isTransition
+            ? colorChannel("To B", toColor.getBlue(), Material.LIGHT_BLUE_CONCRETE, toColor,
+                v -> commitDust(display, pe, fromColor,
+                    Color.fromRGB(toColor.getRed(), toColor.getGreen(), clamp(v)), dustSize, true))
+            : EMPTY;
+
+        SimpleItem sizeDec = hasDustColor
+            ? dec(click -> commitDust(display, pe, fromColor, toColor,
+                Math.max(0.01f, dustSize - stepFloat(click)), isTransition))
+            : EMPTY;
+        SimpleItem sizeDisp = hasDustColor
+            ? new SimpleItem(
+                new ItemStackBuilder(Material.PAPER)
+                    .name(Component.text("Size: ", NamedTextColor.GRAY)
+                        .append(Component.text(String.format("%.2f", dustSize), NamedTextColor.GOLD, TextDecoration.BOLD)))
+                    .lore(List.of(Component.text("Click to type a value.", NamedTextColor.DARK_GRAY)))
+                    .build(),
+                click -> openFloatAnvil("Dust Size", dustSize,
+                    v -> commitDust(display, pe, fromColor, toColor, Math.max(0.01f, v), isTransition),
+                    this::open))
+            : EMPTY;
+        SimpleItem sizeInc = hasDustColor
+            ? inc(click -> commitDust(display, pe, fromColor, toColor, dustSize + stepFloat(click), isTransition))
+            : EMPTY;
+
         Gui gui = Gui.normal()
             .setStructure(
-                "B . . . . . . V T",
+                "B # # # # # U V T",
                 ". 1 2 3 . 4 5 6 .",
                 ". q w e . r s t .",
                 ". a b c . . . . .",
-                ". . . . . . . . .",
-                ". . . . . . . . .")
-            .addIngredient('.', BORDER)
+                ". D E F . G H I .",
+                ". J K L . . . . .")
+            .addIngredient('#', BORDER)
             .addIngredient('B', back)
+            .addIngredient('U', addToPreset)
             .addIngredient('V', save)
             .addIngredient('T', typeButton)
             .addIngredient('1', cntDec).addIngredient('2', cntDisp).addIngredient('3', cntInc)
@@ -188,6 +294,9 @@ public class ParticleEffectEditorMenu extends Menu {
             .addIngredient('q', sxDec).addIngredient('w', sxDisp).addIngredient('e', sxInc)
             .addIngredient('r', syDec).addIngredient('s', syDisp).addIngredient('t', syInc)
             .addIngredient('a', szDec).addIngredient('b', szDisp).addIngredient('c', szInc)
+            .addIngredient('D', fromR).addIngredient('E', fromG).addIngredient('F', fromB)
+            .addIngredient('G', toR).addIngredient('H', toG).addIngredient('I', toB)
+            .addIngredient('J', sizeDec).addIngredient('K', sizeDisp).addIngredient('L', sizeInc)
             .build();
 
         Window.single()
@@ -203,14 +312,48 @@ public class ParticleEffectEditorMenu extends Menu {
     private void commit(ParticleDisplay display, ParticleEffect old,
                         Particle type, int count, Vector3f spreadOffset, double speed) {
         ParticleEffect updated = new ParticleEffect(type, count,
-            new Vector3f(spreadOffset), speed, old.dustOptions());
+            new Vector3f(spreadOffset), speed, old.dustOptions(), old.entityColor());
         display.getParticles().set(particleIndex, updated);
         open();
     }
 
+    private void commitDust(ParticleDisplay display, ParticleEffect pe,
+                            Color from, Color to, float size, boolean isTransition) {
+        Particle.DustOptions dust = isTransition
+            ? new Particle.DustTransition(from, to, size)
+            : new Particle.DustOptions(from, size);
+        ParticleEffect updated = new ParticleEffect(
+            pe.type(), pe.count(), new Vector3f(pe.spreadOffset()), pe.speed(), dust, null);
+        display.getParticles().set(particleIndex, updated);
+        open();
+    }
+
+    private void commitEntityColor(ParticleDisplay display, ParticleEffect pe, Color color) {
+        ParticleEffect updated = new ParticleEffect(
+            pe.type(), pe.count(), new Vector3f(pe.spreadOffset()), pe.speed(), null, color);
+        display.getParticles().set(particleIndex, updated);
+        open();
+    }
+
+    private SimpleItem colorChannel(String label, int current, Material mat, Color preview, Consumer<Integer> onCommit) {
+        return new SimpleItem(
+            new ItemStackBuilder(mat)
+                .name(Component.text(label + ": ", NamedTextColor.GRAY)
+                    .append(Component.text(String.valueOf(current), NamedTextColor.GOLD, TextDecoration.BOLD)))
+                .lore(List.of(
+                    Component.text("Click to type a value (0–255).", NamedTextColor.DARK_GRAY),
+                    Component.text("████████", TextColor.color(preview.getRed(), preview.getGreen(), preview.getBlue()))))
+                .build(),
+            click -> openIntAnvil(label, current, onCommit, this::open));
+    }
+
+    private static int clamp(int v) {
+        return Math.max(0, Math.min(255, v));
+    }
+
     private SimpleItem spreadField(String label, float current, Material mat,
                                    ParticleEffect pe, ParticleDisplay display,
-                                   java.util.function.Function<Float, Vector3f> spreadBuilder) {
+                                   Function<Float, Vector3f> spreadBuilder) {
         return new SimpleItem(
             new ItemStackBuilder(mat)
                 .name(Component.text(label + ": ", NamedTextColor.GRAY)

--- a/src/main/java/btm/sword/system/inventory/menu/dev/ParticleListMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/ParticleListMenu.java
@@ -126,7 +126,7 @@ public class ParticleListMenu extends Menu {
 
         PagedGui<Item> gui = PagedGui.items()
             .setStructure(
-                "B V I # # # X # A",
+                "B V I # A # X # #",
                 "x x x x x x x x x",
                 "x x x x x x x x x",
                 "x x x x x x x x x",

--- a/src/main/java/btm/sword/system/inventory/menu/dev/ParticleListMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/ParticleListMenu.java
@@ -107,6 +107,14 @@ public class ParticleListMenu extends Menu {
             ).open()
         );
 
+        SimpleItem fromPreset = new SimpleItem(
+            new ItemStackBuilder(Material.NETHER_STAR)
+                .name(Component.text("Add from Preset", NamedTextColor.AQUA, TextDecoration.BOLD))
+                .lore(List.of(Component.text("Pick a pre-configured particle effect.", NamedTextColor.DARK_GRAY)))
+                .build(),
+            click -> new ParticlePresetPickerMenu(swordPlayer, kfIndex, displayIndex).open()
+        );
+
         SimpleItem clearButton = new SimpleItem(
             new ItemStackBuilder(Material.BARRIER)
                 .name(Component.text("Clear All", NamedTextColor.RED, TextDecoration.BOLD))
@@ -126,7 +134,7 @@ public class ParticleListMenu extends Menu {
 
         PagedGui<Item> gui = PagedGui.items()
             .setStructure(
-                "B V I # A # X # #",
+                "B V I # A P X # #",
                 "x x x x x x x x x",
                 "x x x x x x x x x",
                 "x x x x x x x x x",
@@ -139,6 +147,7 @@ public class ParticleListMenu extends Menu {
             .addIngredient('I', info)
             .addIngredient('X', clearButton)
             .addIngredient('A', addButton)
+            .addIngredient('P', fromPreset)
             .addIngredient('<', new btm.sword.system.inventory.item.PreviousItem())
             .addIngredient('>', new btm.sword.system.inventory.item.ForwardItem())
             .setContent(items)

--- a/src/main/java/btm/sword/system/inventory/menu/dev/ParticleListMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/ParticleListMenu.java
@@ -7,6 +7,9 @@ import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3f;
 
 import btm.sword.system.attack.dev.AttackDevSession;
@@ -23,6 +26,7 @@ import net.kyori.adventure.text.format.TextDecoration;
 import xyz.xenondevs.invui.gui.PagedGui;
 import xyz.xenondevs.invui.gui.structure.Markers;
 import xyz.xenondevs.invui.item.Item;
+import xyz.xenondevs.invui.item.impl.AbstractItem;
 import xyz.xenondevs.invui.item.impl.SimpleItem;
 import xyz.xenondevs.invui.window.Window;
 
@@ -97,7 +101,7 @@ public class ParticleListMenu extends Menu {
                 () -> Particle.CRIT,
                 chosen -> {
                     List<ParticleEffect> updated = new ArrayList<>(display.getParticles());
-                    updated.add(new ParticleEffect(chosen, 1, new Vector3f(0.2f, 0.2f, 0.2f), -1.0, null));
+                    updated.add(new ParticleEffect(chosen, 1, new Vector3f(0.2f, 0.2f, 0.2f), -1.0, null, null));
                     display.setParticles(updated);
                 },
                 this::open,
@@ -166,7 +170,7 @@ public class ParticleListMenu extends Menu {
         Vector3f so = pe.spreadOffset();
         String speedLabel = pe.speed() < 0 ? "default" : String.format("%.2f", pe.speed());
 
-        return new xyz.xenondevs.invui.item.impl.AbstractItem() {
+        return new AbstractItem() {
             @Override
             public xyz.xenondevs.invui.item.ItemProvider getItemProvider() {
                 return new xyz.xenondevs.invui.item.ItemWrapper(
@@ -184,16 +188,16 @@ public class ParticleListMenu extends Menu {
             }
 
             @Override
-            public void handleClick(org.bukkit.event.inventory.@org.jetbrains.annotations.NotNull ClickType clickType,
-                                    org.bukkit.entity.@org.jetbrains.annotations.NotNull Player p,
-                                    org.bukkit.event.inventory.@org.jetbrains.annotations.NotNull InventoryClickEvent event) {
-                if (clickType == org.bukkit.event.inventory.ClickType.SHIFT_LEFT) {
+            public void handleClick(@NotNull ClickType clickType,
+                                    @NotNull Player p,
+                                    @NotNull InventoryClickEvent event) {
+                if (clickType == ClickType.SHIFT_LEFT) {
                     List<ParticleEffect> updated = new ArrayList<>(display.getParticles());
                     updated.remove(idx);
                     display.setParticles(updated);
                     open();
                 } else {
-                    new ParticleEffectEditorMenu(swordPlayer, kfIndex, displayIndex, idx).open();
+                    new ParticleEffectEditorMenu(swordPlayer, pe.getType(), kfIndex, displayIndex, idx).open();
                 }
             }
         };

--- a/src/main/java/btm/sword/system/inventory/menu/dev/ParticlePresetPickerMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/ParticlePresetPickerMenu.java
@@ -1,0 +1,179 @@
+package btm.sword.system.inventory.menu.dev;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.bukkit.Material;
+import org.bukkit.Particle;
+
+import btm.sword.system.attack.dev.AttackDevSession;
+import btm.sword.system.attack.simulation.ParticleEffect;
+import btm.sword.system.attack.visuals.ParticleDisplay;
+import btm.sword.system.entity.impl.SwordPlayer;
+import btm.sword.system.inventory.item.ForwardItem;
+import btm.sword.system.inventory.item.PreviousItem;
+import btm.sword.system.inventory.menu.Menu;
+import btm.sword.system.item.ItemStackBuilder;
+import btm.sword.utility.Prefab;
+import btm.sword.utility.display.ParticleWrapper;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import xyz.xenondevs.invui.gui.PagedGui;
+import xyz.xenondevs.invui.gui.structure.Markers;
+import xyz.xenondevs.invui.item.Item;
+import xyz.xenondevs.invui.item.impl.SimpleItem;
+import xyz.xenondevs.invui.window.Window;
+
+/**
+ * Paged preset picker for individual {@link ParticleEffect}s.
+ *
+ * <p>Loads all static {@link ParticleWrapper} fields from {@link Prefab.Particles},
+ * converts each to a {@link ParticleEffect} snapshot, deduplicates by content, and
+ * presents them as clickable entries. Clicking an entry appends the effect to the
+ * target display's particle list and returns to {@link ParticleListMenu}.</p>
+ */
+public class ParticlePresetPickerMenu extends Menu {
+
+    private final int kfIndex;
+    private final int displayIndex;
+
+    /**
+     * @param player       the player opening the menu
+     * @param kfIndex      keyframe index within the edit session
+     * @param displayIndex display index within the keyframe's display list
+     */
+    public ParticlePresetPickerMenu(SwordPlayer player, int kfIndex, int displayIndex) {
+        super(player);
+        this.kfIndex = kfIndex;
+        this.displayIndex = displayIndex;
+    }
+
+    @Override
+    public void open() {
+        AttackDevSession session = AttackDevSession.getOrCreate(swordPlayer.player());
+        ParticleDisplay display = fetch(session);
+        if (display == null) {
+            new ParticleDisplayEditorMenu(swordPlayer, kfIndex, displayIndex).open();
+            return;
+        }
+
+        SimpleItem back = new SimpleItem(
+            new ItemStackBuilder(Material.COPPER_TRAPDOOR)
+                .name(Component.text("Back", NamedTextColor.GRAY))
+                .build(),
+            click -> new ParticleListMenu(swordPlayer, kfIndex, displayIndex).open()
+        );
+
+        List<Item> entries = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+
+        for (Field field : Prefab.Particles.class.getDeclaredFields()) {
+            if (!Modifier.isStatic(field.getModifiers())) continue;
+            if (!Modifier.isFinal(field.getModifiers())) continue;
+            if (!ParticleWrapper.class.isAssignableFrom(field.getType())) continue;
+            try {
+                ParticleWrapper wrapper = (ParticleWrapper) field.get(null);
+                ParticleEffect effect = ParticleEffect.fromWrapper(wrapper);
+                String key = dedupKey(effect);
+                if (!seen.add(key)) continue;
+
+                String fieldName = field.getName();
+                List<Component> lore = buildEffectLore(effect);
+                lore.add(Component.empty());
+                lore.add(Component.text("Click to add to this display.", NamedTextColor.YELLOW));
+
+                entries.add(new SimpleItem(
+                    new ItemStackBuilder(iconFor(effect.type()))
+                        .name(Component.text(fieldName, NamedTextColor.AQUA, TextDecoration.BOLD))
+                        .lore(lore)
+                        .build(),
+                    click -> {
+                        display.getParticles().add(effect);
+                        new ParticleListMenu(swordPlayer, kfIndex, displayIndex).open();
+                    }
+                ));
+            } catch (IllegalAccessException ignored) {
+                // skip inaccessible fields
+            }
+        }
+
+        PagedGui<Item> gui = PagedGui.items()
+            .setStructure(
+                "B . . . . . . . .",
+                "x x x x x x x x x",
+                "x x x x x x x x x",
+                "x x x x x x x x x",
+                "< # # # # # # # >")
+            .addIngredient('#', BORDER)
+            .addIngredient('.', BORDER)
+            .addIngredient('B', back)
+            .addIngredient('x', Markers.CONTENT_LIST_SLOT_HORIZONTAL)
+            .addIngredient('<', new PreviousItem())
+            .addIngredient('>', new ForwardItem())
+            .setContent(entries)
+            .build();
+
+        Window.single()
+            .setViewer(swordPlayer.player())
+            .setTitle("Particle Presets")
+            .setGui(gui)
+            .build()
+            .open();
+    }
+
+    private ParticleDisplay fetch(AttackDevSession session) {
+        if (session.getEditKeyframes() == null
+                || kfIndex < 0
+                || kfIndex >= session.getEditKeyframes().size()) return null;
+        var effect = session.getEditKeyframes().get(kfIndex).effect();
+        if (effect == null || effect.displays() == null) return null;
+        if (displayIndex < 0 || displayIndex >= effect.displays().size()) return null;
+        return effect.displays().get(displayIndex);
+    }
+
+    private static String dedupKey(ParticleEffect e) {
+        String dust = e.dustOptions() != null
+            ? e.dustOptions().getColor().asRGB() + "_" + e.dustOptions().getSize()
+            : "null";
+        return e.type().name() + "|" + e.count()
+            + "|" + e.spreadOffset().x + "," + e.spreadOffset().y + "," + e.spreadOffset().z
+            + "|" + e.speed()
+            + "|" + dust;
+    }
+
+    private static List<Component> buildEffectLore(ParticleEffect e) {
+        List<Component> lore = new ArrayList<>();
+        lore.add(Component.text("Type: " + e.type().name(), NamedTextColor.GRAY));
+        lore.add(Component.text("Count: " + e.count(), NamedTextColor.GRAY));
+        lore.add(Component.text(String.format("Spread: %.2f / %.2f / %.2f",
+            e.spreadOffset().x, e.spreadOffset().y, e.spreadOffset().z), NamedTextColor.GRAY));
+        String speedLabel = e.speed() < 0 ? "default" : String.format("%.2f", e.speed());
+        lore.add(Component.text("Speed: " + speedLabel, NamedTextColor.GRAY));
+        if (e.dustOptions() != null) {
+            lore.add(Component.text(String.format("Dust: #%06X  size %.1f",
+                e.dustOptions().getColor().asRGB(), e.dustOptions().getSize()), NamedTextColor.DARK_GRAY));
+        }
+        return lore;
+    }
+
+    private static Material iconFor(Particle p) {
+        String n = p.name();
+        if (n.contains("FLAME") || n.contains("FIRE")) return Material.FLINT_AND_STEEL;
+        if (n.contains("SMOKE") || n.contains("CLOUD") || n.contains("POOF")) return Material.COAL;
+        if (n.contains("CRIT") || n.contains("ENCHANTED_HIT")) return Material.DIAMOND_SWORD;
+        if (n.contains("ENCHANT")) return Material.ENCHANTED_BOOK;
+        if (n.contains("DUST") || n.contains("REDSTONE")) return Material.REDSTONE;
+        if (n.contains("SOUL")) return Material.SOUL_SAND;
+        if (n.contains("PORTAL")) return Material.ENDER_EYE;
+        if (n.contains("LAVA")) return Material.LAVA_BUCKET;
+        if (n.contains("HEART")) return Material.PINK_DYE;
+        if (n.contains("GUST") || n.contains("WIND")) return Material.FEATHER;
+        if (n.contains("FLASH")) return Material.GLOWSTONE_DUST;
+        return Material.FIREWORK_STAR;
+    }
+}

--- a/src/main/java/btm/sword/system/inventory/menu/dev/TogglesMenu.java
+++ b/src/main/java/btm/sword/system/inventory/menu/dev/TogglesMenu.java
@@ -151,6 +151,18 @@ public class TogglesMenu extends Menu {
             () -> Config.Debug.LOGGING_VERBOSE_ATTACK_VOLUME = !Config.Debug.LOGGING_VERBOSE_ATTACK_VOLUME
         );
 
+        SimpleItem verboseParticleDisplay = toggle(
+            "Particle Display (toWrapper)",
+            () -> Config.Debug.LOGGING_VERBOSE_PARTICLE_DISPLAY,
+            () -> Config.Debug.LOGGING_VERBOSE_PARTICLE_DISPLAY = !Config.Debug.LOGGING_VERBOSE_PARTICLE_DISPLAY
+        );
+
+        SimpleItem showHitboxes = toggle(
+            "Hitbox Outlines (live attacks)",
+            () -> Config.Debug.VISUALIZATION_SHOW_HITBOXES,
+            () -> Config.Debug.VISUALIZATION_SHOW_HITBOXES = !Config.Debug.VISUALIZATION_SHOW_HITBOXES
+        );
+
         @SuppressWarnings("unchecked")
         Config.ConfigEntry<Boolean> skipLoadEntry = (Config.ConfigEntry<Boolean>) Config.ENTRIES.stream()
             .filter(e -> e.path().equals("debug.skip_data_load"))
@@ -211,7 +223,7 @@ public class TogglesMenu extends Menu {
                 ". A B C D E P Q .",
                 ". F G H I J K R .",
                 ". S T U L M N O .",
-                ". V . . . . . . .",
+                ". V W X . . . . .",
                 "< # # # # # # # #")
             .addIngredient('#', BORDER)
             .addIngredient('A', verboseDebug)
@@ -236,6 +248,8 @@ public class TogglesMenu extends Menu {
             .addIngredient('N', freshProfile)
             .addIngredient('O', resetJoin)
             .addIngredient('V', verboseAttackVolume)
+            .addIngredient('W', verboseParticleDisplay)
+            .addIngredient('X', showHitboxes)
             .addIngredient('<', generatePreviousButtonOrDefault())
             .build();
 

--- a/src/main/java/btm/sword/system/item/KeyRegistry.java
+++ b/src/main/java/btm/sword/system/item/KeyRegistry.java
@@ -208,6 +208,12 @@ public final class KeyRegistry {
     /** Cached {@link NamespacedKey} for {@link #TEST_VOLUME_ATTACK}. */
     public static final NamespacedKey TEST_VOLUME_ATTACK_KEY = key(TEST_VOLUME_ATTACK);
 
+    /** Persistent data key marking an item as the UmbralBlade lifecycle dev tester. */
+    public static final String UMBRAL_BLADE_TESTER = "umbral_blade_tester";
+
+    /** Cached {@link NamespacedKey} for {@link #UMBRAL_BLADE_TESTER}. */
+    public static final NamespacedKey UMBRAL_BLADE_TESTER_KEY = key(UMBRAL_BLADE_TESTER);
+
     // ------------------------------
     //  Utility Methods
     // ------------------------------

--- a/src/main/java/btm/sword/utility/Debug.java
+++ b/src/main/java/btm/sword/utility/Debug.java
@@ -122,6 +122,11 @@ public final class Debug {
         emit(Config.Debug.LOGGING_VERBOSE_UMBRAL, "Umbral", message);
     }
 
+    /** UmbralBlade FSM transition + lifecycle debug. Gated by {@link Config.Debug#LOGGING_VERBOSE_UMBRAL_STATES}. */
+    public static void umbralStates(String message) {
+        emit(Config.Debug.LOGGING_VERBOSE_UMBRAL_STATES, "UmbralStates", message);
+    }
+
     /** Hostile-entity debug. Gated by {@link Config.Debug#LOGGING_VERBOSE_HOSTILE}. */
     public static void hostile(String message) {
         emit(Config.Debug.LOGGING_VERBOSE_HOSTILE, "Hostile", message);

--- a/src/main/java/btm/sword/utility/Debug.java
+++ b/src/main/java/btm/sword/utility/Debug.java
@@ -172,6 +172,11 @@ public final class Debug {
         emit(Config.Debug.LOGGING_VERBOSE_ATTACK_VOLUME, "AttackVolume", message);
     }
 
+    /** ParticleEffect → ParticleWrapper conversion debug (type, dustOptions, dispatch path). Gated by {@link Config.Debug#LOGGING_VERBOSE_PARTICLE_DISPLAY}. */
+    public static void particleDisplay(String message) {
+        emit(Config.Debug.LOGGING_VERBOSE_PARTICLE_DISPLAY, "ParticleDisplay", message);
+    }
+
     // =========================================================================
     // Visual helpers
     // =========================================================================

--- a/src/main/java/btm/sword/utility/Prefab.java
+++ b/src/main/java/btm/sword/utility/Prefab.java
@@ -388,6 +388,29 @@ public final class Prefab {
                 .tag(KeyRegistry.TEST_VOLUME_ATTACK_KEY, PersistentDataType.BOOLEAN, true)
                 .build();
         }
+
+        /**
+         * Builds an UmbralBlade lifecycle dev tester — a breeze rod tagged with
+         * {@link KeyRegistry#UMBRAL_BLADE_TESTER_KEY}. Left click destroys the blade
+         * (deactivate); drop respawns it (activate).
+         *
+         * @return a new ItemStack ready to give to a player
+         */
+        public static ItemStack umbralBladeTester() {
+            return new ItemStackBuilder(Material.BREEZE_ROD)
+                .name(Component.text("✦ Umbral Blade Tester", NamedTextColor.LIGHT_PURPLE, TextDecoration.BOLD))
+                .lore(List.of(
+                    Component.text("Dev lifecycle tester", NamedTextColor.DARK_GRAY).decorate(TextDecoration.ITALIC),
+                    Component.empty(),
+                    Component.text("Left click  ", NamedTextColor.YELLOW)
+                        .append(Component.text("— destroy blade (deactivate)", NamedTextColor.GRAY)),
+                    Component.text("Drop        ", NamedTextColor.YELLOW)
+                        .append(Component.text("— respawn blade (activate)", NamedTextColor.GRAY))
+                ))
+                .unbreakable(true)
+                .tag(KeyRegistry.UMBRAL_BLADE_TESTER_KEY, PersistentDataType.BOOLEAN, true)
+                .build();
+        }
     }
 
     public static final Material[] MODERN_MATERIALS = {

--- a/src/main/java/btm/sword/utility/display/DisplayUtil.java
+++ b/src/main/java/btm/sword/utility/display/DisplayUtil.java
@@ -202,7 +202,11 @@ public final class DisplayUtil {
             null,
             null,
             0, period,
-            DisplayUtil.class, "itemDisplayFollow (2)"
+            DisplayUtil.class, "itemDisplayFollowLerp",
+            new PredicateRunnablePair(
+                () -> !entity.self().isValid() || display.isDead() || !display.isValid(),
+                null
+            )
         );
     }
 

--- a/src/main/java/btm/sword/utility/display/ObbWireframe.java
+++ b/src/main/java/btm/sword/utility/display/ObbWireframe.java
@@ -1,0 +1,128 @@
+package btm.sword.utility.display;
+
+import org.bukkit.Particle;
+import org.bukkit.World;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+
+/**
+ * Renders an OBB (Oriented Bounding Box) as a particle wireframe on the main thread.
+ *
+ * <p>Used by both the dev-mode {@code VolumeEditorMode} and the live
+ * {@code VolumeSimulation} hitbox-outline visualization.</p>
+ */
+public final class ObbWireframe {
+
+    private static final float EDGE_SPACING = 0.18f;
+    private static final int SPHERE_SEGMENTS = 16;
+
+    private ObbWireframe() {}
+
+    /**
+     * Renders the 12 edges of an OBB as a dust-particle wireframe.
+     *
+     * @param world       world to spawn particles in
+     * @param center      world-space OBB centre
+     * @param halfExtents OBB half-extents along its local axes
+     * @param rotation    OBB orientation as a unit quaternion
+     * @param dust        colour/size to use for the dust particles
+     * @return total particle spawn calls made
+     */
+    public static int renderObb(World world, Vector3f center, Vector3f halfExtents,
+            Quaternionf rotation, Particle.DustOptions dust) {
+        Vector3f ax = rotation.transform(new Vector3f(halfExtents.x, 0, 0), new Vector3f());
+        Vector3f ay = rotation.transform(new Vector3f(0, halfExtents.y, 0), new Vector3f());
+        Vector3f az = rotation.transform(new Vector3f(0, 0, halfExtents.z), new Vector3f());
+
+        Vector3f[] corners = new Vector3f[8];
+        for (int i = 0; i < 8; i++) {
+            float sx = (i & 1) != 0 ? 1f : -1f;
+            float sy = (i & 2) != 0 ? 1f : -1f;
+            float sz = (i & 4) != 0 ? 1f : -1f;
+            corners[i] = new Vector3f(center)
+                .add(ax.x * sx, ax.y * sx, ax.z * sx)
+                .add(ay.x * sy, ay.y * sy, ay.z * sy)
+                .add(az.x * sz, az.y * sz, az.z * sz);
+        }
+
+        int count = 0;
+        count += drawEdge(world, corners[0], corners[1], dust);
+        count += drawEdge(world, corners[2], corners[3], dust);
+        count += drawEdge(world, corners[4], corners[5], dust);
+        count += drawEdge(world, corners[6], corners[7], dust);
+        count += drawEdge(world, corners[0], corners[2], dust);
+        count += drawEdge(world, corners[1], corners[3], dust);
+        count += drawEdge(world, corners[4], corners[6], dust);
+        count += drawEdge(world, corners[5], corners[7], dust);
+        count += drawEdge(world, corners[0], corners[4], dust);
+        count += drawEdge(world, corners[1], corners[5], dust);
+        count += drawEdge(world, corners[2], corners[6], dust);
+        count += drawEdge(world, corners[3], corners[7], dust);
+        return count;
+    }
+
+    /**
+     * Renders three orthogonal great circles to represent a sphere.
+     *
+     * @param world  world to spawn particles in
+     * @param center world-space sphere centre
+     * @param radius sphere radius
+     * @param dust   colour/size to use for the dust particles
+     * @return total particle spawn calls made
+     */
+    public static int renderSphere(World world, Vector3f center, float radius,
+            Particle.DustOptions dust) {
+        int count = 0;
+        for (int ring = 0; ring < 3; ring++) {
+            for (int i = 0; i < SPHERE_SEGMENTS; i++) {
+                float a0 = (float) (2 * Math.PI * i / SPHERE_SEGMENTS);
+                float a1 = (float) (2 * Math.PI * (i + 1) / SPHERE_SEGMENTS);
+                float cos0 = (float) Math.cos(a0);
+                float sin0 = (float) Math.sin(a0);
+                float cos1 = (float) Math.cos(a1);
+                float sin1 = (float) Math.sin(a1);
+                Vector3f p0;
+                Vector3f p1;
+                if (ring == 0) {
+                    p0 = new Vector3f(center.x + radius * cos0, center.y, center.z + radius * sin0);
+                    p1 = new Vector3f(center.x + radius * cos1, center.y, center.z + radius * sin1);
+                } else if (ring == 1) {
+                    p0 = new Vector3f(center.x + radius * cos0, center.y + radius * sin0, center.z);
+                    p1 = new Vector3f(center.x + radius * cos1, center.y + radius * sin1, center.z);
+                } else {
+                    p0 = new Vector3f(center.x, center.y + radius * sin0, center.z + radius * cos0);
+                    p1 = new Vector3f(center.x, center.y + radius * sin1, center.z + radius * cos1);
+                }
+                count += drawEdge(world, p0, p1, dust);
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Draws a single edge between two world-space points using evenly-spaced dust particles.
+     *
+     * @param world world to spawn particles in
+     * @param a     start point
+     * @param b     end point
+     * @param dust  colour/size to use
+     * @return number of particle spawn calls made
+     */
+    public static int drawEdge(World world, Vector3f a, Vector3f b, Particle.DustOptions dust) {
+        float dx = b.x - a.x;
+        float dy = b.y - a.y;
+        float dz = b.z - a.z;
+        float len = (float) Math.sqrt(dx * dx + dy * dy + dz * dz);
+        if (len < 1e-4f) return 0;
+        int steps = Math.max(1, (int) (len / EDGE_SPACING));
+        float sx = dx / steps;
+        float sy = dy / steps;
+        float sz = dz / steps;
+        for (int i = 0; i <= steps; i++) {
+            world.spawnParticle(Particle.DUST,
+                a.x + sx * i, a.y + sy * i, a.z + sz * i,
+                1, 0, 0, 0, 0, dust);
+        }
+        return steps + 1;
+    }
+}

--- a/src/main/java/btm/sword/utility/display/ParticleWrapper.java
+++ b/src/main/java/btm/sword/utility/display/ParticleWrapper.java
@@ -129,6 +129,29 @@ public class ParticleWrapper {
         return this;
     }
 
+    // ── Snapshot getters (call suppliers once, used for serialization) ──────
+
+    /** Returns the current particle type by calling the supplier. */
+    public Particle getParticle() { return particle.get(); }
+
+    /** Returns the current particle count by calling the supplier. */
+    public int getCount() { return count.get(); }
+
+    /** Returns the current X-axis spawn offset by calling the supplier. */
+    public double getXOffset() { return xOffset.get(); }
+
+    /** Returns the current Y-axis spawn offset by calling the supplier. */
+    public double getYOffset() { return yOffset.get(); }
+
+    /** Returns the current Z-axis spawn offset by calling the supplier. */
+    public double getZOffset() { return zOffset.get(); }
+
+    /** Returns the current speed by calling the supplier. */
+    public double getSpeed() { return speed.get(); }
+
+    /** Returns the current dust options by calling the supplier, or {@code null} if none. */
+    public Particle.DustOptions getDustOptions() { return options.get(); }
+
     /**
      * Displays the particle effect at the specified location in the world.
      * Suppliers are evaluated at display time, enabling runtime-resolved values.

--- a/src/main/java/btm/sword/utility/display/ParticleWrapper.java
+++ b/src/main/java/btm/sword/utility/display/ParticleWrapper.java
@@ -152,6 +152,9 @@ public class ParticleWrapper {
     /** Returns the current dust options by calling the supplier, or {@code null} if none. */
     public Particle.DustOptions getDustOptions() { return options.get(); }
 
+    /** Returns the current dust transition by calling the supplier, or {@code null} if none. */
+    public Particle.DustTransition getDustTransition() { return transition.get(); }
+
     /**
      * Displays the particle effect at the specified location in the world.
      * Suppliers are evaluated at display time, enabling runtime-resolved values.

--- a/src/main/java/btm/sword/utility/display/ParticleWrapper.java
+++ b/src/main/java/btm/sword/utility/display/ParticleWrapper.java
@@ -3,6 +3,7 @@ package btm.sword.utility.display;
 import java.util.Collection;
 import java.util.function.Supplier;
 
+import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.World;
@@ -55,6 +56,9 @@ public class ParticleWrapper {
 
     /** Supplier for block data used with block crack or block dust particle types, if applicable. */
     private Supplier<BlockData> blockData = () -> null;
+
+    /** Supplier for a direct colour applied to {@link Particle#ENTITY_EFFECT}; {@code null} otherwise. */
+    private Supplier<Color> entityColor = () -> null;
 
     /**
      * Constructs a ParticleWrapper with only a particle type supplier and default parameters.
@@ -129,6 +133,17 @@ public class ParticleWrapper {
         return this;
     }
 
+    /**
+     * Sets the entity colour supplier for {@link Particle#ENTITY_EFFECT} and returns {@code this}.
+     *
+     * @param entityColor supplier for the colour to pass as extra particle data
+     * @return this instance
+     */
+    public ParticleWrapper withEntityColor(Supplier<Color> entityColor) {
+        this.entityColor = entityColor;
+        return this;
+    }
+
     // ── Snapshot getters (call suppliers once, used for serialization) ──────
 
     /** Returns the current particle type by calling the supplier. */
@@ -155,6 +170,9 @@ public class ParticleWrapper {
     /** Returns the current dust transition by calling the supplier, or {@code null} if none. */
     public Particle.DustTransition getDustTransition() { return transition.get(); }
 
+    /** Returns the current entity colour by calling the supplier, or {@code null} if none. */
+    public Color getEntityColor() { return entityColor.get(); }
+
     /**
      * Displays the particle effect at the specified location in the world.
      * Suppliers are evaluated at display time, enabling runtime-resolved values.
@@ -172,17 +190,23 @@ public class ParticleWrapper {
         Particle.DustTransition t = transition.get();
         Particle.DustOptions o = options.get();
         BlockData bd = blockData.get();
+        Color ec = entityColor.get();
 
-        if (t == null && o == null && bd == null)
+        if (ec != null)
+            world.spawnParticle(p, location, c, x, y, z, s < 0 ? 1.0 : s, ec);
+        else if (t == null && o == null && bd == null)
             if (s == -1.0)
                 world.spawnParticle(p, location, c, x, y, z);
             else
                 world.spawnParticle(p, location, c, x, y, z, s);
 
-        else if (o == null && bd == null)
+        else if (t != null && bd == null)
             world.spawnParticle(p, location, c, x, y, z, data.get(), t);
 
-        else if (bd == null)
+        else if (o instanceof Particle.DustTransition dt && bd == null)
+            world.spawnParticle(p, location, c, x, y, z, data.get(), dt);
+
+        else if (o != null && bd == null)
             world.spawnParticle(p, location, c, o);
 
         else

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -333,6 +333,7 @@ debug:
   logging_verbose_movement: false
   
   logging_verbose_config: false
+  logging_verbose_particle_display: false
   
   visualization_show_hitboxes: false
   visualization_show_raytraces: false

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -328,11 +328,12 @@ world:
 
 
 debug:
-  
+
   logging_verbose_combat: false
   logging_verbose_movement: false
-  
+
   logging_verbose_config: false
+  logging_verbose_umbral_states: false
   
   visualization_show_hitboxes: false
   visualization_show_raytraces: false

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -13,7 +13,7 @@ color:
   text_item_base: '#787878'
   text_cool_dark: '#333C4B'
   
-  umbral_glow: '#FFFFFF'
+  umbral_glow: '#640000'
   ferocious_sweep: '#FF0000'
 
 
@@ -333,14 +333,14 @@ debug:
   logging_verbose_movement: false
   
   logging_verbose_config: false
-  logging_verbose_particle_display: false
   
   visualization_show_hitboxes: false
   visualization_show_raytraces: false
-  wireframe_selected_size: 0.9
-  wireframe_default_color: "FFE63C"
-  wireframe_default_size: 0.7
-  wireframe_live_size: 1.0
+  wireframe_selected_size: 0.5
+  wireframe_default_size: 0.5
+  wireframe_live_size: 0.3
+  skip_data_save: false
+  skip_data_load: false
 
 
 grab:
@@ -418,3 +418,5 @@ roguelike:
   spawn_x: -209.0
   spawn_y: 104.0
   spawn_z: -1968.0
+umbral-blade:
+  scale-y: 1.0


### PR DESCRIPTION
## Summary
- Keyframe effects UX overhaul (raycast anchor multi-kf creation nav arrows effect count display all-effects menu particle library presets)
- UmbralBlade lifecycle unification — Combatant.handleUmbralBladeTick is now the single authority for blade existence
- InactiveState becomes a behavioural suspend state lifecycle layer destroys and recreates the blade on the next tick
- Removes BladeRequest.ACTIVATE_TO_PREVIOUS empties PlayerListener.gameChangeEvent switches AnimationMode to Combatant.setUmbralBladeActive
- New Debug.umbralStates + Config.LOGGING_VERBOSE_UMBRAL_STATES flag for transition + lifecycle tracing
- New BREEZE_ROD dev tester item (KeyRegistry.UMBRAL_BLADE_TESTER_KEY) wired through DevSwordPlayer LEFT deactivates DROP activates
- Bug fixes — null-safe display access in onDeath/onZeroHealth null blade ref after dispose in onLeave isValid guard in dispose

## Test plan
- [ ] Join server blade activates cleanly in spawn box
- [ ] /kill blade activates cleanly on respawn
- [ ] /spectator blade disposed cleanly no jitter
- [ ] /survival blade recreates within one tick cycle
- [ ] Leave then rejoin exactly one blade no ghost
- [ ] /kill all item displays externally RecoverState respawns within ~1s
- [ ] AnimationMode enter blade removed cleanly
- [ ] AnimationMode exit blade recreates in SheathedState within ~200ms
- [ ] BREEZE_ROD LEFT blade gone immediately
- [ ] BREEZE_ROD DROP blade recreates exactly once
- [ ] Rapid LEFT/DROP cycle no duplicate displays no leaked tasks
- [ ] LOGGING_VERBOSE_UMBRAL_STATES toggled transitions logged with player + state names