### PR TITLE
refactor/umbral-blade-decoupling

### DIFF
--- a/src/main/java/btm/sword/action/throwing/InteractiveItemArbiter.java
+++ b/src/main/java/btm/sword/action/throwing/InteractiveItemArbiter.java
@@ -83,7 +83,9 @@ public final class InteractiveItemArbiter {
     /** Returns {@code true} if the targeted item is not currently impaling the given entity. */
     public static boolean notImpaled(SwordEntity self, ItemDisplay targeted) {
         InteractiveItem thrown = INTERACTIVE_ITEMS.getOrDefault(targeted, null);
-        return !(thrown instanceof ThrownItem ti) || ti.getHitEntity() == null || !ti.getHitEntity().equals(self);
+        return !(thrown instanceof Lodgeable lodgeable)
+            || lodgeable.getImpaledEntity() == null
+            || !lodgeable.getImpaledEntity().equals(self);
     }
 
     /**
@@ -115,8 +117,8 @@ public final class InteractiveItemArbiter {
     public static void onGrab(ItemDisplay display, Combatant executor) {
         InteractiveItem interactiveItem = remove(display, false);
         if (interactiveItem == null) return;
-        if (interactiveItem instanceof ThrownItem thrownItem) {
-            thrownItem.setRetrieved(true);
+        if (interactiveItem instanceof Lodgeable lodgeable) {
+            lodgeable.setRetrieved(true);
         }
 
         // UmbralBlade manages its own item state (weapon/link/blade fields) and never populates

--- a/src/main/java/btm/sword/action/throwing/Lodgeable.java
+++ b/src/main/java/btm/sword/action/throwing/Lodgeable.java
@@ -1,0 +1,31 @@
+package btm.sword.action.throwing;
+
+import btm.sword.entity.base.SwordEntity;
+
+/**
+ * Behavioral contract for {@link InteractiveItem}s that can become lodged in (or attached to) a
+ * {@link SwordEntity} after a successful hit.
+ * <p>
+ * Extracted from {@link btm.sword.action.throwing.types.ThrownItem} so consumers such as
+ * {@link InteractiveItemArbiter} can dispatch on behavior rather than concrete type — the
+ * UmbralBlade and any future lodge-capable item can satisfy this contract without participating
+ * in the {@code ThrownItem} inheritance chain.
+ */
+public interface Lodgeable extends InteractiveItem {
+
+    /**
+     * Returns the entity this item is currently lodged in, or {@code null} if it is not currently
+     * impaling/attached to anything.
+     *
+     * @return the impaled entity, or {@code null} if not lodged
+     */
+    SwordEntity getImpaledEntity();
+
+    /**
+     * Marks this item as having been retrieved by an entity (typically via the dash-pickup flow).
+     * Implementations are expected to debounce this flag — see existing usages for the convention.
+     *
+     * @param retrieved {@code true} when the item is being picked up
+     */
+    void setRetrieved(boolean retrieved);
+}

--- a/src/main/java/btm/sword/action/throwing/Lodgeable.java
+++ b/src/main/java/btm/sword/action/throwing/Lodgeable.java
@@ -28,4 +28,19 @@ public interface Lodgeable extends InteractiveItem {
      * @param retrieved {@code true} when the item is being picked up
      */
     void setRetrieved(boolean retrieved);
+
+    /**
+     * Returns {@code true} if this item has been marked as retrieved. Used by the impalement
+     * watchdog to decide when its bookkeeping should release the impaled entity.
+     *
+     * @return whether the item is currently flagged as retrieved
+     */
+    boolean isRetrieved();
+
+    /**
+     * Disposes this item and emits a fresh interactive world-item at its current location.
+     * Used by impalement bookkeeping to drop the lodged item back into the world when the
+     * impalement ends without the item being explicitly retrieved.
+     */
+    void disposeWithNewInteractiveItem();
 }

--- a/src/main/java/btm/sword/action/throwing/impale/Impalement.java
+++ b/src/main/java/btm/sword/action/throwing/impale/Impalement.java
@@ -1,13 +1,13 @@
 package btm.sword.action.throwing.impale;
 
-import btm.sword.action.throwing.types.ThrownItem;
+import btm.sword.action.throwing.Lodgeable;
 import btm.sword.entity.base.SwordEntity;
 import btm.sword.runtime.scheduler.PredicateRunnablePair;
 import btm.sword.runtime.scheduler.TimeArbiter;
 import lombok.Getter;
 import lombok.Setter;
 
-/** Represents an active impalement state binding a thrown item to an impaled entity. */
+/** Represents an active impalement state binding a lodgeable item to an impaled entity. */
 public class Impalement {
     @Getter
     private final SwordEntity impaledEntity;
@@ -19,21 +19,27 @@ public class Impalement {
         this.impaledEntity = impaledEntity;
     }
 
-    /** Starts a recurring task that disposes the impalement once the item is retrieved or the entity dies. */
-    public void startShouldDisposeCheckTask(SwordEntity hitEntity, ThrownItem impalingItem) {
+    /**
+     * Starts a recurring task that disposes the impalement once the item is retrieved, the
+     * entity dies, or the impalement is otherwise released.
+     *
+     * @param hitEntity     the entity being impaled
+     * @param impalingItem  the lodgeable item performing the impalement
+     */
+    public void startShouldDisposeCheckTask(SwordEntity hitEntity, Lodgeable impalingItem) {
         TimeArbiter.runTimeIndependentBukkitTaskOnTimer(
             null,
             null,
             0, 75,
             Impalement.class, "startShouldDisposeCheckTask",
             new PredicateRunnablePair(
-                () -> shouldDispose || impalingItem.getHitEntity() == null ||
+                () -> shouldDispose || impalingItem.getImpaledEntity() == null ||
                     hitEntity.isDead() ||
                     impalingItem.getDisplay() == null,
                 impalingItem::disposeWithNewInteractiveItem
             ),
             new PredicateRunnablePair(
-                () -> impalingItem.getDisplay().isDead() || impalingItem.isRetrieved(),
+                () -> impalingItem.getDisplay() == null || impalingItem.getDisplay().isDead() || impalingItem.isRetrieved(),
                 () -> hitEntity.removeImpalement(this)
             )
         );

--- a/src/main/java/btm/sword/action/throwing/types/ThrownItem.java
+++ b/src/main/java/btm/sword/action/throwing/types/ThrownItem.java
@@ -26,6 +26,7 @@ import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
 import btm.sword.action.throwing.ImpactType;
+import btm.sword.action.throwing.Lodgeable;
 import btm.sword.action.throwing.ThrowAction;
 import btm.sword.action.throwing.impale.Impalement;
 import btm.sword.combat.hit.HitValuePacket;
@@ -62,7 +63,7 @@ import net.kyori.adventure.text.format.TextDecoration;
  */
 @Getter
 @Setter
-public class ThrownItem extends VisualProjectile {
+public class ThrownItem extends VisualProjectile implements Lodgeable {
     protected final Combatant thrower;
 
     protected Impalement thisImpalement;
@@ -320,6 +321,18 @@ public class ThrownItem extends VisualProjectile {
         } else {
             ItemUsageManager.damageItemStack(itemStack, onThrowHitDamageToItem, thrower.self());
         }
+    }
+
+    /**
+     * Returns the entity this thrown item is currently lodged in. Delegates to the inherited
+     * {@code hitEntity} field — preserves the pre-{@link Lodgeable} dispatch behavior that
+     * {@link btm.sword.action.throwing.InteractiveItemArbiter} relied on via {@code getHitEntity()}.
+     *
+     * @return the impaled entity, or {@code null} if not currently lodged
+     */
+    @Override
+    public SwordEntity getImpaledEntity() {
+        return hitEntity;
     }
 
     /**

--- a/src/main/java/btm/sword/action/throwing/types/ThrownItem.java
+++ b/src/main/java/btm/sword/action/throwing/types/ThrownItem.java
@@ -90,7 +90,6 @@ public class ThrownItem extends VisualProjectile implements Lodgeable {
      *
      * @param thrower                   the combatant performing the throw
      * @param displaySetupInstructions  applied to the {@link ItemDisplay} immediately after it spawns
-     * @param setupPeriod               polling interval in ticks for the spawn-check loop
      */
     public ThrownItem(Combatant thrower, Consumer<ItemDisplay> displaySetupInstructions) {
         this.thrower = thrower;

--- a/src/main/java/btm/sword/combat/attack/UmbralBladeAttack.java
+++ b/src/main/java/btm/sword/combat/attack/UmbralBladeAttack.java
@@ -2,12 +2,12 @@ package btm.sword.combat.attack;
 
 import java.util.HashSet;
 
-import org.bukkit.entity.ItemDisplay;
 import org.bukkit.entity.LivingEntity;
 
 import btm.sword.combat.style.AttackProfile;
 import btm.sword.config.Config;
 import btm.sword.umbral.UmbralBlade;
+import btm.sword.umbral.presentation.BladeDisplay;
 import btm.sword.util.entity.HitboxUtil;
 
 
@@ -16,13 +16,13 @@ public class UmbralBladeAttack extends ItemDisplayAttack {
     protected UmbralBlade blade;
 
     /** Full-parameter constructor forwarded to {@link ItemDisplayAttack}. */
-    public UmbralBladeAttack(ItemDisplay weaponDisplay, AttackProfile profile,
+    public UmbralBladeAttack(BladeDisplay weaponDisplay, AttackProfile profile,
                              boolean orientWithPitch, boolean displayOnly,
                              int tpDuration, int displaySteps,
                              int attackStepsPerDisplayStep, int attackMilliseconds,
                              double attackStartValue, double attackEndValue) {
 
-        super(weaponDisplay, profile,
+        super(weaponDisplay.handle(), profile,
             orientWithPitch, displayOnly,
             tpDuration, displaySteps,
             attackStepsPerDisplayStep, attackMilliseconds,
@@ -30,8 +30,8 @@ public class UmbralBladeAttack extends ItemDisplayAttack {
     }
 
     /** Convenience constructor using default display step count from config. */
-    public UmbralBladeAttack(ItemDisplay weaponDisplay, AttackProfile profile, boolean orientWithPitch, boolean displayOnly, int tpDuration) {
-        super(weaponDisplay, profile, orientWithPitch, displayOnly, tpDuration);
+    public UmbralBladeAttack(BladeDisplay weaponDisplay, AttackProfile profile, boolean orientWithPitch, boolean displayOnly, int tpDuration) {
+        super(weaponDisplay.handle(), profile, orientWithPitch, displayOnly, tpDuration);
     }
 
 

--- a/src/main/java/btm/sword/entity/base/Combatant.java
+++ b/src/main/java/btm/sword/entity/base/Combatant.java
@@ -224,8 +224,6 @@ public abstract class Combatant extends SwordEntity {
             message("Starting Umbral Blade");
             umbralBlade = new UmbralBlade(this, ItemStack.of(Material.STONE_SWORD));
 
-            umbralBlade.setup(5);
-
             setStartingBlade(false);
             }, 200, TimeUnit.MILLISECONDS
         );

--- a/src/main/java/btm/sword/umbral/BladeIdentity.java
+++ b/src/main/java/btm/sword/umbral/BladeIdentity.java
@@ -1,0 +1,40 @@
+package btm.sword.umbral;
+
+import java.util.Objects;
+
+import org.bukkit.inventory.ItemStack;
+
+import btm.sword.entity.base.Combatant;
+import btm.sword.item.special.SoulLinkItem;
+
+/**
+ * Immutable identity record for an UmbralBlade.
+ *
+ * <p>Collects the four pieces of "what this blade is" that were previously scattered across
+ * {@link UmbralBlade}'s fields: the {@link Combatant} that owns the blade, the original
+ * {@link ItemStack weapon} the blade was unsheathed from, the {@link SoulLinkItem link} anchor
+ * displayed in the inventory while the blade is active, and the visual {@link ItemStack blade}
+ * item displayed when the blade is wielded.</p>
+ *
+ * <p>Pure data — no behavior beyond record accessors. All four components are non-null;
+ * the compact constructor enforces this structurally so an invalid identity cannot exist.
+ * Once constructed, an instance never mutates.</p>
+ *
+ * <p>This record carries no lifecycle of its own. Its lifetime is bounded by the
+ * {@link UmbralBlade} that holds it.</p>
+ *
+ * @param thrower the combatant that owns the blade
+ * @param weapon  the original held weapon the blade was created from
+ * @param link    the soul-link anchor occupying slot 0 while the blade is unwielded
+ * @param blade   the visual blade item occupying slot 0 while the blade is wielded
+ */
+public record BladeIdentity(Combatant thrower, ItemStack weapon, SoulLinkItem link, ItemStack blade) {
+
+    /** Compact constructor enforcing non-null invariants on all components. */
+    public BladeIdentity {
+        Objects.requireNonNull(thrower, "thrower");
+        Objects.requireNonNull(weapon, "weapon");
+        Objects.requireNonNull(link, "link");
+        Objects.requireNonNull(blade, "blade");
+    }
+}

--- a/src/main/java/btm/sword/umbral/UmbralBlade.java
+++ b/src/main/java/btm/sword/umbral/UmbralBlade.java
@@ -693,9 +693,8 @@ public class UmbralBlade implements InteractiveItem, Lodgeable, BladeMotionHost 
 
     @SuppressWarnings("unchecked")
     private void loadBasicAttacks() {
-        ItemDisplay handle = bladeDisplay.handle();
         basicAttacks = new Function[]{
-            combatant -> new UmbralBladeAttack(handle, AttackType.WIDE_UMBRAL_SLASH1_WINDUP,
+            combatant -> new UmbralBladeAttack(bladeDisplay, AttackType.WIDE_UMBRAL_SLASH1_WINDUP,
                 true, true, 1,
                 10, 30, 500,
                 0, 1)
@@ -703,7 +702,7 @@ public class UmbralBlade implements InteractiveItem, Lodgeable, BladeMotionHost 
                 .setInitialMovementTicks(25)
                 .setDrawParticles(false)
                 .setNextAttack(
-                    new UmbralBladeAttack(handle, AttackType.WIDE_UMBRAL_SLASH1,
+                    new UmbralBladeAttack(bladeDisplay, AttackType.WIDE_UMBRAL_SLASH1,
                         true, false, 0,
                         20, 10, 100,
                         0, 1)
@@ -712,7 +711,7 @@ public class UmbralBlade implements InteractiveItem, Lodgeable, BladeMotionHost 
                         .setCallback(attackEndCallback, 200),
                     100),
 
-            combatant -> new UmbralBladeAttack(handle, AttackType.WIDE_UMBRAL_SLASH2_WINDUP,
+            combatant -> new UmbralBladeAttack(bladeDisplay, AttackType.WIDE_UMBRAL_SLASH2_WINDUP,
                 true, true, 2,
                 10, 30, 500,
                 0, 1)
@@ -720,7 +719,7 @@ public class UmbralBlade implements InteractiveItem, Lodgeable, BladeMotionHost 
                 .setInitialMovementTicks(25)
                 .setDrawParticles(false)
                 .setNextAttack(
-                    new UmbralBladeAttack(handle, AttackType.WIDE_UMBRAL_SLASH2,
+                    new UmbralBladeAttack(bladeDisplay, AttackType.WIDE_UMBRAL_SLASH2,
                         true, false, 0,
                         20, 10, 100,
                         0, 1)
@@ -729,7 +728,7 @@ public class UmbralBlade implements InteractiveItem, Lodgeable, BladeMotionHost 
                         .setCallback(attackEndCallback, 200),
                     100),
 
-            combatant -> new UmbralBladeAttack(handle, AttackType.WIDE_UMBRAL_SLASH3_WINDUP,
+            combatant -> new UmbralBladeAttack(bladeDisplay, AttackType.WIDE_UMBRAL_SLASH3_WINDUP,
                 false, true, 3,
                 10, 30, 500,
                 0, 1.2)
@@ -737,7 +736,7 @@ public class UmbralBlade implements InteractiveItem, Lodgeable, BladeMotionHost 
                 .setInitialMovementTicks(25)
                 .setDrawParticles(false)
                 .setNextAttack(
-                    new UmbralBladeAttack(handle, AttackType.WIDE_UMBRAL_SLASH3,
+                    new UmbralBladeAttack(bladeDisplay, AttackType.WIDE_UMBRAL_SLASH3,
                         false, false, 0,
                         20, 10, 50,
                         0, 1)

--- a/src/main/java/btm/sword/umbral/UmbralBlade.java
+++ b/src/main/java/btm/sword/umbral/UmbralBlade.java
@@ -23,6 +23,7 @@ import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
 import btm.sword.action.movement.DashDirection;
+import btm.sword.action.throwing.Lodgeable;
 import btm.sword.action.throwing.types.ThrownItem;
 import btm.sword.combat.attack.Attack;
 import btm.sword.combat.attack.UmbralBladeAttack;
@@ -70,7 +71,7 @@ import net.kyori.adventure.text.format.TextDecoration;
 // while flying and attacking on its own, no soulfire is reaped on attacks
 // while in hand, higher soulfire intake on hit
 /** The signature UmbralBlade weapon — a thrown item backed by a full FSM managing all combat states and visual transitions. */
-public class UmbralBlade extends ThrownItem {
+public class UmbralBlade extends ThrownItem implements Lodgeable {
     /** Type of dash-reclaim attack to perform on the next quick or heavy attack entry. */
     public enum ReclaimType {
         NONE,

--- a/src/main/java/btm/sword/umbral/UmbralBlade.java
+++ b/src/main/java/btm/sword/umbral/UmbralBlade.java
@@ -11,7 +11,6 @@ import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
 import org.bukkit.entity.Display;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.ItemDisplay;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.ItemStack;
@@ -47,6 +46,7 @@ import btm.sword.umbral.input.InputBuffer;
 import btm.sword.umbral.motion.BladeMotion;
 import btm.sword.umbral.motion.BladeMotionHost;
 import btm.sword.umbral.motion.drivers.ImpalementFollowDriver;
+import btm.sword.umbral.presentation.BladeDisplay;
 import btm.sword.umbral.statemachine.UmbralStateMachine;
 import btm.sword.umbral.statemachine.state.AttackingHeavyState;
 import btm.sword.umbral.statemachine.state.AttackingQuickState;
@@ -59,7 +59,6 @@ import btm.sword.umbral.statemachine.state.SheathedState;
 import btm.sword.umbral.statemachine.state.StandbyState;
 import btm.sword.umbral.statemachine.state.WaitingState;
 import btm.sword.umbral.statemachine.state.WieldState;
-import btm.sword.util.display.DisplayUtil;
 import btm.sword.util.display.DrawUtil;
 import btm.sword.util.display.ParticleWrapper;
 import btm.sword.util.math.BezierUtil;
@@ -95,6 +94,16 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
      */
     @Getter
     private final BladeMotion bladeMotion;
+    /**
+     * Single owner of the underlying {@link ItemDisplay} handle for this blade. All umbral-side
+     * presentation operations (teleport / transformation / bobbing / spawn / dispose) route
+     * through this wrapper. The inherited {@code display} field on {@link ThrownItem}'s parents
+     * remains alive transitionally because inherited physics methods still read it; both fields
+     * point to the same {@code ItemDisplay} handle and are synced on respawn/dispose. The
+     * inherited field is removed entirely when inheritance is severed in step 9.
+     */
+    @Getter
+    private final BladeDisplay bladeDisplay;
     @Getter
     private Function<Combatant, Attack>[] basicAttacks;
     @Getter
@@ -112,10 +121,6 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
     @Getter
     private final Vector3f scale = new Vector3f(
         (float) Config.UmbralBlade.SCALE_X, (float) Config.UmbralBlade.SCALE_Y, (float) Config.UmbralBlade.SCALE_Z);
-
-    @Getter
-    @Setter
-    private TimeArbiter.TaskHandle idleMovementTask;
 
     @Getter
     private final Predicate<UmbralBlade> endHoverPredicate;
@@ -230,6 +235,9 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
 
         this.weapon = weapon;
 
+        this.bladeDisplay = new BladeDisplay(scale);
+        this.bladeDisplay.adopt(display);
+
         generateUmbralItems();
 
         this.attackEndCallback = () -> attackCompleted = true;
@@ -311,36 +319,33 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
 
     @Override
     public void teleportDisplay(Location location, Vector direction, int teleportDuration) {
-        if (display == null || !display.isValid()) return;
-        TimeArbiter.teleportDisplay(display, location, direction, teleportDuration,
-            UmbralBlade.class, 0);
+        bladeDisplay.teleportTo(location, direction, teleportDuration);
     }
 
     @Override
     public void setDisplayTransformation(Transformation transformation, int transformDuration) {
-        if (display == null || !display.isValid()) return;
-        TimeArbiter.setDisplayTransformation(display, transformation, transformDuration);
+        bladeDisplay.setTransformation(transformation, transformDuration);
     }
 
     @Override
     public Location currentDisplayLocation() {
-        return (display == null || !display.isValid()) ? null : display.getLocation();
+        return bladeDisplay.currentLocation();
     }
 
     @Override
     public boolean isDisplayValid() {
-        return display != null && display.isValid();
+        return bladeDisplay.isValid();
     }
 
     // TODO: #240 - Make a method for calculating correct orientation of blade for edge to align with plane of swing on attack
     /** Applies the display transformation for the given state class after a 50 ms delay. */
     public void setDisplayTransformation(Class<? extends State<UmbralBlade>> state) {
-        if (display == null) return;
+        if (!bladeDisplay.isValid()) return;
 
         int duration = getInterpolationDurationForState(state);
         SwordScheduler.runBukkitTaskLater(() -> {
-            DisplayUtil.setInterpolationValues(display, 0, duration);
-            display.setTransformation(getStateDisplayTransformation(state));
+            bladeDisplay.setInterpolation(0, duration);
+            bladeDisplay.setTransformationImmediate(getStateDisplayTransformation(state));
             }, 50, TimeUnit.MILLISECONDS
         );
     }
@@ -397,7 +402,7 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
                 new Quaternionf()
             );
         } else if (state == LodgedState.class) {
-            return display.getTransformation();
+            return bladeDisplay.currentTransformation();
         } else if (state == AttackingQuickState.class || state == AttackingHeavyState.class) {
             return new Transformation(
                 new Vector3f(0, 0, -1),
@@ -415,36 +420,12 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
 
     /** Starts the cosine idle bobbing animation on the blade's display entity. */
     public void startIdleMovement() {
-        if (idleMovementTask != null) {
-            idleMovementTask.cancel();
-        }
-        final double[] step = {0};
-        idleMovementTask = TimeArbiter.runTimeBoundBukkitTaskOnTimer(
-            () -> {
-                TimeArbiter.setDisplayTransformation(display,
-                    new Transformation(
-                        new Vector3f(0, (float) (Math.cos(step[0]) * Config.UmbralBlade.IDLE_MOVEMENT_AMPLITUDE), 0),
-                        display.getTransformation().getLeftRotation(),
-                        scale,
-                        new Quaternionf()
-                    ),
-                    Config.UmbralBlade.IDLE_MOVEMENT_PERIOD
-                );
-
-                step[0] += Math.PI / 8;
-            },
-            null,
-            null,
-            0, Config.UmbralBlade.IDLE_MOVEMENT_PERIOD,
-            UmbralBlade.class, "startIdleMovement"
-        );
+        bladeDisplay.startBobbing(Config.UmbralBlade.IDLE_MOVEMENT_AMPLITUDE, Config.UmbralBlade.IDLE_MOVEMENT_PERIOD);
     }
 
     /** Cancels the idle bobbing animation task if it is currently running. */
     public void endIdleMovement() {
-        if (idleMovementTask != null) {
-            idleMovementTask.cancel();
-        }
+        bladeDisplay.stopBobbing();
     }
 
     @Override
@@ -556,14 +537,10 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
 
     /** Removes the existing display entity and respawns a fresh one at the thrower's eye level. */
     public void resetWeaponDisplay() {
-        if (display != null) {
-            display.remove();
-            display = null;
-        }
-
-        LivingEntity e = thrower.self();
-        display = (ItemDisplay) e.getWorld().spawnEntity(e.getEyeLocation(), EntityType.ITEM_DISPLAY);
-        displaySetupInstructions.accept(display);
+        bladeDisplay.respawn(thrower.self(), displaySetupInstructions);
+        // TODO: #step-9 — sync removed once inheritance is severed and bladeDisplay becomes
+        //       the only handle holder.
+        display = bladeDisplay.handle();
     }
 
     @Override
@@ -656,8 +633,7 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
 
     @Override
     protected void teleport() {
-        TimeArbiter.teleportDisplay(display, cur, to, 2,
-            UmbralBlade.class, 458);
+        bladeDisplay.teleportTo(cur, to, 2);
     }
 
     @Override
@@ -744,9 +720,9 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
         bladeStateMachine.getState().onExit(this);
         bladeStateMachine.setDeactivated(true);
         bladeMotion.stop();
-        if (display != null && display.isValid()) {
-            display.remove();
-        }
+        bladeDisplay.dispose();
+        // TODO: #step-9 — sync removed once inheritance is severed and bladeDisplay becomes
+        //       the only handle holder.
         display = null;
     }
 

--- a/src/main/java/btm/sword/umbral/UmbralBlade.java
+++ b/src/main/java/btm/sword/umbral/UmbralBlade.java
@@ -109,11 +109,14 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
     @Getter
     private int currentComboStep = -1;
 
-    private SoulLinkItem link;
+    /**
+     * Immutable identity of this blade — thrower, original weapon, soul-link anchor, and visual
+     * blade item. Constructed once in the UmbralBlade constructor and never mutated. All
+     * identity-related accessors delegate to this record.
+     */
     @Getter
-    private ItemStack blade;
-    @Getter
-    private final ItemStack weapon;
+    private final BladeIdentity identity;
+
     @Getter
     @Setter
     private long lastActionTime = 0;
@@ -160,6 +163,16 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
     @Setter
     private boolean bladeWielded = false;
 
+    /** Returns the original weapon {@link ItemStack} the blade was created from. */
+    public ItemStack getWeapon() {
+        return identity.weapon();
+    }
+
+    /** Returns the visual blade {@link ItemStack} displayed when the blade is wielded. */
+    public ItemStack getBlade() {
+        return identity.blade();
+    }
+
     /**
      * Returns the Soul Link {@link ItemStack} for use as an inventory item.
      * Use {@link #getLinkAnchor()} when slot-restoration logic is needed.
@@ -167,7 +180,7 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
      * @return the Soul Link ItemStack
      */
     public ItemStack getLink() {
-        return link.getItemStack();
+        return identity.link().getItemStack();
     }
 
     /**
@@ -176,7 +189,7 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
      * @return the Soul Link anchor
      */
     public SoulLinkItem getLinkAnchor() {
-        return link;
+        return identity.link();
     }
 
     /**
@@ -186,7 +199,7 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
      * @return the ItemStack that should currently occupy slot 0
      */
     public ItemStack getExpectedSlotItem() {
-        return bladeWielded ? blade : getLink();
+        return bladeWielded ? identity.blade() : getLink();
     }
 
     /**
@@ -233,12 +246,10 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
 
         // TODO: Removed the setup call; must set up elsewhere now.
 
-        this.weapon = weapon;
-
         this.bladeDisplay = new BladeDisplay(scale);
         this.bladeDisplay.adopt(display);
 
-        generateUmbralItems();
+        this.identity = new BladeIdentity(thrower, weapon, createLinkItem(thrower), createBladeItem(thrower, weapon));
 
         this.attackEndCallback = () -> attackCompleted = true;
 
@@ -505,9 +516,12 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
         };
     }
 
-    private void generateUmbralItems() {
-        // item Stack used for determining umbral blade inputs
-        this.link = new SoulLinkItem(new ItemStackBuilder(Material.HEAVY_CORE)
+    /**
+     * Builds the {@link SoulLinkItem} for the given thrower. Pure factory — no instance state.
+     * Result is consumed once during {@link BladeIdentity} construction.
+     */
+    private static SoulLinkItem createLinkItem(Combatant thrower) {
+        return new SoulLinkItem(new ItemStackBuilder(Material.HEAVY_CORE)
             .hideAll()
             .name(Component.text("~ ", Config.SwordColor.TEXT_ITEM_NAME)
                 .append(Component.text(thrower.getDisplayName() + "'s Soul Link",
@@ -518,8 +532,15 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
             .tag(KeyRegistry.SOUL_LINK_KEY, PersistentDataType.STRING, thrower.getUniqueId().toString())
             .tagSwordItem(SwordItemType.UMBRAL_LINK)
             .build());
+    }
 
-        this.blade = new ItemStackBuilder(weapon.getType())
+    /**
+     * Builds the visual blade {@link ItemStack} for the given thrower and source weapon.
+     * Pure factory — no instance state. Result is consumed once during
+     * {@link BladeIdentity} construction.
+     */
+    private static ItemStack createBladeItem(Combatant thrower, ItemStack weapon) {
+        return new ItemStackBuilder(weapon.getType())
             .hideAll()
             .name(Component.text("~ ", Config.SwordColor.TEXT_COOL_DARK)
                 .append(Component.text(thrower.getDisplayName() + "'s Blade",

--- a/src/main/java/btm/sword/umbral/UmbralBlade.java
+++ b/src/main/java/btm/sword/umbral/UmbralBlade.java
@@ -1,30 +1,29 @@
 package btm.sword.umbral;
 
-import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import org.bukkit.FluidCollisionMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Display;
 import org.bukkit.entity.ItemDisplay;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
-import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Transformation;
 import org.bukkit.util.Vector;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
 import btm.sword.action.movement.DashDirection;
+import btm.sword.action.throwing.InteractiveItem;
 import btm.sword.action.throwing.Lodgeable;
 import btm.sword.action.throwing.impale.Impalement;
-import btm.sword.action.throwing.types.ThrownItem;
 import btm.sword.combat.attack.Attack;
 import btm.sword.combat.attack.UmbralBladeAttack;
 import btm.sword.combat.style.AttackType;
@@ -59,11 +58,8 @@ import btm.sword.umbral.statemachine.state.SheathedState;
 import btm.sword.umbral.statemachine.state.StandbyState;
 import btm.sword.umbral.statemachine.state.WaitingState;
 import btm.sword.umbral.statemachine.state.WieldState;
-import btm.sword.util.display.DrawUtil;
 import btm.sword.util.display.ParticleWrapper;
-import btm.sword.util.math.BezierUtil;
 import btm.sword.util.math.ControlVectors;
-import btm.sword.util.math.VectorUtil;
 import btm.sword.util.misc.Debug;
 import btm.sword.util.prefab.Prefab;
 import lombok.Getter;
@@ -71,60 +67,77 @@ import lombok.Setter;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextDecoration;
 
-// while flying and attacking on its own, no soulfire is reaped on attacks
-// while in hand, higher soulfire intake on hit
-/** The signature UmbralBlade weapon — a thrown item backed by a full FSM managing all combat states and visual transitions. */
-public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHost {
+/**
+ * The signature UmbralBlade weapon — coordinator of a layered FSM-driven combat system.
+ *
+ * <p>Composed of four strictly-owned subsystems:
+ * <ul>
+ *   <li>{@link BladeIdentity} — immutable thrower / weapon / link / blade tuple (existence)</li>
+ *   <li>{@link BladeDisplay} — single owner of the {@link ItemDisplay} entity (presentation)</li>
+ *   <li>{@link BladeMotion} — single writer of world-space position via pluggable drivers (motion)</li>
+ *   <li>{@link UmbralStateMachine} — intent / time progression (behavior)</li>
+ * </ul>
+ *
+ * <p>Implements {@link InteractiveItem} and {@link Lodgeable} directly — no inheritance from
+ * {@code ThrownItem}. The blade does not participate in the parent throw/flight pipeline; its
+ * lunge motion is driven by an FSM-installed {@code LungingDriver} on the motion subsystem.</p>
+ *
+ * <p>Lifecycle: {@code UNINITIALIZED -> ALIVE -> DISPOSED}. {@link #dispose} is idempotent.</p>
+ */
+public class UmbralBlade implements InteractiveItem, Lodgeable, BladeMotionHost {
+
     /** Type of dash-reclaim attack to perform on the next quick or heavy attack entry. */
     public enum ReclaimType {
         NONE,
-        CIRCULAR_SLASH, // in waiting state
-        EVISCERATE, // If pulling from Lodged
-        FORWARD_RUSH // otherwise?
+        CIRCULAR_SLASH,
+        EVISCERATE,
+        FORWARD_RUSH
     }
 
-    @Getter
-    private final UmbralStateMachine bladeStateMachine;
-    /**
-     * Per-tick motion subsystem. Owns the currently-installed
-     * {@link btm.sword.umbral.motion.BladeMotionDriver} (if any) and is the single writer
-     * of the blade's world-space position via the {@link BladeMotionHost} bridge below.
-     * Initially {@link BladeMotion.State#IDLE IDLE}; states install drivers on entry and
-     * stop on exit.
-     */
-    @Getter
-    private final BladeMotion bladeMotion;
-    /**
-     * Single owner of the underlying {@link ItemDisplay} handle for this blade. All umbral-side
-     * presentation operations (teleport / transformation / bobbing / spawn / dispose) route
-     * through this wrapper. The inherited {@code display} field on {@link ThrownItem}'s parents
-     * remains alive transitionally because inherited physics methods still read it; both fields
-     * point to the same {@code ItemDisplay} handle and are synced on respawn/dispose. The
-     * inherited field is removed entirely when inheritance is severed in step 9.
-     */
-    @Getter
-    private final BladeDisplay bladeDisplay;
-    @Getter
-    private Function<Combatant, Attack>[] basicAttacks;
-    @Getter
-    private int currentComboStep = -1;
+    // -----------------------------------------------------------------------
+    // Identity & subsystems (immutable references for the lifetime of the blade)
+    // -----------------------------------------------------------------------
 
     /**
-     * Immutable identity of this blade — thrower, original weapon, soul-link anchor, and visual
-     * blade item. Constructed once in the UmbralBlade constructor and never mutated. All
-     * identity-related accessors delegate to this record.
+     * Immutable identity — thrower, original weapon, soul-link anchor, visual blade item.
+     * Constructed once in the constructor and never mutated.
      */
     @Getter
     private final BladeIdentity identity;
 
+    /**
+     * Per-tick motion subsystem. Owns the currently-installed
+     * {@link btm.sword.umbral.motion.BladeMotionDriver} and is the single writer of the blade's
+     * world-space position via the {@link BladeMotionHost} bridge below.
+     */
     @Getter
-    @Setter
-    private long lastActionTime = 0;
+    private final BladeMotion bladeMotion;
 
+    /**
+     * Single owner of the underlying {@link ItemDisplay} handle. All presentation operations
+     * route through this wrapper.
+     */
+    @Getter
+    private final BladeDisplay bladeDisplay;
+
+    /** Finite state machine driving the blade's behavioral states. */
+    @Getter
+    private final UmbralStateMachine bladeStateMachine;
+
+    /** Initial display setup consumer; reused by {@link #resetWeaponDisplay}. */
+    private final Consumer<ItemDisplay> displaySetup;
+
+    // -----------------------------------------------------------------------
+    // Combat configuration
+    // -----------------------------------------------------------------------
+
+    @Getter
+    private Function<Combatant, Attack>[] basicAttacks;
+    @Getter
+    private int currentComboStep = -1;
     @Getter
     private final Vector3f scale = new Vector3f(
         (float) Config.UmbralBlade.SCALE_X, (float) Config.UmbralBlade.SCALE_Y, (float) Config.UmbralBlade.SCALE_Z);
-
     @Getter
     private final Predicate<UmbralBlade> endHoverPredicate;
     @Getter
@@ -132,7 +145,6 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
     @Getter
     @Setter
     private boolean attackCompleted = false;
-
     @Getter
     @Setter
     private ControlVectors ctrlPointsForLunge;
@@ -156,12 +168,104 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
 
     /**
      * Tracks whether the blade item (true) or the link item (false) should occupy slot 0.
-     * Set by state transitions — independent of actual inventory contents so player
-     * manipulation cannot desync it.
+     * Independent of actual inventory contents so player manipulation cannot desync it.
      */
     @Getter
     @Setter
     private boolean bladeWielded = false;
+
+    @Getter
+    @Setter
+    private long lastActionTime = 0;
+
+    // -----------------------------------------------------------------------
+    // Impalement bookkeeping (set by the lunge collision pipeline; read by FSM transitions)
+    // -----------------------------------------------------------------------
+
+    /**
+     * The entity most recently struck by a lunge. Set by the lunge {@code onEntity} callback;
+     * read by FSM transitions to drive the LungingState/GrabImpaleState -> LodgedState branch.
+     */
+    @Getter
+    @Setter
+    private SwordEntity hitEntity;
+
+    /**
+     * The blade's velocity direction at the moment of the last hit. Captured by lunge drivers
+     * and read by FSM knockback computations and {@link #impale}.
+     */
+    private Vector lastVelocity = new Vector();
+
+    /**
+     * Whether the blade has been flagged as retrieved. Debounced by {@link #setRetrieved} to
+     * preserve the legacy 60 ms hold-window behavior.
+     */
+    @Getter
+    private boolean retrieved;
+
+    /** The active {@link Impalement} record while the blade is in {@link LodgedState}. */
+    @Getter
+    @Setter
+    private Impalement thisImpalement;
+
+    /**
+     * Predicate tested by the {@link ImpalementFollowDriver} to decide when impalement ends.
+     * Composed at the blade level so the driver remains FSM-agnostic.
+     */
+    @Getter
+    private final Predicate<UmbralBlade> exitImpalementStatePredicate;
+
+    // -----------------------------------------------------------------------
+    // Lifecycle
+    // -----------------------------------------------------------------------
+
+    private boolean disposed = false;
+
+    // -----------------------------------------------------------------------
+    // Construction
+    // -----------------------------------------------------------------------
+
+    /** Constructs the UmbralBlade, spawning its display and initialising the FSM and attack chains. */
+    public UmbralBlade(Combatant thrower, ItemStack weapon) {
+        this.displaySetup = display -> {
+            display.setItemStack(weapon);
+            display.setTransformation(new Transformation(
+                new Vector3f(0.28f, -1.35f, -0.5f),
+                new Quaternionf().rotationY((float) Math.PI / 2).rotateZ(-(float) Math.PI / (1.65f)),
+                new Vector3f(0.85f, 1.3f, 1f),
+                new Quaternionf()
+            ));
+            display.setPersistent(false);
+            thrower.self().addPassenger(display);
+            display.setBillboard(Display.Billboard.FIXED);
+        };
+
+        this.bladeDisplay = new BladeDisplay(scale);
+        this.bladeDisplay.respawn(thrower.self(), displaySetup);
+
+        this.identity = new BladeIdentity(thrower, weapon, createLinkItem(thrower), createBladeItem(thrower, weapon));
+
+        this.attackEndCallback = () -> attackCompleted = true;
+
+        loadBasicAttacks();
+
+        this.bladeStateMachine = new UmbralStateMachine(this, new SheathedState());
+        bladeStateMachine.initTransitions();
+
+        this.bladeMotion = new BladeMotion(this);
+
+        this.exitImpalementStatePredicate = blade -> !inState(LodgedState.class);
+        this.endHoverPredicate = blade -> !bladeStateMachine.inState(new StandbyState());
+    }
+
+    // -----------------------------------------------------------------------
+    // Identity-derived accessors
+    // -----------------------------------------------------------------------
+
+    /** Returns the blade's owning {@link Combatant}. */
+    public Combatant getThrower() {
+        return identity.thrower();
+    }
 
     /** Returns the original weapon {@link ItemStack} the blade was created from. */
     public ItemStack getWeapon() {
@@ -176,18 +280,12 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
     /**
      * Returns the Soul Link {@link ItemStack} for use as an inventory item.
      * Use {@link #getLinkAnchor()} when slot-restoration logic is needed.
-     *
-     * @return the Soul Link ItemStack
      */
     public ItemStack getLink() {
         return identity.link().getItemStack();
     }
 
-    /**
-     * Returns the {@link SoulLinkItem} anchor for slot-restoration and satisfaction checks.
-     *
-     * @return the Soul Link anchor
-     */
+    /** Returns the {@link SoulLinkItem} anchor for slot-restoration and satisfaction checks. */
     public SoulLinkItem getLinkAnchor() {
         return identity.link();
     }
@@ -195,8 +293,6 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
     /**
      * Returns the correct {@link ItemStack} for slot 0 based on the internal
      * {@link #bladeWielded} flag — the blade when active, the link otherwise.
-     *
-     * @return the ItemStack that should currently occupy slot 0
      */
     public ItemStack getExpectedSlotItem() {
         return bladeWielded ? identity.blade() : getLink();
@@ -207,7 +303,7 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
      * Ensures slot 0 contains the correct item based on {@link #bladeWielded}.
      */
     public void purgeStrayItems() {
-        if (!(thrower instanceof SwordPlayer sp)) return;
+        if (!(identity.thrower() instanceof SwordPlayer sp)) return;
         org.bukkit.inventory.PlayerInventory inv = sp.getPlayer().getInventory();
 
         for (int i = 1; i < inv.getSize(); i++) {
@@ -219,7 +315,6 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
             }
         }
 
-        // Ensure slot 0 has the correct item
         ItemStack slot0 = inv.getItem(0);
         ItemStack expected = getExpectedSlotItem();
         NamespacedKey expectedKey = bladeWielded ? KeyRegistry.UMBRAL_BLADE_KEY : KeyRegistry.SOUL_LINK_KEY;
@@ -228,42 +323,9 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
         }
     }
 
-    /** Constructs the UmbralBlade, spawning its display entity and initialising the FSM and attack chains. */
-    public UmbralBlade(Combatant thrower, ItemStack weapon) {
-        super(thrower, display -> {
-            display.setItemStack(weapon);
-            display.setTransformation(new Transformation(
-                    new Vector3f(0.28f, -1.35f, -0.5f),
-                    new Quaternionf().rotationY((float) Math.PI / 2).rotateZ(-(float) Math.PI / (1.65f)),
-                    new Vector3f(0.85f, 1.3f, 1f),
-                    new Quaternionf()
-            ));
-            display.setPersistent(false);
-
-            thrower.self().addPassenger(display);
-            display.setBillboard(Display.Billboard.FIXED);
-        });
-
-        // TODO: Removed the setup call; must set up elsewhere now.
-
-        this.bladeDisplay = new BladeDisplay(scale);
-        this.bladeDisplay.adopt(display);
-
-        this.identity = new BladeIdentity(thrower, weapon, createLinkItem(thrower), createBladeItem(thrower, weapon));
-
-        this.attackEndCallback = () -> attackCompleted = true;
-
-        loadBasicAttacks();
-
-        this.bladeStateMachine = new UmbralStateMachine(this, new SheathedState());
-        bladeStateMachine.initTransitions();
-
-        this.bladeMotion = new BladeMotion(this);
-
-        exitImpalementStatePredicate = blade -> !inState(LodgedState.class);
-
-        endHoverPredicate = blade -> !bladeStateMachine.inState(new StandbyState());
-    }
+    // -----------------------------------------------------------------------
+    // Input request API
+    // -----------------------------------------------------------------------
 
     /** Pushes the given request into the input buffer for evaluation on the next FSM tick. */
     public void request(BladeRequest request) {
@@ -278,9 +340,7 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
     /** Returns {@code true} if any of the given requests is present in the input buffer. */
     public boolean isRequested(BladeRequest... requests) {
         for (BladeRequest request : requests) {
-            if (inputBuffer.consumeIfPresent(request)) {
-                return true;
-            }
+            if (inputBuffer.consumeIfPresent(request)) return true;
         }
         return false;
     }
@@ -292,7 +352,7 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
 
     /** Returns {@code true} if this blade belongs to the given combatant. */
     public boolean isOwnedBy(Combatant combatant) {
-        return combatant.getUniqueId().equals(thrower.getUniqueId());
+        return combatant.getUniqueId().equals(identity.thrower().getUniqueId());
     }
 
     /** Returns {@code true} if the FSM is currently in the given state class. */
@@ -300,32 +360,32 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
         return bladeStateMachine.getState().getClass().equals(clazz);
     }
 
+    // -----------------------------------------------------------------------
+    // Per-tick orchestration
+    // -----------------------------------------------------------------------
+
     /**
      * Ticks the blade: disposes if the thrower is invalid, advances the installed motion driver,
      * then advances the FSM by one tick. Motion is ticked first so that states observe the
      * post-tick blade position when their {@code onTick} runs.
      */
     public void onTick() {
-        if (thrower.isInvalid()) {
-//            thrower.message("Ending Umbral Blade");
+        if (disposed) return;
+        if (identity.thrower().isInvalid()) {
             dispose();
+            return;
         }
-
         bladeMotion.tick();
-
-        if (bladeStateMachine != null)
-            bladeStateMachine.tick();
+        bladeStateMachine.tick();
     }
 
     // -----------------------------------------------------------------------
     // BladeMotionHost — bridge from the motion subsystem to this blade's display + thrower.
-    // Drivers never touch the ItemDisplay directly; every motion-driven write to the world
-    // routes through these methods so display-handle ownership stays with the blade.
     // -----------------------------------------------------------------------
 
     @Override
     public Combatant thrower() {
-        return thrower;
+        return identity.thrower();
     }
 
     @Override
@@ -348,6 +408,54 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
         return bladeDisplay.isValid();
     }
 
+    // -----------------------------------------------------------------------
+    // InteractiveItem — required for legacy world-item integration paths
+    // -----------------------------------------------------------------------
+
+    @Override
+    public ItemDisplay getDisplay() {
+        return bladeDisplay.handle();
+    }
+
+    @Override
+    public ItemStack getItemStack() {
+        return identity.blade();
+    }
+
+    // -----------------------------------------------------------------------
+    // Lodgeable — impalement bookkeeping contract
+    // -----------------------------------------------------------------------
+
+    @Override
+    public SwordEntity getImpaledEntity() {
+        return hitEntity;
+    }
+
+    /**
+     * Sets the retrieved flag with a 60 ms automatic reset window. Only schedules the reset when
+     * setting to {@code true} so repeated {@code false} calls do not stack scheduled tasks.
+     */
+    @Override
+    public void setRetrieved(boolean retrieved) {
+        this.retrieved = retrieved;
+        if (retrieved) {
+            SwordScheduler.runBukkitTaskLater(() -> this.retrieved = false, 60, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /**
+     * In the FSM-driven blade, "dispose with new interactive item" is interpreted as a recall
+     * request — the blade returns to the thrower rather than dropping a world item.
+     */
+    @Override
+    public void disposeWithNewInteractiveItem() {
+        request(BladeRequest.RECALL);
+    }
+
+    // -----------------------------------------------------------------------
+    // Display transitions per FSM state
+    // -----------------------------------------------------------------------
+
     // TODO: #240 - Make a method for calculating correct orientation of blade for edge to align with plane of swing on attack
     /** Applies the display transformation for the given state class after a 50 ms delay. */
     public void setDisplayTransformation(Class<? extends State<UmbralBlade>> state) {
@@ -361,14 +469,7 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
         );
     }
 
-    /**
-     * Returns the interpolation duration in ticks to use when transitioning the blade display
-     * into the given state. Fast action states use short durations; idle/equipped states use longer
-     * durations for smoother visual transitions.
-     *
-     * @param state the target state class
-     * @return interpolation duration in ticks
-     */
+    /** Returns the interpolation duration in ticks to use when transitioning into the given state. */
     private int getInterpolationDurationForState(Class<? extends State<UmbralBlade>> state) {
         if (state == LungingState.class || state == GrabImpaleState.class) return 2;
         if (state == AttackingQuickState.class || state == AttackingHeavyState.class) return 2;
@@ -403,15 +504,13 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
                 new Vector3f(),
                 new Quaternionf().rotateX((float) Math.PI / 2),
                 scale,
-                new Quaternionf()
-            );
+                new Quaternionf());
         } else if (state == GrabImpaleState.class) {
             return new Transformation(
                 new Vector3f(),
                 new Quaternionf().rotateX((float) -Math.PI / 2),
                 scale,
-                new Quaternionf()
-            );
+                new Quaternionf());
         } else if (state == LodgedState.class) {
             return bladeDisplay.currentTransformation();
         } else if (state == AttackingQuickState.class || state == AttackingHeavyState.class) {
@@ -429,176 +528,82 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
         }
     }
 
-    /** Starts the cosine idle bobbing animation on the blade's display entity. */
+    /** Starts the cosine idle bobbing animation on the blade's display. */
     public void startIdleMovement() {
         bladeDisplay.startBobbing(Config.UmbralBlade.IDLE_MOVEMENT_AMPLITUDE, Config.UmbralBlade.IDLE_MOVEMENT_PERIOD);
     }
 
-    /** Cancels the idle bobbing animation task if it is currently running. */
+    /** Cancels the idle bobbing animation if running. */
     public void endIdleMovement() {
         bladeDisplay.stopBobbing();
     }
 
-    @Override
-    public void groundedCheck() {
-        RayTraceResult hitBlock = display.getWorld()
-            .rayTraceBlocks(prev, velocity, // detect from prev, checks go through later, which is what I need to happen.
-                cur.toVector()
-                    .subtract(prev.toVector())
-                    .lengthSquared() * Config.Detection.THROW_GROUND_CHECK_MULTIPLIER / 10,
-                FluidCollisionMode.NEVER, true);
-
-        if (hitBlock == null) {
-            return;
-        }
-
-        if (hitBlock.getHitBlock() == null || hitBlock.getHitBlock().getType().isAir())
-            return;
-
-        grounded = true;
-        stuckBlock = hitBlock.getHitBlock();
-        cur = hitBlock.getHitPosition().toLocation(display.getWorld());
-    }
-
-    @SuppressWarnings("unchecked")
-    private void loadBasicAttacks() {
-        basicAttacks = new Function[]{
-            combatant -> new UmbralBladeAttack(display, AttackType.WIDE_UMBRAL_SLASH1_WINDUP,
-                true, true, 1,
-                10, 30, 500,
-                0, 1)
-                .setBlade(this)
-                .setInitialMovementTicks(25)
-                .setDrawParticles(false)
-                .setNextAttack(
-                    new UmbralBladeAttack(display, AttackType.WIDE_UMBRAL_SLASH1,
-                        true, false, 0,
-                        20, 10, 100,
-                        0, 1)
-                        .setBlade(this)
-                        .setOnEntityHitInstructions(swordEntity -> Prefab.Particles.BLEED.display(swordEntity.getChestLocation()))
-                        .setCallback(attackEndCallback, 200),
-                    100),
-
-            combatant -> new UmbralBladeAttack(display, AttackType.WIDE_UMBRAL_SLASH2_WINDUP,
-                true, true, 2,
-                10, 30, 500,
-                0, 1)
-                .setBlade(this)
-                .setInitialMovementTicks(25)
-                .setDrawParticles(false)
-                .setNextAttack(
-                    new UmbralBladeAttack(display, AttackType.WIDE_UMBRAL_SLASH2,
-                        true, false, 0,
-                        20, 10, 100,
-                        0, 1)
-                        .setBlade(this)
-                        .setOnEntityHitInstructions(swordEntity -> Prefab.Particles.BLEED.display(swordEntity.getChestLocation()))
-                        .setCallback(attackEndCallback, 200),
-                    100),
-
-            combatant -> new UmbralBladeAttack(display, AttackType.WIDE_UMBRAL_SLASH3_WINDUP,
-                false, true, 3,
-                10, 30, 500,
-                0, 1.2)
-                .setBlade(this)
-                .setInitialMovementTicks(25)
-                .setDrawParticles(false)
-                .setNextAttack(
-                    new UmbralBladeAttack(display, AttackType.WIDE_UMBRAL_SLASH3,
-                        false, false, 0,
-                        20, 10, 50,
-                        0, 1)
-                        .setBlade(this)
-                        .setOnEntityHitInstructions(swordEntity -> Prefab.Particles.BLEED.display(swordEntity.getChestLocation()))
-                        .setCallback(attackEndCallback, 200),
-                    250)
-        };
-    }
-
-    /**
-     * Builds the {@link SoulLinkItem} for the given thrower. Pure factory — no instance state.
-     * Result is consumed once during {@link BladeIdentity} construction.
-     */
-    private static SoulLinkItem createLinkItem(Combatant thrower) {
-        return new SoulLinkItem(new ItemStackBuilder(Material.HEAVY_CORE)
-            .hideAll()
-            .name(Component.text("~ ", Config.SwordColor.TEXT_ITEM_NAME)
-                .append(Component.text(thrower.getDisplayName() + "'s Soul Link",
-                    Config.SwordColor.TEXT_ITEM_NAME, TextDecoration.BOLD))
-                .append(Component.text(" ~", Config.SwordColor.TEXT_ITEM_NAME)))
-            .lore(Prefab.Text.SOUL_LINK_LORE)
-            .unbreakable(true)
-            .tag(KeyRegistry.SOUL_LINK_KEY, PersistentDataType.STRING, thrower.getUniqueId().toString())
-            .tagSwordItem(SwordItemType.UMBRAL_LINK)
-            .build());
-    }
-
-    /**
-     * Builds the visual blade {@link ItemStack} for the given thrower and source weapon.
-     * Pure factory — no instance state. Result is consumed once during
-     * {@link BladeIdentity} construction.
-     */
-    private static ItemStack createBladeItem(Combatant thrower, ItemStack weapon) {
-        return new ItemStackBuilder(weapon.getType())
-            .hideAll()
-            .name(Component.text("~ ", Config.SwordColor.TEXT_COOL_DARK)
-                .append(Component.text(thrower.getDisplayName() + "'s Blade",
-                    Config.SwordColor.TEXT_COOL, TextDecoration.BOLD))
-                .append(Component.text(" ~", Config.SwordColor.TEXT_COOL_DARK)))
-            .lore(Prefab.Text.UMBRAL_BLADE_LORE)
-            .unbreakable(true)
-            .tag(KeyRegistry.UMBRAL_BLADE_KEY, PersistentDataType.STRING, thrower.getUniqueId().toString())
-            .tag(KeyRegistry.SPECIAL_ITEM_KEY, PersistentDataType.BOOLEAN, true)
-            .tag(KeyRegistry.NON_MOVABLE_KEY, PersistentDataType.BOOLEAN, true)
-            .tagSwordItem(SwordItemType.UMBRAL_BLADE)
-            .tagAttackStyle(WeaponAttackStyle.SLASH)
-            .build();
-    }
-
     /** Removes the existing display entity and respawns a fresh one at the thrower's eye level. */
     public void resetWeaponDisplay() {
-        bladeDisplay.respawn(thrower.self(), displaySetupInstructions);
-        // TODO: #step-9 — sync removed once inheritance is severed and bladeDisplay becomes
-        //       the only handle holder.
-        display = bladeDisplay.handle();
+        bladeDisplay.respawn(identity.thrower().self(), displaySetup);
     }
 
-    @Override
-    public void generateFunctions(double initialVelocity) {
-        if (ctrlPointsForLunge == null) {
-            super.generateFunctions(initialVelocity);
-        }
-        else {
-            calcBezierTrajectory();
-        }
+    // -----------------------------------------------------------------------
+    // Lunge collision integration — called from LungingDriver callbacks
+    // -----------------------------------------------------------------------
+
+    /**
+     * Captures the blade's instantaneous velocity vector, used by FSM transition actions to
+     * compute knockback and by {@link #impale} to orient the impalement follow.
+     *
+     * @param velocity the velocity vector at impact time; defensively cloned
+     */
+    public void setLastVelocity(Vector velocity) {
+        this.lastVelocity = velocity == null ? new Vector() : velocity.clone();
     }
 
-    protected void calcBezierTrajectory() {
-        SwordEntity target = inState(GrabImpaleState.class) ?
-            getThrower().getGrabbedEntity() :
-            thrower.getTargetedEntity(20);
-
-        origin = display.getLocation();
-        cur = origin.clone();
-        prev = cur.clone();
-
-        Vector dir;
-        if (target == null) {
-            Location intent = thrower.locFromEyeDir(20);
-            dir = intent.toVector().subtract(display.getLocation().toVector());
-        }
-        else {
-            DrawUtil.secant(List.of(Prefab.Particles.TEST_SPARKLE), display.getLocation(), target.getChestLocation(), 0.5);
-
-            dir = target.getChestLocation().toVector().subtract(display.getLocation().toVector());
-        }
-        this.currentBasis = VectorUtil.getBasis(display.getLocation().setDirection(dir), dir);
-
-        ControlVectors adjusted = ctrlPointsForLunge.adjustToBasis(currentBasis, 1);
-        this.positionFunction = BezierUtil.cubicBezier3D(adjusted);
-        this.velocityFunction = t -> dir.clone().multiply(0.5);
+    /** Returns a defensive clone of the last captured velocity vector. */
+    public Vector getVelocity() {
+        return lastVelocity.clone();
     }
+
+    /** Emits the dramatic dust-pillar particle effect at the given location for a stuck-block hit. */
+    public void emitStuckBlockEffect(Block block, Location at) {
+        new ParticleWrapper(
+            () -> Particle.DUST_PILLAR, () -> 50, () -> 1.0, () -> 1.0, () -> 1.0)
+            .withBlockData(block::getBlockData)
+            .display(at);
+    }
+
+    /**
+     * Embeds the blade in the given target entity by installing an {@link ImpalementFollowDriver}
+     * and registering the {@link Impalement} bookkeeping. Reads {@link #hitEntity} (set by the
+     * lunge {@code onEntity} callback) and {@link #lastVelocity} (also captured at hit time).
+     */
+    public void impale(LivingEntity hit) {
+        thisImpalement = new Impalement(hitEntity);
+        thisImpalement.startShouldDisposeCheckTask(hitEntity, this);
+        hitEntity.addImpalement(thisImpalement);
+
+        double max = hit.getEyeLocation().getY();
+        double feet = hit.getLocation().getY();
+        double diff = max - feet;
+        Location curLoc = bladeDisplay.currentLocation();
+        double curY = curLoc != null ? curLoc.getY() : feet;
+        double heightOffset = Math.max(0, Math.min(curY - feet, hit.getHeight()));
+
+        boolean followHead = !Config.Combat.IMPALEMENT_HEAD_FOLLOW_EXCEPTIONS.contains(hitEntity.type())
+            && heightOffset >= diff * Config.Combat.IMPALEMENT_HEAD_ZONE_RATIO;
+
+        Vector dir = lastVelocity.lengthSquared() < 1e-9 ? new Vector(0, 0, 1) : lastVelocity.clone().normalize();
+        bladeMotion.install(new ImpalementFollowDriver(
+            hitEntity,
+            dir,
+            heightOffset,
+            followHead,
+            () -> !inState(LodgedState.class),
+            2
+        ));
+    }
+
+    // -----------------------------------------------------------------------
+    // Combat helpers
+    // -----------------------------------------------------------------------
 
     /** Sets the reclaim type and schedules a reset to {@link ReclaimType#NONE} after the given duration. */
     public void setReclaimType(ReclaimType type, int durationMilliseconds) {
@@ -618,10 +623,9 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
             return;
         }
 
-        if (inState(WaitingState.class)) { // set reclaim type for 1/4 of a second.
+        if (inState(WaitingState.class)) {
             setReclaimType(ReclaimType.CIRCULAR_SLASH, Config.UmbralBlade.RECLAIM_WINDOW_MS);
-        }
-        else if (inState(LodgedState.class)) {
+        } else if (inState(LodgedState.class)) {
             setReclaimType(ReclaimType.EVISCERATE, Config.UmbralBlade.RECLAIM_WINDOW_MS);
         }
 
@@ -640,126 +644,14 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
                     () -> {}
                 )
             );
-
-        }
-        else {
+        } else {
             request(BladeRequest.STANDBY);
         }
-    }
-
-    @Override
-    protected boolean shouldShowLandingMarker() {
-        return false;
-    }
-
-    @Override
-    protected void teleport() {
-        bladeDisplay.teleportTo(cur, to, 2);
-    }
-
-    @Override
-    protected void rotate() {
-        // no-op
-    }
-
-    @Override
-    protected void onCatch() {
-        // No action on catch.
-    }
-
-    @Override
-    protected void onGrounded() {
-        if (stuckBlock != null) {
-            this.blockDustPillarParticle = new ParticleWrapper(
-                () -> Particle.DUST_PILLAR, () -> 50, () -> 1.0, () -> 1.0, () -> 1.0)
-                .withBlockData(() -> stuckBlock.getBlockData());
-            blockDustPillarParticle.display(cur);
-        }
-        request(BladeRequest.RECALL);
-    }
-
-    @Override
-    public void onEnd() {
-        super.onEnd();
-        finishedLunging = true;
-        resetFlightState();
-    }
-
-    @Override
-    public void onHit() {
-        // no-op — hit effects are applied explicitly in FSM transition actions and LodgedState.onEnter()
-    }
-
-    @Override
-    protected void handleOnReleaseActions() {
-        Prefab.Sounds.THROW.playForAllInRadius(getThrower().self());
-    }
-
-    @Override
-    public void handleItemDamageAndCheckIfBroken() {}
-
-    /**
-     * Overrides the inherited impalement follow-task to install an {@link ImpalementFollowDriver}
-     * on this blade's {@link BladeMotion} instead of scheduling a {@code DisplayUtil} task.
-     * <p>
-     * Behavioral parity with the parent: bookkeeping for the {@link Impalement} record is preserved
-     * (registered on the hit entity and on this blade), and the driver tracks the hit entity with the
-     * same {@code heightOffset} / {@code followHead} resolution. The exit predicate watches the FSM
-     * — the driver reports DONE as soon as the blade leaves {@link LodgedState}.
-     */
-    @Override
-    public void impale(LivingEntity hit) {
-        setThisImpalement(new Impalement(hitEntity));
-        getThisImpalement().startShouldDisposeCheckTask(hitEntity, this);
-        hitEntity.addImpalement(getThisImpalement());
-
-        double max = hit.getEyeLocation().getY();
-        double feet = hit.getLocation().getY();
-        double diff = max - feet;
-        double heightOffset = Math.max(0, Math.min(cur.getY() - feet, hit.getHeight()));
-
-        boolean followHead = !Config.Combat.IMPALEMENT_HEAD_FOLLOW_EXCEPTIONS.contains(hitEntity.type())
-            && heightOffset >= diff * Config.Combat.IMPALEMENT_HEAD_ZONE_RATIO;
-
-        bladeMotion.install(new ImpalementFollowDriver(
-            hitEntity,
-            velocity.clone().normalize(),
-            heightOffset,
-            followHead,
-            () -> !inState(LodgedState.class),
-            2
-        ));
-    }
-
-    @Override
-    public void disposeWithNewInteractiveItem() {
-        request(BladeRequest.RECALL);
-    }
-
-    @Override
-    public void dispose() {
-        bladeStateMachine.getState().onExit(this);
-        bladeStateMachine.setDeactivated(true);
-        bladeMotion.stop();
-        bladeDisplay.dispose();
-        // TODO: #step-9 — sync removed once inheritance is severed and bladeDisplay becomes
-        //       the only handle holder.
-        display = null;
-    }
-
-    /** Clears all mid-flight flags so the blade can be launched again cleanly. */
-    public void resetFlightState() {
-        hit = false;
-        grounded = false;
-        caught = false;
-        stuckBlock = null;
-        timeScalingFactor = -1;
     }
 
     /** Sets the active dash direction and resets it to {@link DashDirection#NONE} after 250 ms. */
     public void setDashingDirection(DashDirection direction) {
         this.dashDirection = direction;
-
         SwordScheduler.runBukkitTaskLater(
             () -> dashDirection = DashDirection.NONE,
             250, TimeUnit.MILLISECONDS
@@ -775,5 +667,122 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
     public void requestQuickAttack(int comboStep) {
         currentComboStep = comboStep;
         request(BladeRequest.ATTACK_QUICK);
+    }
+
+    // -----------------------------------------------------------------------
+    // Disposal
+    // -----------------------------------------------------------------------
+
+    /**
+     * Idempotent disposal: deactivates the FSM, stops motion, removes the display entity. After
+     * disposal {@link #onTick} is a no-op and all subsystems are in their terminal state.
+     */
+    @Override
+    public void dispose() {
+        if (disposed) return;
+        disposed = true;
+        bladeStateMachine.getState().onExit(this);
+        bladeStateMachine.setDeactivated(true);
+        bladeMotion.stop();
+        bladeDisplay.dispose();
+    }
+
+    // -----------------------------------------------------------------------
+    // Private factories — pure helpers used during construction
+    // -----------------------------------------------------------------------
+
+    @SuppressWarnings("unchecked")
+    private void loadBasicAttacks() {
+        ItemDisplay handle = bladeDisplay.handle();
+        basicAttacks = new Function[]{
+            combatant -> new UmbralBladeAttack(handle, AttackType.WIDE_UMBRAL_SLASH1_WINDUP,
+                true, true, 1,
+                10, 30, 500,
+                0, 1)
+                .setBlade(this)
+                .setInitialMovementTicks(25)
+                .setDrawParticles(false)
+                .setNextAttack(
+                    new UmbralBladeAttack(handle, AttackType.WIDE_UMBRAL_SLASH1,
+                        true, false, 0,
+                        20, 10, 100,
+                        0, 1)
+                        .setBlade(this)
+                        .setOnEntityHitInstructions(swordEntity -> Prefab.Particles.BLEED.display(swordEntity.getChestLocation()))
+                        .setCallback(attackEndCallback, 200),
+                    100),
+
+            combatant -> new UmbralBladeAttack(handle, AttackType.WIDE_UMBRAL_SLASH2_WINDUP,
+                true, true, 2,
+                10, 30, 500,
+                0, 1)
+                .setBlade(this)
+                .setInitialMovementTicks(25)
+                .setDrawParticles(false)
+                .setNextAttack(
+                    new UmbralBladeAttack(handle, AttackType.WIDE_UMBRAL_SLASH2,
+                        true, false, 0,
+                        20, 10, 100,
+                        0, 1)
+                        .setBlade(this)
+                        .setOnEntityHitInstructions(swordEntity -> Prefab.Particles.BLEED.display(swordEntity.getChestLocation()))
+                        .setCallback(attackEndCallback, 200),
+                    100),
+
+            combatant -> new UmbralBladeAttack(handle, AttackType.WIDE_UMBRAL_SLASH3_WINDUP,
+                false, true, 3,
+                10, 30, 500,
+                0, 1.2)
+                .setBlade(this)
+                .setInitialMovementTicks(25)
+                .setDrawParticles(false)
+                .setNextAttack(
+                    new UmbralBladeAttack(handle, AttackType.WIDE_UMBRAL_SLASH3,
+                        false, false, 0,
+                        20, 10, 50,
+                        0, 1)
+                        .setBlade(this)
+                        .setOnEntityHitInstructions(swordEntity -> Prefab.Particles.BLEED.display(swordEntity.getChestLocation()))
+                        .setCallback(attackEndCallback, 200),
+                    250)
+        };
+    }
+
+    /**
+     * Builds the {@link SoulLinkItem} for the given thrower. Pure factory — no instance state.
+     */
+    private static SoulLinkItem createLinkItem(Combatant thrower) {
+        return new SoulLinkItem(new ItemStackBuilder(Material.HEAVY_CORE)
+            .hideAll()
+            .name(Component.text("~ ", Config.SwordColor.TEXT_ITEM_NAME)
+                .append(Component.text(thrower.getDisplayName() + "'s Soul Link",
+                    Config.SwordColor.TEXT_ITEM_NAME, TextDecoration.BOLD))
+                .append(Component.text(" ~", Config.SwordColor.TEXT_ITEM_NAME)))
+            .lore(Prefab.Text.SOUL_LINK_LORE)
+            .unbreakable(true)
+            .tag(KeyRegistry.SOUL_LINK_KEY, PersistentDataType.STRING, thrower.getUniqueId().toString())
+            .tagSwordItem(SwordItemType.UMBRAL_LINK)
+            .build());
+    }
+
+    /**
+     * Builds the visual blade {@link ItemStack} for the given thrower and source weapon.
+     * Pure factory — no instance state.
+     */
+    private static ItemStack createBladeItem(Combatant thrower, ItemStack weapon) {
+        return new ItemStackBuilder(weapon.getType())
+            .hideAll()
+            .name(Component.text("~ ", Config.SwordColor.TEXT_COOL_DARK)
+                .append(Component.text(thrower.getDisplayName() + "'s Blade",
+                    Config.SwordColor.TEXT_COOL, TextDecoration.BOLD))
+                .append(Component.text(" ~", Config.SwordColor.TEXT_COOL_DARK)))
+            .lore(Prefab.Text.UMBRAL_BLADE_LORE)
+            .unbreakable(true)
+            .tag(KeyRegistry.UMBRAL_BLADE_KEY, PersistentDataType.STRING, thrower.getUniqueId().toString())
+            .tag(KeyRegistry.SPECIAL_ITEM_KEY, PersistentDataType.BOOLEAN, true)
+            .tag(KeyRegistry.NON_MOVABLE_KEY, PersistentDataType.BOOLEAN, true)
+            .tagSwordItem(SwordItemType.UMBRAL_BLADE)
+            .tagAttackStyle(WeaponAttackStyle.SLASH)
+            .build();
     }
 }

--- a/src/main/java/btm/sword/umbral/UmbralBlade.java
+++ b/src/main/java/btm/sword/umbral/UmbralBlade.java
@@ -24,6 +24,7 @@ import org.joml.Vector3f;
 
 import btm.sword.action.movement.DashDirection;
 import btm.sword.action.throwing.Lodgeable;
+import btm.sword.action.throwing.impale.Impalement;
 import btm.sword.action.throwing.types.ThrownItem;
 import btm.sword.combat.attack.Attack;
 import btm.sword.combat.attack.UmbralBladeAttack;
@@ -45,6 +46,7 @@ import btm.sword.umbral.input.BladeRequest;
 import btm.sword.umbral.input.InputBuffer;
 import btm.sword.umbral.motion.BladeMotion;
 import btm.sword.umbral.motion.BladeMotionHost;
+import btm.sword.umbral.motion.drivers.ImpalementFollowDriver;
 import btm.sword.umbral.statemachine.UmbralStateMachine;
 import btm.sword.umbral.statemachine.state.AttackingHeavyState;
 import btm.sword.umbral.statemachine.state.AttackingQuickState;
@@ -698,6 +700,39 @@ public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHos
 
     @Override
     public void handleItemDamageAndCheckIfBroken() {}
+
+    /**
+     * Overrides the inherited impalement follow-task to install an {@link ImpalementFollowDriver}
+     * on this blade's {@link BladeMotion} instead of scheduling a {@code DisplayUtil} task.
+     * <p>
+     * Behavioral parity with the parent: bookkeeping for the {@link Impalement} record is preserved
+     * (registered on the hit entity and on this blade), and the driver tracks the hit entity with the
+     * same {@code heightOffset} / {@code followHead} resolution. The exit predicate watches the FSM
+     * — the driver reports DONE as soon as the blade leaves {@link LodgedState}.
+     */
+    @Override
+    public void impale(LivingEntity hit) {
+        setThisImpalement(new Impalement(hitEntity));
+        getThisImpalement().startShouldDisposeCheckTask(hitEntity, this);
+        hitEntity.addImpalement(getThisImpalement());
+
+        double max = hit.getEyeLocation().getY();
+        double feet = hit.getLocation().getY();
+        double diff = max - feet;
+        double heightOffset = Math.max(0, Math.min(cur.getY() - feet, hit.getHeight()));
+
+        boolean followHead = !Config.Combat.IMPALEMENT_HEAD_FOLLOW_EXCEPTIONS.contains(hitEntity.type())
+            && heightOffset >= diff * Config.Combat.IMPALEMENT_HEAD_ZONE_RATIO;
+
+        bladeMotion.install(new ImpalementFollowDriver(
+            hitEntity,
+            velocity.clone().normalize(),
+            heightOffset,
+            followHead,
+            () -> !inState(LodgedState.class),
+            2
+        ));
+    }
 
     @Override
     public void disposeWithNewInteractiveItem() {

--- a/src/main/java/btm/sword/umbral/UmbralBlade.java
+++ b/src/main/java/btm/sword/umbral/UmbralBlade.java
@@ -43,6 +43,8 @@ import btm.sword.runtime.scheduler.TimeArbiter;
 import btm.sword.runtime.statemachine.State;
 import btm.sword.umbral.input.BladeRequest;
 import btm.sword.umbral.input.InputBuffer;
+import btm.sword.umbral.motion.BladeMotion;
+import btm.sword.umbral.motion.BladeMotionHost;
 import btm.sword.umbral.statemachine.UmbralStateMachine;
 import btm.sword.umbral.statemachine.state.AttackingHeavyState;
 import btm.sword.umbral.statemachine.state.AttackingQuickState;
@@ -71,7 +73,7 @@ import net.kyori.adventure.text.format.TextDecoration;
 // while flying and attacking on its own, no soulfire is reaped on attacks
 // while in hand, higher soulfire intake on hit
 /** The signature UmbralBlade weapon — a thrown item backed by a full FSM managing all combat states and visual transitions. */
-public class UmbralBlade extends ThrownItem implements Lodgeable {
+public class UmbralBlade extends ThrownItem implements Lodgeable, BladeMotionHost {
     /** Type of dash-reclaim attack to perform on the next quick or heavy attack entry. */
     public enum ReclaimType {
         NONE,
@@ -82,6 +84,15 @@ public class UmbralBlade extends ThrownItem implements Lodgeable {
 
     @Getter
     private final UmbralStateMachine bladeStateMachine;
+    /**
+     * Per-tick motion subsystem. Owns the currently-installed
+     * {@link btm.sword.umbral.motion.BladeMotionDriver} (if any) and is the single writer
+     * of the blade's world-space position via the {@link BladeMotionHost} bridge below.
+     * Initially {@link BladeMotion.State#IDLE IDLE}; states install drivers on entry and
+     * stop on exit.
+     */
+    @Getter
+    private final BladeMotion bladeMotion;
     @Getter
     private Function<Combatant, Attack>[] basicAttacks;
     @Getter
@@ -226,6 +237,8 @@ public class UmbralBlade extends ThrownItem implements Lodgeable {
         this.bladeStateMachine = new UmbralStateMachine(this, new SheathedState());
         bladeStateMachine.initTransitions();
 
+        this.bladeMotion = new BladeMotion(this);
+
         exitImpalementStatePredicate = blade -> !inState(LodgedState.class);
 
         endHoverPredicate = blade -> !bladeStateMachine.inState(new StandbyState());
@@ -266,15 +279,55 @@ public class UmbralBlade extends ThrownItem implements Lodgeable {
         return bladeStateMachine.getState().getClass().equals(clazz);
     }
 
-    /** Ticks the blade: disposes if the thrower is invalid, then advances the FSM by one tick. */
+    /**
+     * Ticks the blade: disposes if the thrower is invalid, advances the installed motion driver,
+     * then advances the FSM by one tick. Motion is ticked first so that states observe the
+     * post-tick blade position when their {@code onTick} runs.
+     */
     public void onTick() {
         if (thrower.isInvalid()) {
 //            thrower.message("Ending Umbral Blade");
             dispose();
         }
 
+        bladeMotion.tick();
+
         if (bladeStateMachine != null)
             bladeStateMachine.tick();
+    }
+
+    // -----------------------------------------------------------------------
+    // BladeMotionHost — bridge from the motion subsystem to this blade's display + thrower.
+    // Drivers never touch the ItemDisplay directly; every motion-driven write to the world
+    // routes through these methods so display-handle ownership stays with the blade.
+    // -----------------------------------------------------------------------
+
+    @Override
+    public Combatant thrower() {
+        return thrower;
+    }
+
+    @Override
+    public void teleportDisplay(Location location, Vector direction, int teleportDuration) {
+        if (display == null || !display.isValid()) return;
+        TimeArbiter.teleportDisplay(display, location, direction, teleportDuration,
+            UmbralBlade.class, 0);
+    }
+
+    @Override
+    public void setDisplayTransformation(Transformation transformation, int transformDuration) {
+        if (display == null || !display.isValid()) return;
+        TimeArbiter.setDisplayTransformation(display, transformation, transformDuration);
+    }
+
+    @Override
+    public Location currentDisplayLocation() {
+        return (display == null || !display.isValid()) ? null : display.getLocation();
+    }
+
+    @Override
+    public boolean isDisplayValid() {
+        return display != null && display.isValid();
     }
 
     // TODO: #240 - Make a method for calculating correct orientation of blade for edge to align with plane of swing on attack
@@ -655,6 +708,7 @@ public class UmbralBlade extends ThrownItem implements Lodgeable {
     public void dispose() {
         bladeStateMachine.getState().onExit(this);
         bladeStateMachine.setDeactivated(true);
+        bladeMotion.stop();
         if (display != null && display.isValid()) {
             display.remove();
         }

--- a/src/main/java/btm/sword/umbral/collision/BladeCollider.java
+++ b/src/main/java/btm/sword/umbral/collision/BladeCollider.java
@@ -1,0 +1,116 @@
+package btm.sword.umbral.collision;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.bukkit.FluidCollisionMode;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.util.RayTraceResult;
+import org.bukkit.util.Vector;
+
+import btm.sword.util.entity.HitboxUtil;
+
+/**
+ * Stateless world-query helper used by UmbralBlade FSM states to detect block and entity
+ * collisions along a per-tick motion segment.
+ * <p>
+ * <b>Ownership:</b> {@code BladeCollider} owns no mutable state. The caller is responsible for
+ * supplying the segment endpoints and any per-tick "previous position" cache — that cache lives
+ * inside the producing {@link btm.sword.umbral.motion.BladeMotionDriver motion driver}, since
+ * only the driver knows what "previous tick" means semantically.
+ * <p>
+ * <b>Composition:</b> wraps Bukkit's {@link World#rayTraceBlocks} / {@link World#rayTraceEntities}
+ * for single-hit queries and {@link HitboxUtil#secant} for multi-hit sweeps. It does not
+ * reimplement raytracing.
+ */
+public final class BladeCollider {
+
+    private BladeCollider() {}
+
+    /**
+     * Performs a block-only raytrace from {@code from} to {@code to} and returns the first
+     * non-air block intersected, if any.
+     *
+     * @param from the segment start in world space
+     * @param to   the segment end in world space; must share a world with {@code from}
+     * @param mode how fluid blocks are treated by the trace
+     * @return the first {@link BlockHit} along the segment, or {@link Optional#empty()} if the
+     *         segment hits nothing
+     */
+    public static Optional<BlockHit> scanBlocks(Location from, Location to, FluidCollisionMode mode) {
+        Vector segment = to.toVector().subtract(from.toVector());
+        double length = segment.length();
+        if (length < 1e-6) return Optional.empty();
+
+        Vector direction = segment.clone().multiply(1.0 / length);
+        RayTraceResult result = from.getWorld().rayTraceBlocks(from, direction, length, mode, true);
+        if (result == null) return Optional.empty();
+
+        Block block = result.getHitBlock();
+        if (block == null || block.getType().isAir()) return Optional.empty();
+
+        Location hitPosition = result.getHitPosition().toLocation(from.getWorld());
+        BlockFace face = result.getHitBlockFace() != null ? result.getHitBlockFace() : BlockFace.UP;
+        return Optional.of(new BlockHit(result, block, hitPosition, face));
+    }
+
+    /**
+     * Performs an entity raytrace from {@code from} to {@code to} and returns the first matching
+     * entity along the segment, if any.
+     *
+     * @param from    the segment start in world space
+     * @param to      the segment end in world space; must share a world with {@code from}
+     * @param raySize the radial thickness of the ray, used as Bukkit's {@code raySize} parameter
+     * @param filter  predicate to include or exclude candidate entities; may be {@code null} to
+     *                accept all entities
+     * @return the first {@link EntityHit} along the segment, or {@link Optional#empty()} if no
+     *         matching entity is intersected
+     */
+    public static Optional<EntityHit> firstEntity(Location from, Location to, double raySize, Predicate<Entity> filter) {
+        Vector segment = to.toVector().subtract(from.toVector());
+        double length = segment.length();
+        if (length < 1e-6) return Optional.empty();
+
+        Vector direction = segment.clone().multiply(1.0 / length);
+        RayTraceResult result = from.getWorld().rayTraceEntities(from, direction, length, raySize, filter);
+        if (result == null || result.getHitEntity() == null) return Optional.empty();
+
+        Location hitPosition = result.getHitPosition().toLocation(from.getWorld());
+        return Optional.of(new EntityHit(result, result.getHitEntity(), hitPosition));
+    }
+
+    /**
+     * Sweeps the segment between {@code from} and {@code to} using a sphere walk and returns
+     * every {@link LivingEntity} detected along the path. Each detection is reported with the
+     * entity's location at the moment of detection; the {@link EntityHit#result()} field is
+     * {@code null} for sweep-based hits since no single raytrace produced them.
+     * <p>
+     * Use this when the blade should affect every entity in its swept volume on a single tick;
+     * use {@link #firstEntity} when only the closest hit matters.
+     *
+     * @param from    the segment start in world space
+     * @param to      the segment end in world space; must share a world with {@code from}
+     * @param raySize the radial thickness of the sweep, used as the spherical step size
+     * @param filter  predicate to include or exclude candidate entities; must not be {@code null}
+     * @return the list of {@link EntityHit} detections along the segment, in no particular order;
+     *         empty if nothing was detected
+     */
+    public static List<EntityHit> scanEntities(Location from, Location to, double raySize, Predicate<Entity> filter) {
+        HashSet<LivingEntity> hits = HitboxUtil.secant(from, to, raySize, filter);
+        if (hits.isEmpty()) return List.of();
+
+        List<EntityHit> out = new ArrayList<>(hits.size());
+        for (LivingEntity entity : hits) {
+            out.add(new EntityHit(null, entity, entity.getLocation()));
+        }
+        return out;
+    }
+}

--- a/src/main/java/btm/sword/umbral/collision/BlockHit.java
+++ b/src/main/java/btm/sword/umbral/collision/BlockHit.java
@@ -1,0 +1,20 @@
+package btm.sword.umbral.collision;
+
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.util.RayTraceResult;
+
+/**
+ * Result of a single block-collision query performed by {@link BladeCollider}.
+ * <p>
+ * Carries the raw {@link RayTraceResult} alongside the resolved hit {@link Location} and
+ * {@link BlockFace} for caller convenience — neither {@code position} nor {@code face} may be
+ * {@code null}, since a {@code BlockHit} is only constructed when both are known.
+ *
+ * @param result   the underlying raytrace result returned by Bukkit
+ * @param block    the block that was struck
+ * @param position the world-space position where the ray entered the block
+ * @param face     the face of the block that was struck
+ */
+public record BlockHit(RayTraceResult result, Block block, Location position, BlockFace face) {}

--- a/src/main/java/btm/sword/umbral/collision/EntityHit.java
+++ b/src/main/java/btm/sword/umbral/collision/EntityHit.java
@@ -1,0 +1,21 @@
+package btm.sword.umbral.collision;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.util.RayTraceResult;
+
+/**
+ * Result of a single entity-collision query performed by {@link BladeCollider}.
+ * <p>
+ * Carries the raw {@link RayTraceResult} alongside the resolved hit {@link Location} and the
+ * struck {@link Entity}. The {@code result} field may be {@code null} for entries produced by
+ * the multi-hit {@link BladeCollider#scanEntities} sweep, which discovers entities via radial
+ * proximity rather than a single ray; in that case {@code position} is the entity's location
+ * at the moment of detection. For single-hit lookups via {@link BladeCollider#firstEntity}
+ * {@code result} is always non-null.
+ *
+ * @param result   the underlying raytrace result, or {@code null} for sweep-based detections
+ * @param entity   the entity that was struck or detected
+ * @param position the world-space position of the hit
+ */
+public record EntityHit(RayTraceResult result, Entity entity, Location position) {}

--- a/src/main/java/btm/sword/umbral/motion/BladeMotion.java
+++ b/src/main/java/btm/sword/umbral/motion/BladeMotion.java
@@ -1,0 +1,162 @@
+package btm.sword.umbral.motion;
+
+import java.util.Objects;
+
+/**
+ * Single owner of the blade's per-tick motion. Hosts at most one {@link BladeMotionDriver} at a
+ * time and forwards each {@link #tick()} call to it.
+ * <p>
+ * <b>Lifecycle states</b> (see {@link State}):
+ * <ul>
+ *   <li>{@link State#IDLE IDLE} — initial state; no driver installed; {@link #tick()} is a no-op.</li>
+ *   <li>{@link State#DRIVING DRIVING} — a driver is installed and being ticked.</li>
+ *   <li>{@link State#ENDED ENDED} — terminal-until-reinstall; the previously installed driver
+ *       has been uninstalled and no driver is currently active. Reinstalling via
+ *       {@link #install(BladeMotionDriver)} returns the motion to {@code DRIVING}.</li>
+ * </ul>
+ *
+ * <b>Invariants:</b>
+ * <ol>
+ *   <li>At most one driver is installed at any moment.</li>
+ *   <li>{@link BladeMotionDriver#onInstall} is called exactly once before the first
+ *       {@link BladeMotionDriver#tick}.</li>
+ *   <li>{@link BladeMotionDriver#onUninstall} is called exactly once for both the natural
+ *       {@code DONE}-from-tick path and the external {@link #stop()} path.</li>
+ *   <li>{@link #install(BladeMotionDriver)} and {@link #stop()} are safe to call from inside a
+ *       driver's {@link BladeMotionDriver#tick} — their effect is queued and applied at end of
+ *       tick. Last call wins.</li>
+ *   <li>{@link #stop()} is idempotent.</li>
+ * </ol>
+ *
+ * <b>Ownership:</b> the {@link BladeMotionContext} is created by and exclusively owned by this
+ * class; no other component may construct one. The underlying {@link BladeMotionHost} is
+ * supplied at construction and is expected to remain valid for the motion's entire lifetime.
+ */
+public final class BladeMotion {
+
+    /** Lifecycle state of the motion subsystem. */
+    public enum State {
+        /** Initial state. No driver installed. */
+        IDLE,
+        /** A driver is installed and being ticked each server tick. */
+        DRIVING,
+        /** A driver has been uninstalled. Reinstall to return to {@code DRIVING}. */
+        ENDED
+    }
+
+    private final BladeMotionContext context;
+    private State state = State.IDLE;
+    private BladeMotionDriver currentDriver;
+    private BladeMotionDriver pendingDriver;
+    private boolean pendingStop;
+    private boolean ticking;
+
+    /**
+     * Creates a new motion subsystem bound to the given host.
+     *
+     * @param host the bridge to the underlying display + thrower; must remain valid for the
+     *             lifetime of this motion
+     */
+    public BladeMotion(BladeMotionHost host) {
+        this.context = new BladeMotionContext(Objects.requireNonNull(host, "host"));
+    }
+
+    /** Returns the current lifecycle state. */
+    public State state() {
+        return state;
+    }
+
+    /** Returns {@code true} if the motion is in {@link State#ENDED ENDED}. */
+    public boolean isEnded() {
+        return state == State.ENDED;
+    }
+
+    /** Returns {@code true} if a driver is currently installed and being ticked. */
+    public boolean isDriving() {
+        return state == State.DRIVING;
+    }
+
+    /**
+     * Installs a driver, replacing the current one (if any). Transitions to
+     * {@link State#DRIVING DRIVING}. If called from inside a driver's tick, the swap is queued
+     * and applied at end of tick (last call wins).
+     *
+     * @param driver the driver to install; must not be {@code null}
+     */
+    public void install(BladeMotionDriver driver) {
+        Objects.requireNonNull(driver, "driver");
+        if (ticking) {
+            pendingDriver = driver;
+            pendingStop = false;
+            return;
+        }
+        swapTo(driver);
+    }
+
+    /**
+     * Uninstalls the current driver (if any) and transitions to {@link State#ENDED ENDED}.
+     * Idempotent. If called from inside a driver's tick, takes effect at end of tick (last call
+     * wins — a subsequent {@link #install} from the same tick supersedes the stop).
+     */
+    public void stop() {
+        if (ticking) {
+            pendingStop = true;
+            pendingDriver = null;
+            return;
+        }
+        if (state == State.DRIVING && currentDriver != null) {
+            BladeMotionDriver finished = currentDriver;
+            currentDriver = null;
+            state = State.ENDED;
+            finished.onUninstall(context);
+        } else {
+            state = State.ENDED;
+        }
+    }
+
+    /**
+     * Advances the installed driver by one tick. No-op if not in {@link State#DRIVING DRIVING}.
+     * Must be called exactly once per server tick by the blade's coordinator.
+     */
+    public void tick() {
+        if (state != State.DRIVING || currentDriver == null) return;
+        ticking = true;
+        try {
+            context.incrementTicksSinceInstall();
+            BladeMotionDriver.Status status = currentDriver.tick(context);
+            if (status == BladeMotionDriver.Status.DONE) {
+                BladeMotionDriver finished = currentDriver;
+                currentDriver = null;
+                state = State.ENDED;
+                finished.onUninstall(context);
+            }
+        } finally {
+            ticking = false;
+            applyPending();
+        }
+    }
+
+    private void applyPending() {
+        if (pendingDriver != null) {
+            BladeMotionDriver next = pendingDriver;
+            pendingDriver = null;
+            pendingStop = false;
+            swapTo(next);
+        } else if (pendingStop) {
+            pendingStop = false;
+            stop();
+        }
+    }
+
+    private void swapTo(BladeMotionDriver next) {
+        if (currentDriver != null) {
+            BladeMotionDriver previous = currentDriver;
+            currentDriver = null;
+            previous.onUninstall(context);
+        }
+        currentDriver = next;
+        state = State.DRIVING;
+        context.resetTicksSinceInstall();
+        next.onInstall(context);
+    }
+}

--- a/src/main/java/btm/sword/umbral/motion/BladeMotionContext.java
+++ b/src/main/java/btm/sword/umbral/motion/BladeMotionContext.java
@@ -1,0 +1,72 @@
+package btm.sword.umbral.motion;
+
+import org.bukkit.Location;
+import org.bukkit.util.Transformation;
+import org.bukkit.util.Vector;
+
+import btm.sword.entity.base.Combatant;
+
+/**
+ * Per-driver view of the motion subsystem.
+ * <p>
+ * Drivers receive an instance of this class as the only argument to their lifecycle methods.
+ * The context forwards display operations to a {@link BladeMotionHost} and exposes a tick
+ * counter that resets each time a new driver is installed. Drivers MUST NOT cache the context
+ * reference outside of their own internal fields and MUST NOT downcast it.
+ * <p>
+ * The instance is created by and owned exclusively by {@link BladeMotion}; only that class may
+ * mutate the tick counter via the package-private accessors below.
+ */
+public final class BladeMotionContext {
+
+    private final BladeMotionHost host;
+    private long ticksSinceInstall;
+
+    BladeMotionContext(BladeMotionHost host) {
+        this.host = host;
+    }
+
+    /** Returns the combatant who owns the blade. Read-only access. */
+    public Combatant thrower() {
+        return host.thrower();
+    }
+
+    /**
+     * Teleports the blade display to the given location with the given facing direction.
+     * See {@link BladeMotionHost#teleportDisplay} for parameter semantics.
+     */
+    public void teleportTo(Location location, Vector direction, int teleportDuration) {
+        host.teleportDisplay(location, direction, teleportDuration);
+    }
+
+    /**
+     * Sets the blade display's transformation directly.
+     * See {@link BladeMotionHost#setDisplayTransformation} for parameter semantics.
+     */
+    public void setTransformation(Transformation transformation, int transformDuration) {
+        host.setDisplayTransformation(transformation, transformDuration);
+    }
+
+    /** Returns the current world location of the blade display, or {@code null} if unavailable. */
+    public Location currentLocation() {
+        return host.currentDisplayLocation();
+    }
+
+    /** Returns {@code true} if the blade display is alive and valid in the world. */
+    public boolean isDisplayValid() {
+        return host.isDisplayValid();
+    }
+
+    /** Returns the number of ticks the currently-installed driver has been ticked, starting at 0. */
+    public long tickCount() {
+        return ticksSinceInstall;
+    }
+
+    void resetTicksSinceInstall() {
+        ticksSinceInstall = 0;
+    }
+
+    void incrementTicksSinceInstall() {
+        ticksSinceInstall++;
+    }
+}

--- a/src/main/java/btm/sword/umbral/motion/BladeMotionContext.java
+++ b/src/main/java/btm/sword/umbral/motion/BladeMotionContext.java
@@ -12,7 +12,7 @@ import btm.sword.entity.base.Combatant;
  * Drivers receive an instance of this class as the only argument to their lifecycle methods.
  * The context forwards display operations to a {@link BladeMotionHost} and exposes a tick
  * counter that resets each time a new driver is installed. Drivers MUST NOT cache the context
- * reference outside of their own internal fields and MUST NOT downcast it.
+ * reference outside their own internal fields and MUST NOT downcast it.
  * <p>
  * The instance is created by and owned exclusively by {@link BladeMotion}; only that class may
  * mutate the tick counter via the package-private accessors below.

--- a/src/main/java/btm/sword/umbral/motion/BladeMotionDriver.java
+++ b/src/main/java/btm/sword/umbral/motion/BladeMotionDriver.java
@@ -1,0 +1,60 @@
+package btm.sword.umbral.motion;
+
+/**
+ * Pluggable per-tick motion strategy installed on a {@link BladeMotion}.
+ * <p>
+ * Drivers carry whatever internal state their algorithm needs (parametric {@code t},
+ * accumulated tick counts, last-position cache, etc.) and may freely mutate that state during
+ * {@link #tick}. They MUST NOT touch the underlying {@link org.bukkit.entity.ItemDisplay}
+ * directly, schedule their own scheduler tasks, or read FSM state — every interaction with
+ * the world goes through the supplied {@link BladeMotionContext}.
+ * <p>
+ * <b>Lifecycle contract:</b>
+ * <ol>
+ *   <li>{@link #onInstall} is invoked exactly once before the first {@link #tick} call.</li>
+ *   <li>{@link #tick} is invoked once per server tick while this driver is the installed driver
+ *       on its hosting {@link BladeMotion}. Returning {@link Status#DONE} signals that the
+ *       driver has completed its work and should be uninstalled.</li>
+ *   <li>{@link #onUninstall} is invoked exactly once when the driver leaves the
+ *       {@link BladeMotion.State#DRIVING DRIVING} state — whether because {@code tick} returned
+ *       {@code DONE}, the host called {@link BladeMotion#stop()}, or another driver was
+ *       installed in its place.</li>
+ * </ol>
+ * A driver instance MUST NOT be reused after {@code onUninstall}. Returning {@code DONE} does
+ * not itself trigger any FSM transition; the owning state must observe {@link BladeMotion#isEnded()}
+ * during its own tick to react.
+ */
+public interface BladeMotionDriver {
+
+    /**
+     * Called exactly once before the first {@link #tick}.
+     *
+     * @param context the per-driver view of the motion subsystem
+     */
+    void onInstall(BladeMotionContext context);
+
+    /**
+     * Called once per server tick while this driver is installed.
+     *
+     * @param context the per-driver view of the motion subsystem
+     * @return {@link Status#RUNNING} to remain installed for another tick, or {@link Status#DONE}
+     *         to be uninstalled at the end of this tick
+     */
+    Status tick(BladeMotionContext context);
+
+    /**
+     * Called exactly once when this driver leaves {@code DRIVING}. Implementations should
+     * release any per-instance resources captured in {@link #onInstall} or during {@link #tick}.
+     *
+     * @param context the per-driver view of the motion subsystem
+     */
+    void onUninstall(BladeMotionContext context);
+
+    /** Per-tick result reported by {@link #tick}. */
+    enum Status {
+        /** Driver wants to be ticked again next server tick. */
+        RUNNING,
+        /** Driver has completed and should be uninstalled at the end of this tick. */
+        DONE
+    }
+}

--- a/src/main/java/btm/sword/umbral/motion/BladeMotionHost.java
+++ b/src/main/java/btm/sword/umbral/motion/BladeMotionHost.java
@@ -1,0 +1,50 @@
+package btm.sword.umbral.motion;
+
+import org.bukkit.Location;
+import org.bukkit.util.Transformation;
+import org.bukkit.util.Vector;
+
+import btm.sword.entity.base.Combatant;
+
+/**
+ * Bridge between the motion subsystem and the underlying display + thrower state owned by
+ * the blade. Exposes only the narrow surface that {@link BladeMotionDriver}s legitimately need:
+ * read access to the thrower and write access to the display's position and transformation.
+ * <p>
+ * <b>Why an interface:</b> the motion package must remain agnostic to the blade's internal
+ * representation of its display. Today the blade exposes a Bukkit {@code ItemDisplay} via
+ * inheritance from {@code ThrownItem}; in the future it will expose a {@code BladeDisplay}
+ * wrapper. The driver code does not change in either case.
+ * <p>
+ * Implementations are expected to be supplied at construction time of the {@link BladeMotion}
+ * and to remain valid for that {@code BladeMotion}'s entire lifetime.
+ */
+public interface BladeMotionHost {
+
+    /** Returns the combatant who owns the blade. Read-only access. */
+    Combatant thrower();
+
+    /**
+     * Teleports the blade display to the given location with the given facing direction.
+     *
+     * @param location          the target world location
+     * @param direction         the direction the display should face after teleporting; may be
+     *                          {@code null} to leave the current direction unchanged
+     * @param teleportDuration  the smoothing duration in ticks (clamped to Bukkit's 0..59 range)
+     */
+    void teleportDisplay(Location location, Vector direction, int teleportDuration);
+
+    /**
+     * Sets the blade display's transformation directly.
+     *
+     * @param transformation     the new transformation to apply
+     * @param transformDuration  the interpolation duration in milliseconds
+     */
+    void setDisplayTransformation(Transformation transformation, int transformDuration);
+
+    /** Returns the current world location of the blade display, or {@code null} if unavailable. */
+    Location currentDisplayLocation();
+
+    /** Returns {@code true} if the blade display is alive and valid in the world. */
+    boolean isDisplayValid();
+}

--- a/src/main/java/btm/sword/umbral/motion/drivers/AnchoredFollowDriver.java
+++ b/src/main/java/btm/sword/umbral/motion/drivers/AnchoredFollowDriver.java
@@ -1,0 +1,60 @@
+package btm.sword.umbral.motion.drivers;
+
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
+
+import btm.sword.entity.base.Combatant;
+import btm.sword.umbral.motion.BladeMotionContext;
+import btm.sword.umbral.motion.BladeMotionDriver;
+
+/**
+ * Follows the thrower with a basis-rotated offset, smoothly tracking the thrower's facing.
+ * <p>
+ * Replaces {@code DisplayUtil.itemDisplayFollowLerp}. The offset is expressed in the thrower's
+ * local basis: {@code x} along {@link Combatant#rightBasisVector(boolean) right},
+ * {@code y} along {@link Combatant#upBasisVector(boolean) up}, {@code z} along
+ * {@link Combatant#forwardBasisVector(boolean) forward}. Each tick the blade is teleported to
+ * {@code thrower.location + (right * x + up * y + forward * z)} and oriented to face along
+ * the thrower's forward axis.
+ * <p>
+ * The driver runs indefinitely; the owning state must call {@link btm.sword.umbral.motion.BladeMotion#stop()}
+ * or install a different driver to end it.
+ */
+public final class AnchoredFollowDriver implements BladeMotionDriver {
+
+    private final Vector localOffset;
+    private final boolean withPitch;
+    private final int teleportDuration;
+
+    /**
+     * @param localOffset       the thrower-local offset (right / up / forward components)
+     * @param withPitch         {@code true} to use pitch-aware basis vectors, {@code false} for
+     *                          horizontal-only follow
+     * @param teleportDuration  smoothing duration in ticks for the teleport interpolation
+     */
+    public AnchoredFollowDriver(Vector localOffset, boolean withPitch, int teleportDuration) {
+        this.localOffset = localOffset.clone();
+        this.withPitch = withPitch;
+        this.teleportDuration = teleportDuration;
+    }
+
+    @Override
+    public void onInstall(BladeMotionContext context) {}
+
+    @Override
+    public Status tick(BladeMotionContext context) {
+        Combatant thrower = context.thrower();
+        if (thrower == null || thrower.isInvalid()) return Status.DONE;
+
+        Vector worldOffset = thrower.rightBasisVector(withPitch).multiply(localOffset.getX())
+            .add(thrower.upBasisVector(withPitch).multiply(localOffset.getY()))
+            .add(thrower.forwardBasisVector(withPitch).multiply(localOffset.getZ()));
+
+        Location target = thrower.self().getLocation().add(worldOffset);
+        context.teleportTo(target, thrower.forwardBasisVector(withPitch), teleportDuration);
+        return Status.RUNNING;
+    }
+
+    @Override
+    public void onUninstall(BladeMotionContext context) {}
+}

--- a/src/main/java/btm/sword/umbral/motion/drivers/BezierDriver.java
+++ b/src/main/java/btm/sword/umbral/motion/drivers/BezierDriver.java
@@ -1,0 +1,97 @@
+package btm.sword.umbral.motion.drivers;
+
+import java.util.function.Function;
+
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
+
+import btm.sword.umbral.motion.BladeMotionContext;
+import btm.sword.umbral.motion.BladeMotionDriver;
+import btm.sword.util.math.Basis;
+import btm.sword.util.math.BezierUtil;
+import btm.sword.util.math.ControlVectors;
+
+/**
+ * Drives the blade along a parametric cubic-Bézier path over a fixed number of ticks.
+ * <p>
+ * Replaces the inherited {@code generateFunctions}/{@code stepFlight} flow used by
+ * {@code LungingState} and the existing {@code UmbralBlade.calcBezierTrajectory}. On install,
+ * the supplied {@link ControlVectors} are baked into the supplied {@link Basis} via
+ * {@link ControlVectors#adjustToBasis} and a position function is materialised via
+ * {@link BezierUtil#cubicBezier3D}. Each tick samples {@code positionFunction(t)} with
+ * {@code t = tickCount * timeStep}, teleports the blade to {@code origin + sample}, and
+ * reports {@link Status#DONE DONE} once {@code tickCount} reaches {@code durationTicks}.
+ * <p>
+ * The path's origin is captured at install time from the context's current location — the
+ * driver does not extrapolate motion if the display is moved externally during flight.
+ */
+public final class BezierDriver implements BladeMotionDriver {
+
+    private final ControlVectors controlVectors;
+    private final Basis basis;
+    private final long durationTicks;
+    private final double timeStep;
+    private final int teleportDuration;
+    private final double scale;
+
+    private Location origin;
+    private Location previousSample;
+    private Function<Double, Vector> positionFunction;
+
+    /**
+     * @param controlVectors    the four cubic-Bézier control points
+     * @param basis             the basis to project control vectors into world space
+     * @param scale             scale factor passed to {@link ControlVectors#adjustToBasis}
+     * @param durationTicks     total number of ticks before the driver reports DONE
+     * @param timeStep          parametric step size per tick (typical value: {@code 1.0 / durationTicks})
+     * @param teleportDuration  smoothing duration in ticks for the teleport interpolation
+     */
+    public BezierDriver(ControlVectors controlVectors, Basis basis, double scale,
+                        long durationTicks, double timeStep, int teleportDuration) {
+        if (durationTicks <= 0) {
+            throw new IllegalArgumentException("durationTicks must be positive");
+        }
+        this.controlVectors = controlVectors;
+        this.basis = basis;
+        this.scale = scale;
+        this.durationTicks = durationTicks;
+        this.timeStep = timeStep;
+        this.teleportDuration = teleportDuration;
+    }
+
+    @Override
+    public void onInstall(BladeMotionContext context) {
+        ControlVectors adjusted = controlVectors.adjustToBasis(basis, scale);
+        positionFunction = BezierUtil.cubicBezier3D(adjusted);
+        origin = context.currentLocation();
+        previousSample = origin == null ? null : origin.clone();
+    }
+
+    @Override
+    public Status tick(BladeMotionContext context) {
+        if (origin == null || positionFunction == null) return Status.DONE;
+
+        double t = context.tickCount() * timeStep;
+        Vector sample = positionFunction.apply(t);
+        Location target = origin.clone().add(sample);
+
+        Vector direction;
+        if (previousSample == null) {
+            direction = basis.forward();
+        } else {
+            direction = target.toVector().subtract(previousSample.toVector());
+            if (direction.lengthSquared() < 1e-9) direction = basis.forward();
+        }
+        context.teleportTo(target, direction, teleportDuration);
+        previousSample = target;
+
+        return context.tickCount() >= durationTicks ? Status.DONE : Status.RUNNING;
+    }
+
+    @Override
+    public void onUninstall(BladeMotionContext context) {
+        origin = null;
+        previousSample = null;
+        positionFunction = null;
+    }
+}

--- a/src/main/java/btm/sword/umbral/motion/drivers/ImpalementFollowDriver.java
+++ b/src/main/java/btm/sword/umbral/motion/drivers/ImpalementFollowDriver.java
@@ -1,0 +1,87 @@
+package btm.sword.umbral.motion.drivers;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
+
+import btm.sword.config.Config;
+import btm.sword.entity.base.SwordEntity;
+import btm.sword.umbral.motion.BladeMotionContext;
+import btm.sword.umbral.motion.BladeMotionDriver;
+import btm.sword.util.prefab.Prefab;
+
+/**
+ * Pins the blade to a host entity, rotating with the host's body or head yaw.
+ * <p>
+ * Replaces {@code DisplayUtil.itemDisplayFollow}. Used by {@code LodgedState} when the blade is
+ * embedded in an entity. The original direction vector supplied at construction is rotated each
+ * tick by the delta between the host's yaw at install time and its current yaw, so the blade
+ * stays oriented relative to the host's body.
+ * <p>
+ * Reports {@link Status#DONE DONE} when the host becomes invalid or the externally-supplied
+ * {@code exitCondition} returns {@code true}. Visual flair (bleed particles every
+ * {@link Config.Display#ITEM_DISPLAY_FOLLOW_PARTICLE_INTERVAL}-th tick) is preserved from the
+ * original utility.
+ */
+public final class ImpalementFollowDriver implements BladeMotionDriver {
+
+    private final SwordEntity host;
+    private final Vector initialDirection;
+    private final double heightOffset;
+    private final boolean followHead;
+    private final Supplier<Boolean> exitCondition;
+    private final int teleportDuration;
+
+    private double originalYawRadians;
+
+    /**
+     * @param host              the entity the blade is embedded in
+     * @param initialDirection  the world-space direction the blade is oriented along at install
+     * @param heightOffset      vertical offset from the host's foot location
+     * @param followHead        {@code true} to align rotation with the host's head yaw,
+     *                          {@code false} for body yaw
+     * @param exitCondition     external predicate; when it returns {@code true}, report DONE
+     *                          (may be {@code null} to keep running until the host dies)
+     * @param teleportDuration  smoothing duration in ticks for the teleport interpolation
+     */
+    public ImpalementFollowDriver(SwordEntity host, Vector initialDirection,
+                                  double heightOffset, boolean followHead,
+                                  Supplier<Boolean> exitCondition, int teleportDuration) {
+        this.host = Objects.requireNonNull(host, "host");
+        this.initialDirection = initialDirection.clone();
+        this.heightOffset = heightOffset;
+        this.followHead = followHead;
+        this.exitCondition = exitCondition;
+        this.teleportDuration = teleportDuration;
+    }
+
+    @Override
+    public void onInstall(BladeMotionContext context) {
+        if (host.isInvalid()) return;
+        originalYawRadians = Math.toRadians(host.self().getBodyYaw());
+    }
+
+    @Override
+    public Status tick(BladeMotionContext context) {
+        if (host.isInvalid() || host.isDead()) return Status.DONE;
+        if (exitCondition != null && Boolean.TRUE.equals(exitCondition.get())) return Status.DONE;
+
+        Vector verticalOffset = Config.Direction.up().multiply(heightOffset);
+        Location target = host.self().getLocation().add(verticalOffset);
+
+        double currentYawRadians = Math.toRadians(followHead ? host.self().getYaw() : host.self().getBodyYaw());
+        Vector currentDirection = initialDirection.clone().rotateAroundY(originalYawRadians - currentYawRadians);
+
+        context.teleportTo(target, currentDirection, teleportDuration);
+
+        if (context.tickCount() % Config.Display.ITEM_DISPLAY_FOLLOW_PARTICLE_INTERVAL == 0) {
+            Prefab.Particles.BLEED.display(target);
+        }
+        return Status.RUNNING;
+    }
+
+    @Override
+    public void onUninstall(BladeMotionContext context) {}
+}

--- a/src/main/java/btm/sword/umbral/motion/drivers/LinearDriver.java
+++ b/src/main/java/btm/sword/umbral/motion/drivers/LinearDriver.java
@@ -1,0 +1,58 @@
+package btm.sword.umbral.motion.drivers;
+
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
+
+import btm.sword.umbral.motion.BladeMotionContext;
+import btm.sword.umbral.motion.BladeMotionDriver;
+
+/**
+ * Moves the blade in a straight line at constant speed for a fixed number of ticks.
+ * <p>
+ * Used as a simple flight-path fallback when the more elaborate {@link BezierDriver} is not
+ * appropriate. The direction vector is normalized at construction; the per-tick displacement is
+ * {@code direction * speed}. The driver reports {@link Status#DONE DONE} once the configured
+ * number of ticks has elapsed.
+ */
+public final class LinearDriver implements BladeMotionDriver {
+
+    private final Vector unitDirection;
+    private final double speed;
+    private final long durationTicks;
+    private final int teleportDuration;
+
+    /**
+     * @param direction        the direction of motion; must be non-zero (normalized internally)
+     * @param speed            the per-tick world-space speed
+     * @param durationTicks    the number of ticks to run before reporting DONE
+     * @param teleportDuration smoothing duration in ticks for the teleport interpolation
+     * @throws IllegalArgumentException if {@code direction} is the zero vector
+     */
+    public LinearDriver(Vector direction, double speed, long durationTicks, int teleportDuration) {
+        if (direction.lengthSquared() < 1e-9) {
+            throw new IllegalArgumentException("direction must be a non-zero vector");
+        }
+        this.unitDirection = direction.clone().normalize();
+        this.speed = speed;
+        this.durationTicks = durationTicks;
+        this.teleportDuration = teleportDuration;
+    }
+
+    @Override
+    public void onInstall(BladeMotionContext context) {}
+
+    @Override
+    public Status tick(BladeMotionContext context) {
+        Location current = context.currentLocation();
+        if (current == null) return Status.DONE;
+
+        Vector step = unitDirection.clone().multiply(speed);
+        Location next = current.clone().add(step);
+        context.teleportTo(next, unitDirection.clone(), teleportDuration);
+
+        return context.tickCount() >= durationTicks ? Status.DONE : Status.RUNNING;
+    }
+
+    @Override
+    public void onUninstall(BladeMotionContext context) {}
+}

--- a/src/main/java/btm/sword/umbral/motion/drivers/LungingDriver.java
+++ b/src/main/java/btm/sword/umbral/motion/drivers/LungingDriver.java
@@ -1,0 +1,159 @@
+package btm.sword.umbral.motion.drivers;
+
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.bukkit.FluidCollisionMode;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.util.Vector;
+
+import btm.sword.umbral.collision.BladeCollider;
+import btm.sword.umbral.collision.BlockHit;
+import btm.sword.umbral.collision.EntityHit;
+import btm.sword.umbral.motion.BladeMotionContext;
+import btm.sword.umbral.motion.BladeMotionDriver;
+import btm.sword.util.math.Basis;
+import btm.sword.util.math.BezierUtil;
+import btm.sword.util.math.ControlVectors;
+
+/**
+ * Drives the blade along a parametric cubic-Bézier path while running per-tick collision scans
+ * against the world.
+ *
+ * <p>Replaces the inherited {@code stepFlight} pipeline used by {@code LungingState} and
+ * {@code GrabImpaleState}'s lunge phase. The driver owns the bezier integration and exposes
+ * collision results to the caller via three callbacks:
+ * <ul>
+ *   <li>{@code onEntity} — invoked when the segment between previous and current samples
+ *       intersects a matching entity. Reports DONE.</li>
+ *   <li>{@code onBlock} — invoked when the segment intersects a non-air block. Reports DONE.</li>
+ *   <li>{@code onCompleteWithoutCollision} — invoked when {@code durationTicks} elapses without
+ *       any collision. Reports DONE.</li>
+ * </ul>
+ * The callbacks each receive the impact direction (segment vector) so consumers can compute
+ * impalement orientation or knockback without re-deriving it.</p>
+ *
+ * <p>The driver's lifecycle is the standard
+ * {@link BladeMotionDriver} contract: {@code onInstall} bakes the bezier
+ * function and captures origin; each {@code tick} samples and tests; {@code onUninstall} clears
+ * internal references. The driver does not import FSM, schedulers, or display handles.</p>
+ */
+public final class LungingDriver implements BladeMotionDriver {
+
+    private static final double ENTITY_RAY_SIZE = 0.0;
+
+    private final ControlVectors controlVectors;
+    private final Basis basis;
+    private final double scale;
+    private final long durationTicks;
+    private final double timeStep;
+    private final int teleportDuration;
+    private final Predicate<Entity> entityFilter;
+    private final BiConsumer<EntityHit, Vector> onEntity;
+    private final BiConsumer<BlockHit, Vector> onBlock;
+    private final Runnable onCompleteWithoutCollision;
+
+    private Location origin;
+    private Location previousSample;
+    private Function<Double, Vector> positionFunction;
+
+    /**
+     * @param controlVectors             the four cubic-Bézier control points
+     * @param basis                      the basis to project control vectors into world space
+     * @param scale                      scale factor passed to {@link ControlVectors#adjustToBasis}
+     * @param durationTicks              number of ticks before the driver reports DONE without collision
+     * @param timeStep                   parametric step size per tick
+     * @param teleportDuration           smoothing duration in ticks for the teleport interpolation
+     * @param entityFilter               predicate restricting which entities count as a hit
+     * @param onEntity                   callback for the first entity intersection along a tick segment
+     * @param onBlock                    callback for the first block intersection along a tick segment
+     * @param onCompleteWithoutCollision callback fired when the bezier expires with no collision
+     */
+    public LungingDriver(ControlVectors controlVectors,
+                         Basis basis,
+                         double scale,
+                         long durationTicks,
+                         double timeStep,
+                         int teleportDuration,
+                         Predicate<Entity> entityFilter,
+                         BiConsumer<EntityHit, Vector> onEntity,
+                         BiConsumer<BlockHit, Vector> onBlock,
+                         Runnable onCompleteWithoutCollision) {
+        if (durationTicks <= 0) {
+            throw new IllegalArgumentException("durationTicks must be positive");
+        }
+        this.controlVectors = controlVectors;
+        this.basis = basis;
+        this.scale = scale;
+        this.durationTicks = durationTicks;
+        this.timeStep = timeStep;
+        this.teleportDuration = teleportDuration;
+        this.entityFilter = entityFilter;
+        this.onEntity = onEntity;
+        this.onBlock = onBlock;
+        this.onCompleteWithoutCollision = onCompleteWithoutCollision;
+    }
+
+    @Override
+    public void onInstall(BladeMotionContext context) {
+        ControlVectors adjusted = controlVectors.adjustToBasis(basis, scale);
+        positionFunction = BezierUtil.cubicBezier3D(adjusted);
+        origin = context.currentLocation();
+        previousSample = origin == null ? null : origin.clone();
+    }
+
+    @Override
+    public Status tick(BladeMotionContext context) {
+        if (origin == null || positionFunction == null) {
+            return finishComplete();
+        }
+
+        double t = context.tickCount() * timeStep;
+        Vector sample = positionFunction.apply(t);
+        Location target = origin.clone().add(sample);
+
+        Vector direction;
+        if (previousSample == null) {
+            direction = basis.forward();
+        } else {
+            direction = target.toVector().subtract(previousSample.toVector());
+            if (direction.lengthSquared() < 1e-9) direction = basis.forward();
+        }
+
+        if (previousSample != null) {
+            Optional<EntityHit> entityHit = BladeCollider.firstEntity(previousSample, target, ENTITY_RAY_SIZE, entityFilter);
+            if (entityHit.isPresent()) {
+                if (onEntity != null) onEntity.accept(entityHit.get(), direction.clone());
+                return Status.DONE;
+            }
+            Optional<BlockHit> blockHit = BladeCollider.scanBlocks(previousSample, target, FluidCollisionMode.NEVER);
+            if (blockHit.isPresent()) {
+                if (onBlock != null) onBlock.accept(blockHit.get(), direction.clone());
+                return Status.DONE;
+            }
+        }
+
+        context.teleportTo(target, direction, teleportDuration);
+        previousSample = target;
+
+        if (context.tickCount() >= durationTicks) {
+            return finishComplete();
+        }
+        return Status.RUNNING;
+    }
+
+    @Override
+    public void onUninstall(BladeMotionContext context) {
+        origin = null;
+        previousSample = null;
+        positionFunction = null;
+    }
+
+    private Status finishComplete() {
+        if (onCompleteWithoutCollision != null) onCompleteWithoutCollision.run();
+        return Status.DONE;
+    }
+}

--- a/src/main/java/btm/sword/umbral/motion/drivers/SlerpToOffsetDriver.java
+++ b/src/main/java/btm/sword/umbral/motion/drivers/SlerpToOffsetDriver.java
@@ -87,12 +87,10 @@ public record SlerpToOffsetDriver(SwordEntity anchor, Vector localOffset, double
 
         Vector step = direction.normalize().multiply(speed);
         Location updated = current.clone().add(step);
-        // Lock the body yaw/pitch toward the target on the first tick only. Subsequent ticks
-        // pass a null direction so Bukkit's smooth-teleport interpolation finishes the single
-        // rotation onto the lock instead of being restarted every tick by a slightly different
-        // step direction (which produced visible stutter on long recalls).
-        Vector teleportDir = context.tickCount() == 1 ? step : null;
-        context.teleportTo(updated, teleportDir, teleportDuration);
+        // Aim body yaw/pitch directly at the moving target each tick. Caller is expected to use
+        // a small teleportDuration (1-2 ticks) so consecutive rotation animations don't pile up
+        // — large durations cause the blade to chase a stale target every tick.
+        context.teleportTo(updated, direction, teleportDuration);
         return Status.RUNNING;
     }
 

--- a/src/main/java/btm/sword/umbral/motion/drivers/SlerpToOffsetDriver.java
+++ b/src/main/java/btm/sword/umbral/motion/drivers/SlerpToOffsetDriver.java
@@ -1,0 +1,109 @@
+package btm.sword.umbral.motion.drivers;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
+
+import btm.sword.entity.base.SwordEntity;
+import btm.sword.runtime.scheduler.SwordScheduler;
+import btm.sword.umbral.motion.BladeMotionContext;
+import btm.sword.umbral.motion.BladeMotionDriver;
+
+/**
+ * Moves the blade smoothly toward a basis-rotated offset around an anchor entity, normalising
+ * the per-tick velocity so the blade approaches the target at a fixed world-space speed.
+ * <p>
+ * Replaces {@code DisplayUtil.displaySlerpToOffset}. Used by {@code RecallingState} (anchor =
+ * thrower, offset = chest vector) and {@code GrabImpaleState} (anchor = grabbed entity, offset
+ * = lock-on point).
+ * <p>
+ * Each tick:
+ * <ol>
+ *   <li>Compute the world-space target as {@code anchor.location + (right*x + up*y + fwd*z)}.</li>
+ *   <li>Compute the direction vector {@code target - currentBladeLocation}.</li>
+ *   <li>If the distance is below {@code endDistance}, report {@link Status#DONE DONE}.</li>
+ *   <li>Otherwise teleport the blade by {@code direction.normalized() * speed} along that vector.</li>
+ * </ol>
+ *
+ * Reports {@link Status#DONE DONE} on arrival, on timeout, when the anchor becomes invalid, or
+ * when the externally-supplied {@code endCondition} returns {@code true}. On any DONE path, the
+ * supplied {@code onArrive} callback (if non-null) is scheduled on the next tick via
+ * {@link SwordScheduler#runBukkitTask(Runnable)}.
+ */
+public final class SlerpToOffsetDriver implements BladeMotionDriver {
+
+    private final SwordEntity anchor;
+    private final Vector localOffset;
+    private final double speed;
+    private final double endDistance;
+    private final long timeoutTicks;
+    private final Supplier<Boolean> endCondition;
+    private final Runnable onArrive;
+    private final int teleportDuration;
+
+    /**
+     * @param anchor            the entity the offset is computed relative to
+     * @param localOffset       the anchor-local offset (right / up / forward components)
+     * @param speed             per-tick world-space speed of approach
+     * @param endDistance       arrival threshold in world units (squared internally for cheap compare)
+     * @param timeoutTicks      maximum ticks before reporting DONE regardless of arrival
+     * @param endCondition      external predicate; when it returns {@code true}, report DONE
+     *                          (may be {@code null} to disable)
+     * @param onArrive          callback scheduled when the driver reports DONE for any reason
+     *                          (may be {@code null})
+     * @param teleportDuration  smoothing duration in ticks for the teleport interpolation
+     */
+    public SlerpToOffsetDriver(SwordEntity anchor, Vector localOffset,
+                               double speed, double endDistance, long timeoutTicks,
+                               Supplier<Boolean> endCondition, Runnable onArrive,
+                               int teleportDuration) {
+        this.anchor = Objects.requireNonNull(anchor, "anchor");
+        this.localOffset = localOffset.clone();
+        this.speed = speed;
+        this.endDistance = endDistance;
+        this.timeoutTicks = timeoutTicks;
+        this.endCondition = endCondition;
+        this.onArrive = onArrive;
+        this.teleportDuration = teleportDuration;
+    }
+
+    @Override
+    public void onInstall(BladeMotionContext context) {}
+
+    @Override
+    public Status tick(BladeMotionContext context) {
+        if (anchor.isInvalid()) return finish();
+        if (context.tickCount() > timeoutTicks) return finish();
+        if (endCondition != null && Boolean.TRUE.equals(endCondition.get())) return finish();
+
+        Location current = context.currentLocation();
+        if (current == null) return finish();
+
+        Location target = anchor.self().getLocation().add(
+            anchor.rightBasisVector(false).multiply(localOffset.getX())
+                .add(anchor.upBasisVector(false).multiply(localOffset.getY()))
+                .add(anchor.forwardBasisVector(false).multiply(localOffset.getZ()))
+        );
+        Vector direction = target.toVector().subtract(current.toVector());
+        if (direction.isZero() || direction.lengthSquared() < endDistance * endDistance) {
+            return finish();
+        }
+
+        Vector step = direction.normalize().multiply(speed);
+        Location updated = current.clone().add(step);
+        context.teleportTo(updated, step, teleportDuration);
+        return Status.RUNNING;
+    }
+
+    @Override
+    public void onUninstall(BladeMotionContext context) {}
+
+    private Status finish() {
+        if (onArrive != null) {
+            SwordScheduler.runBukkitTask(onArrive);
+        }
+        return Status.DONE;
+    }
+}

--- a/src/main/java/btm/sword/umbral/motion/drivers/SlerpToOffsetDriver.java
+++ b/src/main/java/btm/sword/umbral/motion/drivers/SlerpToOffsetDriver.java
@@ -87,7 +87,12 @@ public record SlerpToOffsetDriver(SwordEntity anchor, Vector localOffset, double
 
         Vector step = direction.normalize().multiply(speed);
         Location updated = current.clone().add(step);
-        context.teleportTo(updated, step, teleportDuration);
+        // Lock the body yaw/pitch toward the target on the first tick only. Subsequent ticks
+        // pass a null direction so Bukkit's smooth-teleport interpolation finishes the single
+        // rotation onto the lock instead of being restarted every tick by a slightly different
+        // step direction (which produced visible stutter on long recalls).
+        Vector teleportDir = context.tickCount() == 1 ? step : null;
+        context.teleportTo(updated, teleportDir, teleportDuration);
         return Status.RUNNING;
     }
 

--- a/src/main/java/btm/sword/umbral/motion/drivers/SlerpToOffsetDriver.java
+++ b/src/main/java/btm/sword/umbral/motion/drivers/SlerpToOffsetDriver.java
@@ -26,34 +26,27 @@ import btm.sword.umbral.motion.BladeMotionDriver;
  *   <li>If the distance is below {@code endDistance}, report {@link Status#DONE DONE}.</li>
  *   <li>Otherwise teleport the blade by {@code direction.normalized() * speed} along that vector.</li>
  * </ol>
- *
+ * <p>
  * Reports {@link Status#DONE DONE} on arrival, on timeout, when the anchor becomes invalid, or
  * when the externally-supplied {@code endCondition} returns {@code true}. On any DONE path, the
  * supplied {@code onArrive} callback (if non-null) is scheduled on the next tick via
  * {@link SwordScheduler#runBukkitTask(Runnable)}.
  */
-public final class SlerpToOffsetDriver implements BladeMotionDriver {
-
-    private final SwordEntity anchor;
-    private final Vector localOffset;
-    private final double speed;
-    private final double endDistance;
-    private final long timeoutTicks;
-    private final Supplier<Boolean> endCondition;
-    private final Runnable onArrive;
-    private final int teleportDuration;
+public record SlerpToOffsetDriver(SwordEntity anchor, Vector localOffset, double speed, double endDistance,
+                                  long timeoutTicks, Supplier<Boolean> endCondition, Runnable onArrive,
+                                  int teleportDuration) implements BladeMotionDriver {
 
     /**
-     * @param anchor            the entity the offset is computed relative to
-     * @param localOffset       the anchor-local offset (right / up / forward components)
-     * @param speed             per-tick world-space speed of approach
-     * @param endDistance       arrival threshold in world units (squared internally for cheap compare)
-     * @param timeoutTicks      maximum ticks before reporting DONE regardless of arrival
-     * @param endCondition      external predicate; when it returns {@code true}, report DONE
-     *                          (may be {@code null} to disable)
-     * @param onArrive          callback scheduled when the driver reports DONE for any reason
-     *                          (may be {@code null})
-     * @param teleportDuration  smoothing duration in ticks for the teleport interpolation
+     * @param anchor           the entity the offset is computed relative to
+     * @param localOffset      the anchor-local offset (right / up / forward components)
+     * @param speed            per-tick world-space speed of approach
+     * @param endDistance      arrival threshold in world units (squared internally for cheap compare)
+     * @param timeoutTicks     maximum ticks before reporting DONE regardless of arrival
+     * @param endCondition     external predicate; when it returns {@code true}, report DONE
+     *                         (maybe {@code null} to disable)
+     * @param onArrive         callback scheduled when the driver reports DONE for any reason
+     *                         (maybe {@code null})
+     * @param teleportDuration smoothing duration in ticks for the teleport interpolation
      */
     public SlerpToOffsetDriver(SwordEntity anchor, Vector localOffset,
                                double speed, double endDistance, long timeoutTicks,
@@ -70,7 +63,8 @@ public final class SlerpToOffsetDriver implements BladeMotionDriver {
     }
 
     @Override
-    public void onInstall(BladeMotionContext context) {}
+    public void onInstall(BladeMotionContext context) {
+    }
 
     @Override
     public Status tick(BladeMotionContext context) {
@@ -98,7 +92,8 @@ public final class SlerpToOffsetDriver implements BladeMotionDriver {
     }
 
     @Override
-    public void onUninstall(BladeMotionContext context) {}
+    public void onUninstall(BladeMotionContext context) {
+    }
 
     private Status finish() {
         if (onArrive != null) {

--- a/src/main/java/btm/sword/umbral/motion/drivers/StaticDriver.java
+++ b/src/main/java/btm/sword/umbral/motion/drivers/StaticDriver.java
@@ -1,0 +1,48 @@
+package btm.sword.umbral.motion.drivers;
+
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
+
+import btm.sword.entity.base.Combatant;
+import btm.sword.umbral.motion.BladeMotionContext;
+import btm.sword.umbral.motion.BladeMotionDriver;
+
+/**
+ * Holds the blade at a fixed world-space offset from the thrower's location.
+ * <p>
+ * The offset is in <b>world space</b> — the blade does not rotate with the thrower. Use
+ * {@link AnchoredFollowDriver} when the offset should be expressed in the thrower's local
+ * basis (right / up / forward) and rotate as the thrower turns.
+ * <p>
+ * The driver runs indefinitely; the owning state must call {@link btm.sword.umbral.motion.BladeMotion#stop()}
+ * or install a different driver to end it.
+ */
+public final class StaticDriver implements BladeMotionDriver {
+
+    private final Vector worldOffset;
+    private final int teleportDuration;
+
+    /**
+     * @param worldOffset       the world-space offset added to the thrower's location each tick
+     * @param teleportDuration  smoothing duration in ticks for the teleport interpolation
+     */
+    public StaticDriver(Vector worldOffset, int teleportDuration) {
+        this.worldOffset = worldOffset.clone();
+        this.teleportDuration = teleportDuration;
+    }
+
+    @Override
+    public void onInstall(BladeMotionContext context) {}
+
+    @Override
+    public Status tick(BladeMotionContext context) {
+        Combatant thrower = context.thrower();
+        if (thrower == null || thrower.isInvalid()) return Status.DONE;
+        Location target = thrower.self().getLocation().add(worldOffset);
+        context.teleportTo(target, null, teleportDuration);
+        return Status.RUNNING;
+    }
+
+    @Override
+    public void onUninstall(BladeMotionContext context) {}
+}

--- a/src/main/java/btm/sword/umbral/presentation/BladeDisplay.java
+++ b/src/main/java/btm/sword/umbral/presentation/BladeDisplay.java
@@ -1,0 +1,222 @@
+package btm.sword.umbral.presentation;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.ItemDisplay;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.util.Transformation;
+import org.bukkit.util.Vector;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+
+import btm.sword.runtime.scheduler.TimeArbiter;
+import btm.sword.util.display.DisplayUtil;
+
+/**
+ * Single owner of an {@link ItemDisplay} handle for an UmbralBlade.
+ *
+ * <p>All write operations on the underlying {@code ItemDisplay} that originate from the
+ * {@code btm.sword.umbral} subtree route through this class. Operations are guarded against
+ * the {@link State#UNBOUND UNBOUND} state so calls into a not-yet-spawned (or disposed)
+ * display are safe no-ops.</p>
+ *
+ * <p>Lifecycle: {@code UNBOUND -> BOUND -> UNBOUND}. {@link #adopt} or {@link #respawn}
+ * binds a handle; {@link #dispose} releases it. {@link #respawn} on an already-bound display
+ * disposes the existing entity first, so the BOUND-to-BOUND replacement path leaks nothing.
+ * All public operations are idempotent on the UNBOUND state.</p>
+ *
+ * <p>Bobbing animation tasks (the cosine idle wobble) are owned exclusively by this class
+ * via the {@link #bobbingTask} field. {@link #dispose} and {@link #respawn} both cancel the
+ * task before mutating the handle so a stale task can never reference a disposed entity.</p>
+ *
+ * <p>This class deliberately knows nothing about the FSM or the motion subsystem — it is the
+ * presentation layer for the blade.</p>
+ */
+public final class BladeDisplay {
+
+    /** Lifecycle states for the wrapped handle. */
+    public enum State {
+        /** No handle held. All operations are no-ops; {@link BladeDisplay#isValid} is {@code false}. */
+        UNBOUND,
+        /** A handle is held. Operations route to the underlying {@code ItemDisplay}. */
+        BOUND
+    }
+
+    private final Vector3f scale;
+
+    private ItemDisplay handle;
+    private TimeArbiter.TaskHandle bobbingTask;
+    private State state = State.UNBOUND;
+
+    /**
+     * Creates an unbound BladeDisplay using the given scale for bobbing transformations.
+     *
+     * @param scale the {@link Vector3f} scale to apply to bobbing transformations
+     *              (defensively copied to keep this class's invariants independent of caller mutations)
+     */
+    public BladeDisplay(Vector3f scale) {
+        this.scale = new Vector3f(Objects.requireNonNull(scale, "scale"));
+    }
+
+    /**
+     * Binds an externally-created {@link ItemDisplay} handle to this wrapper.
+     *
+     * <p>Used during transition from inheritance-based display creation: the parent constructor
+     * spawns the entity, then {@code UmbralBlade} adopts the resulting handle into its
+     * {@code BladeDisplay} so subsequent operations route through the wrapper.</p>
+     *
+     * @param existing the handle to bind; must be non-null and valid
+     * @throws IllegalStateException if already bound (call {@link #dispose} first)
+     */
+    public void adopt(ItemDisplay existing) {
+        Objects.requireNonNull(existing, "existing");
+        if (state == State.BOUND) {
+            throw new IllegalStateException("BladeDisplay already bound; dispose before re-adopting");
+        }
+        this.handle = existing;
+        this.state = State.BOUND;
+    }
+
+    /**
+     * Disposes any current handle and spawns a fresh {@link ItemDisplay} at the given origin's
+     * eye location, then runs {@code setup} on the new handle.
+     *
+     * <p>Idempotent on rapid successive calls — each call disposes the previous handle before
+     * spawning the new one.</p>
+     *
+     * @param origin the entity whose eye location is used as the spawn point
+     * @param setup  consumer applied to the freshly-spawned handle
+     * @return the newly-bound {@link ItemDisplay} handle
+     */
+    public ItemDisplay respawn(LivingEntity origin, Consumer<ItemDisplay> setup) {
+        Objects.requireNonNull(origin, "origin");
+        Objects.requireNonNull(setup, "setup");
+        dispose();
+        ItemDisplay spawned = (ItemDisplay) origin.getWorld()
+            .spawnEntity(origin.getEyeLocation(), EntityType.ITEM_DISPLAY);
+        this.handle = spawned;
+        this.state = State.BOUND;
+        setup.accept(spawned);
+        return spawned;
+    }
+
+    /** Returns {@code true} if a handle is bound and the underlying entity is still valid. */
+    public boolean isValid() {
+        return state == State.BOUND && handle != null && handle.isValid();
+    }
+
+    /** Returns the current world-space {@link Location} of the display, or {@code null} if unbound/invalid. */
+    public Location currentLocation() {
+        return isValid() ? handle.getLocation() : null;
+    }
+
+    /** Returns the current {@link Transformation} of the display, or {@code null} if unbound/invalid. */
+    public Transformation currentTransformation() {
+        return isValid() ? handle.getTransformation() : null;
+    }
+
+    /**
+     * Returns the underlying {@link ItemDisplay} handle for transitional callers that have not yet
+     * been migrated off the raw entity reference (currently {@code UmbralBladeAttack} construction
+     * and inherited physics methods).
+     *
+     * <p>This accessor is removed when inheritance is severed in step 9 of the decoupling refactor.</p>
+     *
+     * @return the bound handle, or {@code null} if unbound
+     */
+    public ItemDisplay handle() {
+        return handle;
+    }
+
+    /**
+     * Smoothly teleports the display to {@code to} along {@code direction} over {@code duration} ticks.
+     * No-op if unbound or invalid.
+     */
+    public void teleportTo(Location to, Vector direction, int duration) {
+        if (!isValid()) return;
+        TimeArbiter.teleportDisplay(handle, to, direction, duration, BladeDisplay.class, 0);
+    }
+
+    /**
+     * Schedules a smooth {@link Transformation} transition over {@code duration} ticks.
+     * No-op if unbound or invalid.
+     */
+    public void setTransformation(Transformation transformation, int duration) {
+        if (!isValid()) return;
+        TimeArbiter.setDisplayTransformation(handle, transformation, duration);
+    }
+
+    /**
+     * Applies a {@link Transformation} immediately with no interpolation.
+     * No-op if unbound or invalid.
+     */
+    public void setTransformationImmediate(Transformation transformation) {
+        if (!isValid()) return;
+        handle.setTransformation(transformation);
+    }
+
+    /** Configures interpolation timing on the display. No-op if unbound or invalid. */
+    public void setInterpolation(int delay, int duration) {
+        if (!isValid()) return;
+        DisplayUtil.setInterpolationValues(handle, delay, duration);
+    }
+
+    /**
+     * Starts a cosine bobbing animation on the display, replacing any existing bobbing task.
+     *
+     * <p>Each tick of the timer applies a fresh {@link Transformation} with a vertical offset of
+     * {@code cos(step) * amplitude}, preserving the current left rotation. {@link #stopBobbing}
+     * cancels it; {@link #dispose} cancels it implicitly.</p>
+     *
+     * @param amplitude vertical bob amplitude in world units
+     * @param period    bobbing period in ticks
+     */
+    public void startBobbing(double amplitude, int period) {
+        stopBobbing();
+        if (!isValid()) return;
+        final double[] step = {0};
+        bobbingTask = TimeArbiter.runTimeBoundBukkitTaskOnTimer(
+            () -> {
+                if (!isValid()) return;
+                TimeArbiter.setDisplayTransformation(handle,
+                    new Transformation(
+                        new Vector3f(0, (float) (Math.cos(step[0]) * amplitude), 0),
+                        handle.getTransformation().getLeftRotation(),
+                        scale,
+                        new Quaternionf()
+                    ),
+                    period
+                );
+                step[0] += Math.PI / 8;
+            },
+            null,
+            null,
+            0, period,
+            BladeDisplay.class, "startBobbing"
+        );
+    }
+
+    /** Cancels the bobbing animation if running. Idempotent. */
+    public void stopBobbing() {
+        if (bobbingTask != null) {
+            bobbingTask.cancel();
+            bobbingTask = null;
+        }
+    }
+
+    /**
+     * Cancels the bobbing task, removes the underlying entity if valid, and unbinds the handle.
+     * Idempotent — calling on an already-disposed wrapper is a no-op.
+     */
+    public void dispose() {
+        stopBobbing();
+        if (handle != null && handle.isValid()) {
+            handle.remove();
+        }
+        handle = null;
+        state = State.UNBOUND;
+    }
+}

--- a/src/main/java/btm/sword/umbral/statemachine/UmbralStateMachine.java
+++ b/src/main/java/btm/sword/umbral/statemachine/UmbralStateMachine.java
@@ -411,7 +411,7 @@ public class UmbralStateMachine extends StateMachine<UmbralBlade> {
         addTransition(new Transition<>(
             LungingState.class,
             RecallingState.class,
-            UmbralBlade::isFinishedLunging,
+            b -> b.isFinishedLunging() || b.isRequested(BladeRequest.RECALL),
             b -> {}
         ));
 

--- a/src/main/java/btm/sword/umbral/statemachine/state/AttackingHeavyState.java
+++ b/src/main/java/btm/sword/umbral/statemachine/state/AttackingHeavyState.java
@@ -131,7 +131,7 @@ public class AttackingHeavyState extends UmbralStateFacade {
 
         int duration = 20 * (int) Math.log(Math.max(1, dist * dist));
         Debug.attack("Attack Duration:=" + duration);
-        Attack attackObj = new UmbralBladeAttack(blade.getDisplay(), profile,
+        Attack attackObj = new UmbralBladeAttack(blade.getBladeDisplay(), profile,
             true, true, 1,
             30, 1, (int) (duration * 1.75),
             0.2, -0.1)
@@ -139,7 +139,7 @@ public class AttackingHeavyState extends UmbralStateFacade {
             .setInitialMovementTicks(5)
             .setDrawParticles(false)
             .setNextAttack(
-                new UmbralBladeAttack(blade.getDisplay(), profile,
+                new UmbralBladeAttack(blade.getBladeDisplay(), profile,
                     true, false, 0,
                     (int) (dist * 2), 10, duration / 2,
                     0, 1)

--- a/src/main/java/btm/sword/umbral/statemachine/state/AttackingQuickState.java
+++ b/src/main/java/btm/sword/umbral/statemachine/state/AttackingQuickState.java
@@ -124,7 +124,7 @@ public class AttackingQuickState extends UmbralStateFacade {
             case BACKWARD -> type = AttackType.B_DASH_ATTACK;
             default -> type = AttackType.WIDE_UMBRAL_SLASH3;
         }
-        new UmbralBladeAttack(blade.getDisplay(), type,
+        new UmbralBladeAttack(blade.getBladeDisplay(), type,
             direction.equals(DashDirection.FORWARD), false, 1,
             5, 10, 200,
             0, 1)

--- a/src/main/java/btm/sword/umbral/statemachine/state/GrabImpaleState.java
+++ b/src/main/java/btm/sword/umbral/statemachine/state/GrabImpaleState.java
@@ -2,31 +2,38 @@ package btm.sword.umbral.statemachine.state;
 
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.util.Vector;
 
 import btm.sword.combat.style.AttackType;
 import btm.sword.config.Config;
+import btm.sword.entity.arbiter.SwordEntityArbiter;
 import btm.sword.entity.base.Combatant;
 import btm.sword.entity.base.SwordEntity;
 import btm.sword.runtime.scheduler.SwordScheduler;
 import btm.sword.umbral.UmbralBlade;
+import btm.sword.umbral.input.BladeRequest;
+import btm.sword.umbral.motion.drivers.LungingDriver;
 import btm.sword.umbral.motion.drivers.SlerpToOffsetDriver;
 import btm.sword.umbral.statemachine.UmbralStateFacade;
+import btm.sword.util.math.Basis;
+import btm.sword.util.math.VectorUtil;
 
 /**
  * State that lunges the blade toward a grabbed target and impales it on contact.
- * <p>
- * Two phases:
+ *
+ * <p>Two phases:
  * <ol>
- *   <li><b>Slerp</b> — the blade approaches a ready position above the grabbed entity using a
- *       {@link SlerpToOffsetDriver} on the blade's motion subsystem. On arrival the
- *       driver schedules a 200 ms delay before transitioning to the lunge phase.</li>
- *   <li><b>Lunge</b> — the blade flies through the grabbed entity along an inherited cubic-Bézier
- *       trajectory driven by the parent {@code stepFlight} loop. The driver-based migration of
- *       this phase happens together with {@link LungingState} so the two paths share the same
- *       {@code BezierDriver} integration.</li>
+ *   <li><b>Slerp</b> — approach a ready position above the grabbed entity using a
+ *       {@link SlerpToOffsetDriver}. On arrival schedule a 200 ms delay before transitioning to
+ *       the lunge phase.</li>
+ *   <li><b>Lunge</b> — fly through the grabbed entity along a cubic-Bézier trajectory using a
+ *       {@link LungingDriver} with the same callback shape as
+ *       {@link LungingState}.</li>
  * </ol>
  */
 public class GrabImpaleState extends UmbralStateFacade {
@@ -35,11 +42,11 @@ public class GrabImpaleState extends UmbralStateFacade {
     private static final double SLERP_ARRIVAL_DISTANCE = 2.0;
     private static final long SLERP_TIMEOUT_TICKS = 50;
     private static final int SLERP_TELEPORT_DURATION = 2;
+    private static final int LUNGE_TELEPORT_DURATION = 2;
     private static final int LUNGE_DELAY_MS = 200;
     private static final double EYE_HEIGHT_MULTIPLIER = 6.0;
 
     private ScheduledFuture<?> attackTask;
-    private boolean lungeActive = false;
 
     @Override
     public String name() {
@@ -48,16 +55,13 @@ public class GrabImpaleState extends UmbralStateFacade {
 
     @Override
     public void onEnter(UmbralBlade blade) {
-        blade.setTimeStep(0);
         blade.setHitEntity(null);
         blade.setFinishedLunging(false);
-
         moveToReadyPosition(blade);
     }
 
     @Override
     public void onExit(UmbralBlade blade) {
-        lungeActive = false;
         blade.setFinishedLunging(false);
         blade.getBladeMotion().stop();
         if (attackTask != null) attackTask.cancel(false);
@@ -65,21 +69,13 @@ public class GrabImpaleState extends UmbralStateFacade {
 
     @Override
     public void onTick(UmbralBlade blade) {
-        if (!lungeActive) return;
-        if (blade.stepFlight()) {
-            blade.onEnd();
-            lungeActive = false;
-        }
+        // Driver advances motion; FSM transitions read hitEntity / finishedLunging.
     }
 
     private void moveToReadyPosition(UmbralBlade blade) {
         SwordEntity grabbed = blade.getThrower().getGrabbedEntity();
-        // TODO: potentially -> make random and in cooler more dynamic positions depending on cur blade pos
         Vector offset = new Vector(-1, grabbed.getEyeHeight() * EYE_HEIGHT_MULTIPLIER, -1);
 
-        // Composed end predicate: abandon the slerp if the grab context evaporates (target lost,
-        // thrower dead, or FSM transitioned away from this state). The driver remains generic;
-        // FSM-aware logic stays at the call site.
         Supplier<Boolean> abandonIfGrabLost = () -> {
             Combatant thrower = blade.getThrower();
             return thrower.getGrabbedEntity() == null
@@ -108,10 +104,41 @@ public class GrabImpaleState extends UmbralStateFacade {
         blade.getBladeMotion().stop();
         blade.setHitEntity(null);
         blade.setFinishedLunging(false);
-        blade.setTimeCutoff(Config.UmbralBlade.LUNGE_TIME_CUTOFF);
-        blade.setTimeScalingFactor(Config.UmbralBlade.LUNGE_TIME_SCALING_FACTOR);
         blade.setCtrlPointsForLunge(AttackType.LUNGE1.controlVectors());
-        blade.initFlight(Config.UmbralBlade.LUNGE_ON_RELEASE_VELOCITY);
-        lungeActive = true;
+
+        long durationTicks = (long) Math.max(1, Config.UmbralBlade.LUNGE_TIME_CUTOFF);
+        double timeStep = Config.UmbralBlade.LUNGE_TIME_SCALING_FACTOR;
+        Basis basis = VectorUtil.getBasisWithoutPitch(blade.getThrower().self());
+
+        blade.getBladeMotion().install(new LungingDriver(
+            blade.getCtrlPointsForLunge(),
+            basis,
+            1.0,
+            durationTicks,
+            timeStep,
+            LUNGE_TELEPORT_DURATION,
+            buildEntityFilter(blade),
+            (entityHit, direction) -> {
+                if (!(entityHit.entity() instanceof LivingEntity le)) return;
+                blade.setLastVelocity(direction);
+                blade.setHitEntity(SwordEntityArbiter.getOrAdd(le));
+                blade.impale(le);
+            },
+            (blockHit, direction) -> {
+                blade.setLastVelocity(direction);
+                blade.emitStuckBlockEffect(blockHit.block(), blockHit.position());
+                blade.request(BladeRequest.RECALL);
+            },
+            () -> blade.setFinishedLunging(true)
+        ));
+    }
+
+    private static Predicate<Entity> buildEntityFilter(UmbralBlade blade) {
+        return entity -> {
+            if (!(entity instanceof LivingEntity le) || le.isDead()) return false;
+            if (entity.getUniqueId().equals(blade.getThrower().getUniqueId())) return false;
+            return blade.getDisplay() == null
+                || !entity.getUniqueId().equals(blade.getDisplay().getUniqueId());
+        };
     }
 }

--- a/src/main/java/btm/sword/umbral/statemachine/state/GrabImpaleState.java
+++ b/src/main/java/btm/sword/umbral/statemachine/state/GrabImpaleState.java
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.util.Vector;
@@ -22,6 +23,7 @@ import btm.sword.umbral.motion.drivers.SlerpToOffsetDriver;
 import btm.sword.umbral.statemachine.UmbralStateFacade;
 import btm.sword.util.math.Basis;
 import btm.sword.util.math.VectorUtil;
+import btm.sword.util.misc.Debug;
 
 /**
  * State that lunges the blade toward a grabbed target and impales it on contact.
@@ -106,9 +108,12 @@ public class GrabImpaleState extends UmbralStateFacade {
         blade.setFinishedLunging(false);
         blade.setCtrlPointsForLunge(AttackType.LUNGE1.controlVectors());
 
-        long durationTicks = (long) Math.max(1, Config.UmbralBlade.LUNGE_TIME_CUTOFF);
-        double timeStep = Config.UmbralBlade.LUNGE_TIME_SCALING_FACTOR;
-        Basis basis = VectorUtil.getBasisWithoutPitch(blade.getThrower().self());
+        long durationTicks = Math.max(1, Config.UmbralBlade.LUNGE_TIME_SCALING_FACTOR);
+        double timeStep = Config.UmbralBlade.LUNGE_TIME_CUTOFF / durationTicks;
+        Basis basis = resolveGrabLungeBasis(blade);
+
+        Debug.umbral("GRAB_LUNGE install: durationTicks=" + durationTicks + " timeStep=" + timeStep
+            + " basisFwd=" + basis.forward());
 
         blade.getBladeMotion().install(new LungingDriver(
             blade.getCtrlPointsForLunge(),
@@ -120,17 +125,36 @@ public class GrabImpaleState extends UmbralStateFacade {
             buildEntityFilter(blade),
             (entityHit, direction) -> {
                 if (!(entityHit.entity() instanceof LivingEntity le)) return;
+                Debug.umbral("GRAB_LUNGE entity hit: " + le.getName() + " dir=" + direction);
                 blade.setLastVelocity(direction);
                 blade.setHitEntity(SwordEntityArbiter.getOrAdd(le));
                 blade.impale(le);
             },
             (blockHit, direction) -> {
+                Debug.umbral("GRAB_LUNGE block hit: " + blockHit.block().getType() + " dir=" + direction);
                 blade.setLastVelocity(direction);
                 blade.emitStuckBlockEffect(blockHit.block(), blockHit.position());
                 blade.request(BladeRequest.RECALL);
             },
-            () -> blade.setFinishedLunging(true)
+            () -> {
+                Debug.umbral("GRAB_LUNGE complete: timeout reached");
+                blade.setFinishedLunging(true);
+            }
         ));
+    }
+
+    /**
+     * Builds the basis aimed from the blade toward the grabbed entity's chest. Includes pitch
+     * so the lunge correctly handles airborne or elevated grabs.
+     */
+    private static Basis resolveGrabLungeBasis(UmbralBlade blade) {
+        Location bladeLoc = blade.getBladeDisplay().currentLocation();
+        if (bladeLoc == null) bladeLoc = blade.getThrower().self().getEyeLocation();
+        SwordEntity grabbed = blade.getThrower().getGrabbedEntity();
+        Vector dir = grabbed != null
+            ? grabbed.getChestLocation().toVector().subtract(bladeLoc.toVector())
+            : blade.getThrower().dir().multiply(20);
+        return VectorUtil.getBasis(bladeLoc.clone().setDirection(dir), dir);
     }
 
     private static Predicate<Entity> buildEntityFilter(UmbralBlade blade) {

--- a/src/main/java/btm/sword/umbral/statemachine/state/GrabImpaleState.java
+++ b/src/main/java/btm/sword/umbral/statemachine/state/GrabImpaleState.java
@@ -2,6 +2,7 @@ package btm.sword.umbral.statemachine.state;
 
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import org.bukkit.util.Vector;
 
@@ -10,14 +11,33 @@ import btm.sword.config.Config;
 import btm.sword.entity.base.Combatant;
 import btm.sword.entity.base.SwordEntity;
 import btm.sword.runtime.scheduler.SwordScheduler;
-import btm.sword.runtime.scheduler.TimeArbiter;
 import btm.sword.umbral.UmbralBlade;
+import btm.sword.umbral.motion.drivers.SlerpToOffsetDriver;
 import btm.sword.umbral.statemachine.UmbralStateFacade;
-import btm.sword.util.display.DisplayUtil;
 
-/** State that lunges the blade toward a grabbed target and impales it on contact. */
+/**
+ * State that lunges the blade toward a grabbed target and impales it on contact.
+ * <p>
+ * Two phases:
+ * <ol>
+ *   <li><b>Slerp</b> — the blade approaches a ready position above the grabbed entity using a
+ *       {@link SlerpToOffsetDriver} on the blade's motion subsystem. On arrival the
+ *       driver schedules a 200 ms delay before transitioning to the lunge phase.</li>
+ *   <li><b>Lunge</b> — the blade flies through the grabbed entity along an inherited cubic-Bézier
+ *       trajectory driven by the parent {@code stepFlight} loop. The driver-based migration of
+ *       this phase happens together with {@link LungingState} so the two paths share the same
+ *       {@code BezierDriver} integration.</li>
+ * </ol>
+ */
 public class GrabImpaleState extends UmbralStateFacade {
-    private TimeArbiter.TaskHandle slerpTask;
+
+    private static final double SLERP_SPEED = 1.0;
+    private static final double SLERP_ARRIVAL_DISTANCE = 2.0;
+    private static final long SLERP_TIMEOUT_TICKS = 50;
+    private static final int SLERP_TELEPORT_DURATION = 2;
+    private static final int LUNGE_DELAY_MS = 200;
+    private static final double EYE_HEIGHT_MULTIPLIER = 6.0;
+
     private ScheduledFuture<?> attackTask;
     private boolean lungeActive = false;
 
@@ -39,7 +59,7 @@ public class GrabImpaleState extends UmbralStateFacade {
     public void onExit(UmbralBlade blade) {
         lungeActive = false;
         blade.setFinishedLunging(false);
-        if (slerpTask != null && !slerpTask.isCancelled()) slerpTask.cancel();
+        blade.getBladeMotion().stop();
         if (attackTask != null) attackTask.cancel(false);
     }
 
@@ -55,26 +75,37 @@ public class GrabImpaleState extends UmbralStateFacade {
     private void moveToReadyPosition(UmbralBlade blade) {
         SwordEntity grabbed = blade.getThrower().getGrabbedEntity();
         // TODO: potentially -> make random and in cooler more dynamic positions depending on cur blade pos
-        Vector offset = new Vector(-1, grabbed.getEyeHeight() * 6, -1);
-        slerpTask = DisplayUtil.displaySlerpToOffset(grabbed, blade.getDisplay(), offset,
-            1, 2, 50, 2, false,
-            50,
-            () -> { // predicate for when the movement should end other than when it reaches destination.
-                Combatant thrower = blade.getThrower();
-                return thrower.getGrabbedEntity() == null ||
-                    thrower.getGrabbedEntity().isDead() ||
-                    thrower.isDead() ||
-                    !thrower.getUmbralBlade().inState(GrabImpaleState.class);
-            },
-            () -> false,
-            () -> attackTask = SwordScheduler.runBukkitTaskLater(() -> attackEnemy(blade),
-                200, TimeUnit.MILLISECONDS)
-        );
+        Vector offset = new Vector(-1, grabbed.getEyeHeight() * EYE_HEIGHT_MULTIPLIER, -1);
+
+        // Composed end predicate: abandon the slerp if the grab context evaporates (target lost,
+        // thrower dead, or FSM transitioned away from this state). The driver remains generic;
+        // FSM-aware logic stays at the call site.
+        Supplier<Boolean> abandonIfGrabLost = () -> {
+            Combatant thrower = blade.getThrower();
+            return thrower.getGrabbedEntity() == null
+                || thrower.getGrabbedEntity().isDead()
+                || thrower.isDead()
+                || !thrower.getUmbralBlade().inState(GrabImpaleState.class);
+        };
+
+        blade.getBladeMotion().install(new SlerpToOffsetDriver(
+            grabbed,
+            offset,
+            SLERP_SPEED,
+            SLERP_ARRIVAL_DISTANCE,
+            SLERP_TIMEOUT_TICKS,
+            abandonIfGrabLost,
+            () -> attackTask = SwordScheduler.runBukkitTaskLater(
+                () -> attackEnemy(blade),
+                LUNGE_DELAY_MS, TimeUnit.MILLISECONDS
+            ),
+            SLERP_TELEPORT_DURATION
+        ));
     }
 
     private void attackEnemy(UmbralBlade blade) {
         if (!blade.inState(GrabImpaleState.class)) return;
-        if (slerpTask != null && !slerpTask.isCancelled()) slerpTask.cancel();
+        blade.getBladeMotion().stop();
         blade.setHitEntity(null);
         blade.setFinishedLunging(false);
         blade.setTimeCutoff(Config.UmbralBlade.LUNGE_TIME_CUTOFF);

--- a/src/main/java/btm/sword/umbral/statemachine/state/LodgedState.java
+++ b/src/main/java/btm/sword/umbral/statemachine/state/LodgedState.java
@@ -1,41 +1,22 @@
 package btm.sword.umbral.statemachine.state;
 
 
+import org.bukkit.entity.LivingEntity;
+
 import btm.sword.entity.base.SwordEntity;
 import btm.sword.umbral.UmbralBlade;
 import btm.sword.umbral.statemachine.UmbralStateFacade;
 
 /**
  * State where the UmbralBlade is lodged in an entity or block.
- * <p>
- * In this state, the blade is stuck in a target (enemy entity or solid block)
- * after a throw, lunge, or attack. It remains attached until recalled by the
- * wielder or until the target dies/is destroyed.
- * </p>
- * <p>
- * <b>Entry Actions:</b>
- * <ul>
- *   <li>Stop all movement</li>
- *   <li>Set display transformation for lodged position</li>
- *   <li>Attach display to target entity/block via entity follow task</li>
- * </ul>
- * </p>
- * <p>
- * <b>Exit Actions:</b>
- * <ul>
- *   <li>Cancel entity follow task</li>
- *   <li>Reset flight state</li>
- *   <li>Clear glow</li>
- * </ul>
- * </p>
- * <p>
- * <b>Typical Transitions:</b>
- * <ul>
- *   <li>LODGED → RECALLING (wielder recalls the blade)</li>
- *   <li>LODGED → WAITING (target dies or block destroyed)</li>
- * </ul>
- * </p>
  *
+ * <p>Entry installs the {@link btm.sword.umbral.motion.drivers.ImpalementFollowDriver} on the
+ * blade's motion subsystem via {@code blade.impale(...)} when an impaled entity is present.
+ * Knockback damage is applied by the FSM transition action that reaches this state — this
+ * {@code onEnter} only sets up the follow behavior.</p>
+ *
+ * <p>Exit stops the motion driver. Glow / inventory / display cleanup is handled by the FSM
+ * recovery conditions and outgoing transition actions.</p>
  */
 public class LodgedState extends UmbralStateFacade {
 
@@ -47,31 +28,18 @@ public class LodgedState extends UmbralStateFacade {
     @Override
     public void onEnter(UmbralBlade blade) {
         SwordEntity target = blade.getHitEntity();
-
-        blade.startImpalementTask(target);
-//        if (target != null) {
-//            LivingEntity le = target.self();
-//            double heightOffset = Math.max(0, Math.min(blade.getCur().getY() - le.getLocation().getY(), le.getHeight()));
-//            boolean followHead = !Config.Combat.IMPALEMENT_HEAD_FOLLOW_EXCEPTIONS.contains(target.type())
-//                && heightOffset >= (le.getEyeLocation().getY() - le.getLocation().getY()) * Config.Combat.IMPALEMENT_HEAD_ZONE_RATIO;
-//
-//            followTask = DisplayUtil.itemDisplayFollow(
-//                target, blade.getDisplay(),
-//                blade.getVelocity().clone().normalize(),
-//                heightOffset, followHead,
-//                null, null, null, null
-//            );
-//        }
+        if (target != null && target.self() instanceof LivingEntity le) {
+            blade.impale(le);
+        }
     }
 
     @Override
     public void onExit(UmbralBlade blade) {
         blade.getBladeMotion().stop();
-        blade.resetFlightState();
     }
 
     @Override
     public void onTick(UmbralBlade blade) {
-
+        // Impalement follow runs from the installed motion driver; nothing to do per-tick here.
     }
 }

--- a/src/main/java/btm/sword/umbral/statemachine/state/LodgedState.java
+++ b/src/main/java/btm/sword/umbral/statemachine/state/LodgedState.java
@@ -66,6 +66,7 @@ public class LodgedState extends UmbralStateFacade {
 
     @Override
     public void onExit(UmbralBlade blade) {
+        blade.getBladeMotion().stop();
         blade.resetFlightState();
     }
 

--- a/src/main/java/btm/sword/umbral/statemachine/state/LungingState.java
+++ b/src/main/java/btm/sword/umbral/statemachine/state/LungingState.java
@@ -1,5 +1,7 @@
 package btm.sword.umbral.statemachine.state;
 
+import java.util.function.Predicate;
+
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
@@ -114,7 +116,7 @@ public class LungingState extends UmbralStateFacade {
     }
 
     /** Build an entity filter that excludes the thrower and the blade's own display entity. */
-    private static java.util.function.Predicate<Entity> buildEntityFilter(UmbralBlade blade) {
+    private static Predicate<Entity> buildEntityFilter(UmbralBlade blade) {
         return entity -> {
             if (!(entity instanceof LivingEntity le) || le.isDead()) return false;
             if (entity.getUniqueId().equals(blade.getThrower().getUniqueId())) return false;

--- a/src/main/java/btm/sword/umbral/statemachine/state/LungingState.java
+++ b/src/main/java/btm/sword/umbral/statemachine/state/LungingState.java
@@ -1,12 +1,37 @@
 package btm.sword.umbral.statemachine.state;
 
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+
 import btm.sword.combat.style.AttackType;
 import btm.sword.config.Config;
+import btm.sword.entity.arbiter.SwordEntityArbiter;
 import btm.sword.umbral.UmbralBlade;
+import btm.sword.umbral.input.BladeRequest;
+import btm.sword.umbral.motion.drivers.LungingDriver;
 import btm.sword.umbral.statemachine.UmbralStateFacade;
+import btm.sword.util.math.Basis;
+import btm.sword.util.math.VectorUtil;
 
-/** State that propels the wielder forward along a Bezier trajectory toward a targeted entity. */
+/**
+ * State that propels the blade forward along a Bézier trajectory toward a targeted entity.
+ *
+ * <p>Drives motion via a {@link LungingDriver} on the blade's motion subsystem. The driver
+ * runs per-tick collision scans and hands back results via three callbacks composed at this
+ * call site:
+ * <ul>
+ *   <li>{@code onEntity} — sets {@code hitEntity} + {@code lastVelocity} on the blade and
+ *       calls {@code blade.impale(...)} so the FSM transition action can apply knockback;
+ *       the LungingState -> LodgedState transition then fires on {@code getHitEntity() != null}.</li>
+ *   <li>{@code onBlock} — emits the stuck-block dust pillar effect and requests a recall.</li>
+ *   <li>{@code onComplete} — sets {@code finishedLunging = true} so the
+ *       LungingState -> RecallingState transition fires.</li>
+ * </ul>
+ */
 public class LungingState extends UmbralStateFacade {
+
+    private static final int LUNGE_TELEPORT_DURATION = 2;
+
     @Override
     public String name() {
         return "LUNGING";
@@ -16,21 +41,54 @@ public class LungingState extends UmbralStateFacade {
     public void onEnter(UmbralBlade blade) {
         blade.setHitEntity(null);
         blade.setFinishedLunging(false);
-        blade.setTimeCutoff(Config.UmbralBlade.LUNGE_TIME_CUTOFF);
-        blade.setTimeScalingFactor(Config.UmbralBlade.LUNGE_TIME_SCALING_FACTOR);
         blade.setCtrlPointsForLunge(AttackType.LUNGE1.controlVectors());
-        blade.initFlight(Config.UmbralBlade.LUNGE_ON_RELEASE_VELOCITY);
+
+        long durationTicks = (long) Math.max(1, Config.UmbralBlade.LUNGE_TIME_CUTOFF);
+        double timeStep = Config.UmbralBlade.LUNGE_TIME_SCALING_FACTOR;
+
+        Basis basis = VectorUtil.getBasisWithoutPitch(blade.getThrower().self());
+
+        blade.getBladeMotion().install(new LungingDriver(
+            blade.getCtrlPointsForLunge(),
+            basis,
+            1.0,
+            durationTicks,
+            timeStep,
+            LUNGE_TELEPORT_DURATION,
+            buildEntityFilter(blade),
+            (entityHit, direction) -> {
+                if (!(entityHit.entity() instanceof LivingEntity le)) return;
+                blade.setLastVelocity(direction);
+                blade.setHitEntity(SwordEntityArbiter.getOrAdd(le));
+                blade.impale(le);
+            },
+            (blockHit, direction) -> {
+                blade.setLastVelocity(direction);
+                blade.emitStuckBlockEffect(blockHit.block(), blockHit.position());
+                blade.request(BladeRequest.RECALL);
+            },
+            () -> blade.setFinishedLunging(true)
+        ));
     }
 
     @Override
     public void onExit(UmbralBlade blade) {
         blade.setFinishedLunging(false);
+        blade.getBladeMotion().stop();
     }
 
     @Override
     public void onTick(UmbralBlade blade) {
-        if (blade.stepFlight()) {
-            blade.onEnd();
-        }
+        // Driver advances motion; FSM transitions read hitEntity / finishedLunging.
+    }
+
+    /** Build an entity filter that excludes the thrower and the blade's own display entity. */
+    private static java.util.function.Predicate<Entity> buildEntityFilter(UmbralBlade blade) {
+        return entity -> {
+            if (!(entity instanceof LivingEntity le) || le.isDead()) return false;
+            if (entity.getUniqueId().equals(blade.getThrower().getUniqueId())) return false;
+            return blade.getDisplay() == null
+                || !entity.getUniqueId().equals(blade.getDisplay().getUniqueId());
+        };
     }
 }

--- a/src/main/java/btm/sword/umbral/statemachine/state/LungingState.java
+++ b/src/main/java/btm/sword/umbral/statemachine/state/LungingState.java
@@ -1,17 +1,21 @@
 package btm.sword.umbral.statemachine.state;
 
+import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.util.Vector;
 
 import btm.sword.combat.style.AttackType;
 import btm.sword.config.Config;
 import btm.sword.entity.arbiter.SwordEntityArbiter;
+import btm.sword.entity.base.SwordEntity;
 import btm.sword.umbral.UmbralBlade;
 import btm.sword.umbral.input.BladeRequest;
 import btm.sword.umbral.motion.drivers.LungingDriver;
 import btm.sword.umbral.statemachine.UmbralStateFacade;
 import btm.sword.util.math.Basis;
 import btm.sword.util.math.VectorUtil;
+import btm.sword.util.misc.Debug;
 
 /**
  * State that propels the blade forward along a Bézier trajectory toward a targeted entity.
@@ -43,10 +47,13 @@ public class LungingState extends UmbralStateFacade {
         blade.setFinishedLunging(false);
         blade.setCtrlPointsForLunge(AttackType.LUNGE1.controlVectors());
 
-        long durationTicks = (long) Math.max(1, Config.UmbralBlade.LUNGE_TIME_CUTOFF);
-        double timeStep = Config.UmbralBlade.LUNGE_TIME_SCALING_FACTOR;
+        long durationTicks = Math.max(1, Config.UmbralBlade.LUNGE_TIME_SCALING_FACTOR);
+        double timeStep = Config.UmbralBlade.LUNGE_TIME_CUTOFF / durationTicks;
 
-        Basis basis = VectorUtil.getBasisWithoutPitch(blade.getThrower().self());
+        Basis basis = resolveLungeBasis(blade);
+
+        Debug.umbral("LUNGE install: durationTicks=" + durationTicks + " timeStep=" + timeStep
+            + " basisFwd=" + basis.forward());
 
         blade.getBladeMotion().install(new LungingDriver(
             blade.getCtrlPointsForLunge(),
@@ -58,17 +65,41 @@ public class LungingState extends UmbralStateFacade {
             buildEntityFilter(blade),
             (entityHit, direction) -> {
                 if (!(entityHit.entity() instanceof LivingEntity le)) return;
+                Debug.umbral("LUNGE entity hit: " + le.getName() + " dir=" + direction);
                 blade.setLastVelocity(direction);
                 blade.setHitEntity(SwordEntityArbiter.getOrAdd(le));
                 blade.impale(le);
             },
             (blockHit, direction) -> {
+                Debug.umbral("LUNGE block hit: " + blockHit.block().getType() + " dir=" + direction);
                 blade.setLastVelocity(direction);
                 blade.emitStuckBlockEffect(blockHit.block(), blockHit.position());
                 blade.request(BladeRequest.RECALL);
             },
-            () -> blade.setFinishedLunging(true)
+            () -> {
+                Debug.umbral("LUNGE complete: timeout reached");
+                blade.setFinishedLunging(true);
+            }
         ));
+    }
+
+    /**
+     * Builds the basis used to project the lunge bezier into world space. Aims the blade at the
+     * thrower's targeted entity (chest) when one is in range; otherwise aims at a point 20 blocks
+     * along the thrower's eye direction. Includes pitch so steep aims work.
+     */
+    private static Basis resolveLungeBasis(UmbralBlade blade) {
+        Location bladeLoc = blade.getBladeDisplay().currentLocation();
+        if (bladeLoc == null) bladeLoc = blade.getThrower().self().getEyeLocation();
+        SwordEntity target = blade.getThrower().getTargetedEntity(20);
+        Vector dir;
+        if (target == null) {
+            Location intent = blade.getThrower().locFromEyeDir(20);
+            dir = intent.toVector().subtract(bladeLoc.toVector());
+        } else {
+            dir = target.getChestLocation().toVector().subtract(bladeLoc.toVector());
+        }
+        return VectorUtil.getBasis(bladeLoc.clone().setDirection(dir), dir);
     }
 
     @Override

--- a/src/main/java/btm/sword/umbral/statemachine/state/RecallingState.java
+++ b/src/main/java/btm/sword/umbral/statemachine/state/RecallingState.java
@@ -44,7 +44,9 @@ public class RecallingState extends UmbralStateFacade {
     private static final double SLERP_SPEED = 0.45;
     private static final double SLERP_ARRIVAL_DISTANCE = 1.5;
     private static final long SLERP_TIMEOUT_TICKS = 200;
-    private static final int SLERP_TELEPORT_DURATION = 4;
+    // Short duration so consecutive per-tick yaw aims don't pile up — keeps body rotation
+    // tracking the player smoothly instead of chasing a stale target.
+    private static final int SLERP_TELEPORT_DURATION = 2;
 
     @Override
     public String name() {

--- a/src/main/java/btm/sword/umbral/statemachine/state/RecallingState.java
+++ b/src/main/java/btm/sword/umbral/statemachine/state/RecallingState.java
@@ -93,16 +93,16 @@ public class RecallingState extends UmbralStateFacade {
     }
 
     @Override
-    public void onExit(UmbralBlade blade) {
-        blade.getBladeMotion().stop();
-    }
-
-    @Override
     public void onTick(UmbralBlade blade) {
         // Defensive: if the motion ended for any reason without the onArrive callback firing
         // (e.g. external dispose mid-flight), still request STANDBY so the FSM transitions out.
         if (blade.getBladeMotion().isEnded()) {
             blade.request(BladeRequest.STANDBY);
         }
+    }
+
+    @Override
+    public void onExit(UmbralBlade blade) {
+        blade.getBladeMotion().stop();
     }
 }

--- a/src/main/java/btm/sword/umbral/statemachine/state/RecallingState.java
+++ b/src/main/java/btm/sword/umbral/statemachine/state/RecallingState.java
@@ -8,11 +8,10 @@ import org.bukkit.Location;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
-import btm.sword.runtime.scheduler.TimeArbiter;
 import btm.sword.umbral.UmbralBlade;
 import btm.sword.umbral.input.BladeRequest;
+import btm.sword.umbral.motion.drivers.SlerpToOffsetDriver;
 import btm.sword.umbral.statemachine.UmbralStateFacade;
-import btm.sword.util.display.DisplayUtil;
 
 /**
  * State where the UmbralBlade is being recalled to the wielder.
@@ -23,24 +22,28 @@ import btm.sword.util.display.DisplayUtil;
  * <p>
  * <b>Entry Actions:</b>
  * <ul>
- *   <li>Set display transformation for returning animation</li>
- *   <li>Stop idle movement</li>
- *   <li>Begin lerp movement back to wielder</li>
+ *   <li>Install a {@link SlerpToOffsetDriver} on the blade's {@link btm.sword.umbral.motion.BladeMotion}
+ *       targeting the wielder's chest offset.</li>
+ *   <li>Compose a stationary-with-not-dashing end predicate to short-circuit the slerp when
+ *       the blade has stopped moving (and the wielder is not dashing the target away).</li>
  * </ul>
  * </p>
  * <p>
  * <b>Typical Transitions:</b>
  * <ul>
- *   <li>RECALLING → SHEATHED (when blade arrives)</li>
+ *   <li>RECALLING → STANDBY (on arrival, on stationary-without-dashing, or on timeout)</li>
  * </ul>
  * </p>
- *
  */
 public class RecallingState extends UmbralStateFacade {
+
     private static final int MAX_STATIONARY_ITERATIONS = 4;
     private static final double EPSILON_SQUARED = 0.004;
 
-    private TimeArbiter.TaskHandle returnTask;
+    private static final double SLERP_SPEED = 1.5;
+    private static final double SLERP_ARRIVAL_DISTANCE = 1.5;
+    private static final long SLERP_TIMEOUT_TICKS = 80;
+    private static final int SLERP_TELEPORT_DURATION = 5;
 
     @Override
     public String name() {
@@ -49,23 +52,32 @@ public class RecallingState extends UmbralStateFacade {
 
     @Override
     public void onEnter(UmbralBlade blade) {
-        AtomicReference<Location> currentBladeLoc = new AtomicReference<>(blade.getDisplay().getLocation());
-        AtomicReference<Location> previousBladeLoc = new AtomicReference<>(blade.getDisplay().getLocation());
-        final Supplier<Boolean> stationaryCheck = getBooleanSupplier(blade, currentBladeLoc, previousBladeLoc);
+        Location displayLocation = blade.getDisplay().getLocation();
+        AtomicReference<Location> currentBladeLoc = new AtomicReference<>(displayLocation);
+        AtomicReference<Location> previousBladeLoc = new AtomicReference<>(displayLocation);
+        Supplier<Boolean> stationaryCheck = stationaryCheckSupplier(blade, currentBladeLoc, previousBladeLoc);
 
-        returnTask = DisplayUtil.displaySlerpToOffset(
-            blade.getThrower(), blade.getDisplay(),
+        // The driver ends on arrival, on timeout, or on this composed end predicate. The
+        // dashing-suppress is composed here at the call site instead of being a driver param,
+        // since the driver should remain generic and not know about FSM-level concerns.
+        Supplier<Boolean> endWhenStationaryAndNotDashing =
+            () -> stationaryCheck.get() && !blade.getThrower().isDashing();
+
+        blade.getBladeMotion().install(new SlerpToOffsetDriver(
+            blade.getThrower(),
             blade.getThrower().getChestVector(),
-            1.5, 5, 100, 1.5,
-            false,
-            80,
-            () -> blade.getThrower().isDashing(),
-            stationaryCheck,
-            () -> blade.request(BladeRequest.STANDBY)
-        );
+            SLERP_SPEED,
+            SLERP_ARRIVAL_DISTANCE,
+            SLERP_TIMEOUT_TICKS,
+            endWhenStationaryAndNotDashing,
+            () -> blade.request(BladeRequest.STANDBY),
+            SLERP_TELEPORT_DURATION
+        ));
     }
 
-    private static @NotNull Supplier<Boolean> getBooleanSupplier(UmbralBlade blade, AtomicReference<Location> currentBladeLoc, AtomicReference<Location> previousBladeLoc) {
+    private static @NotNull Supplier<Boolean> stationaryCheckSupplier(UmbralBlade blade,
+                                                                      AtomicReference<Location> currentBladeLoc,
+                                                                      AtomicReference<Location> previousBladeLoc) {
         AtomicInteger stationaryCount = new AtomicInteger(0);
         return () -> {
             currentBladeLoc.set(blade.getDisplay().getLocation());
@@ -82,14 +94,14 @@ public class RecallingState extends UmbralStateFacade {
 
     @Override
     public void onExit(UmbralBlade blade) {
-        if (returnTask != null && !returnTask.isCancelled()) {
-            returnTask.cancel();
-        }
+        blade.getBladeMotion().stop();
     }
 
     @Override
     public void onTick(UmbralBlade blade) {
-        if (returnTask != null && returnTask.isCancelled()) {
+        // Defensive: if the motion ended for any reason without the onArrive callback firing
+        // (e.g. external dispose mid-flight), still request STANDBY so the FSM transitions out.
+        if (blade.getBladeMotion().isEnded()) {
             blade.request(BladeRequest.STANDBY);
         }
     }

--- a/src/main/java/btm/sword/umbral/statemachine/state/RecallingState.java
+++ b/src/main/java/btm/sword/umbral/statemachine/state/RecallingState.java
@@ -12,6 +12,7 @@ import btm.sword.umbral.UmbralBlade;
 import btm.sword.umbral.input.BladeRequest;
 import btm.sword.umbral.motion.drivers.SlerpToOffsetDriver;
 import btm.sword.umbral.statemachine.UmbralStateFacade;
+import btm.sword.util.misc.Debug;
 
 /**
  * State where the UmbralBlade is being recalled to the wielder.
@@ -40,10 +41,10 @@ public class RecallingState extends UmbralStateFacade {
     private static final int MAX_STATIONARY_ITERATIONS = 4;
     private static final double EPSILON_SQUARED = 0.004;
 
-    private static final double SLERP_SPEED = 1.5;
+    private static final double SLERP_SPEED = 0.45;
     private static final double SLERP_ARRIVAL_DISTANCE = 1.5;
-    private static final long SLERP_TIMEOUT_TICKS = 80;
-    private static final int SLERP_TELEPORT_DURATION = 5;
+    private static final long SLERP_TIMEOUT_TICKS = 200;
+    private static final int SLERP_TELEPORT_DURATION = 4;
 
     @Override
     public String name() {
@@ -63,6 +64,9 @@ public class RecallingState extends UmbralStateFacade {
         Supplier<Boolean> endWhenStationaryAndNotDashing =
             () -> stationaryCheck.get() && !blade.getThrower().isDashing();
 
+        Debug.umbral("RECALL install: speed=" + SLERP_SPEED + " arrival=" + SLERP_ARRIVAL_DISTANCE
+            + " timeout=" + SLERP_TIMEOUT_TICKS + " teleportDuration=" + SLERP_TELEPORT_DURATION);
+
         blade.getBladeMotion().install(new SlerpToOffsetDriver(
             blade.getThrower(),
             blade.getThrower().getChestVector(),
@@ -70,7 +74,10 @@ public class RecallingState extends UmbralStateFacade {
             SLERP_ARRIVAL_DISTANCE,
             SLERP_TIMEOUT_TICKS,
             endWhenStationaryAndNotDashing,
-            () -> blade.request(BladeRequest.STANDBY),
+            () -> {
+                Debug.umbral("RECALL onArrive fired -> request STANDBY");
+                blade.request(BladeRequest.STANDBY);
+            },
             SLERP_TELEPORT_DURATION
         ));
     }

--- a/src/main/java/btm/sword/umbral/statemachine/state/RecoverState.java
+++ b/src/main/java/btm/sword/umbral/statemachine/state/RecoverState.java
@@ -9,8 +9,6 @@ public class RecoverState extends UmbralStateFacade {
     private UmbralBlade blade;
     private final Runnable recoverBlade = () -> {
         try {
-            if (blade.getDisplay() != null) blade.getDisplay().remove();
-            blade.setDisplay(null);
             blade.resetWeaponDisplay();
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/main/java/btm/sword/umbral/statemachine/state/StandbyState.java
+++ b/src/main/java/btm/sword/umbral/statemachine/state/StandbyState.java
@@ -5,15 +5,16 @@ import org.bukkit.util.Vector;
 import btm.sword.action.throwing.InteractiveItemArbiter;
 import btm.sword.config.Config;
 import btm.sword.entity.player.SwordPlayer;
-import btm.sword.runtime.scheduler.TimeArbiter;
 import btm.sword.umbral.UmbralBlade;
+import btm.sword.umbral.motion.drivers.AnchoredFollowDriver;
 import btm.sword.umbral.statemachine.UmbralStateFacade;
-import btm.sword.util.display.DisplayUtil;
 import net.kyori.adventure.text.Component;
 
 /** State where the blade hovers near the wielder in a ready position, following their movement. */
 public class StandbyState extends UmbralStateFacade {
-    private TimeArbiter.TaskHandle followTask;
+
+    private static final Vector STANDBY_LOCAL_OFFSET = new Vector(0.7, 0.7, -0.5);
+    private static final int STANDBY_TELEPORT_DURATION = 5;
 
     @Override
     public String name() { return "STANDBY"; }
@@ -23,11 +24,9 @@ public class StandbyState extends UmbralStateFacade {
         // Instead of putting whenever blade enters a diff state, just deactivate when it should be
         InteractiveItemArbiter.remove(blade.getDisplay(), false);
 
-        followTask = DisplayUtil.itemDisplayFollowLerp(
-            blade.getThrower(), blade.getDisplay(),
-            new Vector(0.7, 0.7, -0.5),
-            5, 150, false
-        );
+        blade.getBladeMotion().install(new AnchoredFollowDriver(
+            STANDBY_LOCAL_OFFSET, false, STANDBY_TELEPORT_DURATION
+        ));
         blade.startIdleMovement();
         if (blade.getThrower() instanceof SwordPlayer swordPlayer) {
             swordPlayer.displayTitle(null, Component.text("Ready.").color(Config.SwordColor.TEXT_COOL),
@@ -40,12 +39,11 @@ public class StandbyState extends UmbralStateFacade {
         InteractiveItemArbiter.put(blade);
 
         blade.endIdleMovement();
-        if (followTask != null)
-            followTask.cancel();
+        blade.getBladeMotion().stop();
     }
 
     @Override
     public void onTick(UmbralBlade blade) {
-        // Idle movement handled by a TaskHandle
+        // Position tracking handled by AnchoredFollowDriver via BladeMotion; bobbing handled by idle movement task.
     }
 }

--- a/src/main/java/btm/sword/util/display/DisplayUtil.java
+++ b/src/main/java/btm/sword/util/display/DisplayUtil.java
@@ -1,22 +1,17 @@
 package btm.sword.util.display;
 
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Display;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.ItemDisplay;
-import org.bukkit.entity.Mob;
 import org.bukkit.util.Vector;
 
 import btm.sword.config.Config;
 import btm.sword.entity.base.SwordEntity;
 import btm.sword.runtime.scheduler.PredicateRunnablePair;
-import btm.sword.runtime.scheduler.SwordScheduler;
 import btm.sword.runtime.scheduler.TimeArbiter;
 import btm.sword.util.prefab.Prefab;
 
@@ -52,69 +47,6 @@ public final class DisplayUtil {
     public static void setInterpolationValues(Display display, int delay, int duration) {
         display.setInterpolationDelay(delay);
         display.setInterpolationDuration(duration);
-    }
-
-    /** Smoothly rotates the display toward an offset position using slerp, returning a task handle. */
-    public static TimeArbiter.TaskHandle displaySlerpToOffset(
-        SwordEntity entity, ItemDisplay display, Vector offset,
-        double speed, int tpDuration, int period,
-        double endDistance, boolean removeOnArrival,
-        int timeoutTicks,
-        Supplier<Boolean> contiueDespiteArrivalCondition,
-        Supplier<Boolean> endCondition,
-        Runnable callback) {
-
-        AtomicInteger ticks = new AtomicInteger(0);
-        AtomicReference<Vector> currentDirectionToTarget = new AtomicReference<>();
-        return TimeArbiter.runTimeBoundBukkitTaskOnTimer(
-            () -> {
-                try {
-                    Location curTarget = entity.self().getLocation().add(
-                        entity.rightBasisVector(false).multiply(offset.getX()).add(
-                            entity.upBasisVector(false).multiply(offset.getY()).add(
-                                entity.forwardBasisVector(false).multiply(offset.getZ())
-                            )
-                        )
-                    );
-                    currentDirectionToTarget.set(curTarget.toVector().subtract(display.getLocation().toVector()));
-                } catch (RuntimeException ignored) {}
-            },
-            () -> {
-                Vector scaledDiff = currentDirectionToTarget.get().normalize().multiply(speed);
-                Location update = display.getLocation().add(scaledDiff);
-                TimeArbiter.teleportDisplay(
-                    display,
-                    update, update.toVector().subtract(display.getLocation().toVector()),
-                    tpDuration,
-                    DisplayUtil.class, 148
-                );
-            },
-            null,
-            0, period,
-            DisplayUtil.class, "displaySlerpToOffset (2)",
-            new PredicateRunnablePair(
-                () -> entity.isInvalid() || !display.isValid() ||
-                    ticks.getAndIncrement() > timeoutTicks || endCondition.get(),
-                () -> {
-                    if (display.isValid() && removeOnArrival) display.remove();
-                    if (callback != null) {
-                        SwordScheduler.runBukkitTask(callback);
-                    }
-                }
-            ),
-            new PredicateRunnablePair(
-                () -> currentDirectionToTarget.get().isZero() ||
-                    currentDirectionToTarget.get().lengthSquared() < endDistance * endDistance ||
-                    ticks.get() > timeoutTicks || endCondition.get() &&
-                    !(contiueDespiteArrivalCondition.get()), // make this condition very predictable
-                () -> {
-                    if (display.isValid() && removeOnArrival) display.remove();
-                    if (callback != null) {
-                        SwordScheduler.runBukkitTask(callback);
-                    }
-                }
-            )
-        );
     }
 
     /**
@@ -171,104 +103,6 @@ public final class DisplayUtil {
                     if (callback != null && toConsume != null) callback.accept(toConsume);
                 }
             )
-        );
-    }
-
-    /** Starts a task that moves the display to a lerp-computed offset relative to the entity each period. */
-    public static TimeArbiter.TaskHandle itemDisplayFollowLerp(
-        SwordEntity entity, ItemDisplay display, Vector offset,
-        int tpDuration, int period, boolean withPitch) {
-
-        return TimeArbiter.runTimeBoundBukkitTaskOnTimer(
-            () -> {
-                Vector current =
-                    entity.rightBasisVector(withPitch).multiply(offset.getX()).add(
-                        entity.upBasisVector(withPitch).multiply(offset.getY()).add(
-                            entity.forwardBasisVector(withPitch).multiply(offset.getZ())
-                        )
-                    );
-
-                Location updated = entity.self()
-                    .getLocation()
-                    .add(current);
-
-                TimeArbiter.teleportDisplay(
-                    display,
-                    updated, entity.forwardBasisVector(withPitch),
-                    tpDuration,
-                    DisplayUtil.class, 257
-                );
-            },
-            null,
-            null,
-            0, period,
-            DisplayUtil.class, "itemDisplayFollowLerp",
-            new PredicateRunnablePair(
-                () -> !entity.self().isValid() || display.isDead() || !display.isValid(),
-                null
-            )
-        );
-    }
-
-    /**
-     * Makes an {@link ItemDisplay} track a {@link Mob}'s position each tick with a
-     * yaw-relative offset. The offset axes are relative to the mob's facing:
-     * {@code offsetRight} is the mob's lateral right, {@code offsetUp} is world up,
-     * and {@code offsetForward} is the mob's forward direction.
-     *
-     * @param mob           the mob to follow
-     * @param display       the display entity to teleport
-     * @param offsetRight   right-axis offset (mob's local right)
-     * @param offsetUp      vertical offset
-     * @param offsetForward forward-axis offset (mob's local forward)
-     * @param tpDuration    teleport interpolation duration in ticks
-     * @param period        update interval in ticks
-     * @return a task handle that can be cancelled to stop following
-     */
-    public static TimeArbiter.TaskHandle itemDisplayFollowMob(
-            Mob mob, ItemDisplay display,
-            float offsetRight, float offsetUp, float offsetForward,
-            int tpDuration, int period) {
-        return TimeArbiter.runTimeBoundBukkitTaskOnTimer(
-            () -> {
-                if (!mob.isValid() || !display.isValid()) return;
-                Location loc = mob.getLocation();
-                double yawRad = Math.toRadians(loc.getYaw());
-                // Forward direction in Minecraft: (-sin yaw, 0, cos yaw)
-                double fwdX = -Math.sin(yawRad);
-                double fwdZ = Math.cos(yawRad);
-                // Right direction: 90° clockwise from forward
-                double rightX = Math.cos(yawRad);
-                double rightZ = Math.sin(yawRad);
-                double worldX = offsetRight * rightX + offsetForward * fwdX;
-                double worldZ = offsetRight * rightZ + offsetForward * fwdZ;
-                Location target = loc.clone().add(worldX, offsetUp, worldZ);
-                TimeArbiter.teleportDisplay(display, target, new Vector(fwdX, 0, fwdZ), tpDuration, DisplayUtil.class, 0);
-            },
-            null, null, 0, period,
-            DisplayUtil.class, "itemDisplayFollowMob"
-        );
-    }
-
-    /** Starts a task that teleports the display directly to the entity's location each period. */
-    public static TimeArbiter.TaskHandle itemDisplayFollowDirect(
-        Entity entity, ItemDisplay display, int tpDuration, int period) {
-
-        return TimeArbiter.runTimeBoundBukkitTaskOnTimer(
-            () -> {
-                Location updated = entity.getLocation();
-
-                TimeArbiter.teleportDisplay(
-                    display,
-                    updated, updated.getDirection(),
-                    tpDuration,
-                    DisplayUtil.class, 257
-                );
-            },
-            null,
-            null,
-            0, period,
-            DisplayUtil.class, "itemDisplayFollowDirect"
         );
     }
 }

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -205,7 +205,7 @@ audio:
   throw_volume: 0.35
   throw_pitch: 0.4
   
-  attack_sound: EVENT_RAID_HORN
+  attack_sound: ITEM_TRIDENT_THROW
   attack_volume: 0.6
   attack_pitch: 0.7
   
@@ -219,7 +219,7 @@ audio:
   punch_connect: BLOCK_NETHERRACK_PLACE
   punch_connect_vol: 1.5
   punch_connect_pitch: 1.0
-  pre_attack_sound: ENTITY_DOLPHIN_JUMP
+  pre_attack_sound: ITEM_TRIDENT_THROW
   parry_attempt_sound: ENTITY_ILLUSIONER_CAST_SPELL
 
 
@@ -328,12 +328,11 @@ world:
 
 
 debug:
-
+  
   logging_verbose_combat: false
   logging_verbose_movement: false
-
+  
   logging_verbose_config: false
-  logging_verbose_umbral_states: false
   
   visualization_show_hitboxes: false
   visualization_show_raytraces: false


### PR DESCRIPTION
Completely decoupled UmbralBlade from ThrownItem due to lack of similarity between the two. 

The Umbral blade State Machine now upholds proper conventions of single writer & no circular imports.

Much easier to debug, update, and edit. 